### PR TITLE
A coroutine context already exists

### DIFF
--- a/src/Swoole/SwooleCoroutineDispatcher.php
+++ b/src/Swoole/SwooleCoroutineDispatcher.php
@@ -18,21 +18,19 @@ class SwooleCoroutineDispatcher implements DispatchesCoroutines
     {
         $results = [];
 
-        \Co\run(function () use (&$results, $coroutines, $waitSeconds) {
-            $waitGroup = new WaitGroup;
+        $waitGroup = new WaitGroup;
 
-            foreach ($coroutines as $key => $callback) {
-                go(function () use ($key, $callback, $waitGroup, &$results) {
-                    $waitGroup->add();
+        foreach ($coroutines as $key => $callback) {
+            go(function () use ($key, $callback, $waitGroup, &$results) {
+                $waitGroup->add();
 
-                    $results[$key] = $callback();
+                $results[$key] = $callback();
 
-                    $waitGroup->done();
-                });
-            }
+                $waitGroup->done();
+            });
+        }
 
-            $waitGroup->wait($waitSeconds);
-        });
+        $waitGroup->wait($waitSeconds);
 
         return $results;
     }


### PR DESCRIPTION
When running a swoole server, a coroutine context is already created for every worker, calling `\Co\run` again returns an error:

```
ErrorException
Swoole\Coroutine\Scheduler::start(): eventLoop has already been created. unable to start Swoole\Coroutine\Scheduler
```