### PR TITLE
Makes "spiral/roadrunner" an optional package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "laminas/laminas-diactoros": "^2.5",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/once": "^3.0",
-        "spiral/roadrunner": "^1.8",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {
@@ -34,7 +33,8 @@
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^6.15",
         "phpunit/phpunit": "^9.3",
-        "spatie/laravel-ray": "^1.14"
+        "spatie/laravel-ray": "^1.14",
+        "spiral/roadrunner": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Commands;
 
+use Exception;
 use Illuminate\Support\Str;
 use Laravel\Octane\RoadRunner\ServerProcessInspector;
 use Laravel\Octane\RoadRunner\ServerStateFile;
@@ -47,6 +48,8 @@ class StartRoadRunnerCommand extends Command
         ServerProcessInspector $processInspector,
         ServerStateFile $serverStateFile
     ) {
+        $this->ensureRoadRunnerPackageIsInstalled();
+
         $roadRunnerBinary = $this->ensureRoadRunnerBinaryIsInstalled();
 
         if ($processInspector->serverIsRunning()) {
@@ -96,6 +99,60 @@ class StartRoadRunnerCommand extends Command
         $watcherProcess->stop();
 
         return $serverProcess->getExitCode();
+    }
+
+    /**
+     * Ensure the RoadRunner package is installed into the project.
+     *
+     * @return void
+     */
+    protected function ensureRoadRunnerPackageIsInstalled()
+    {
+        if (class_exists('Spiral\RoadRunner\Worker') && class_exists('Spiral\RoadRunner\PSR7Client')) {
+            return;
+        }
+
+        if (! $this->confirm('Running Octane requires "spiral/roadrunner:^1.9". Do you wish to install it as a dependency?')) {
+            throw new Exception('Octane requires "spiral/roadrunner".');
+        }
+
+        $command = $this->findComposer().' require spiral/roadrunner:^1.9 --with-all-dependencies';
+
+        $process = Process::fromShellCommandline($command, null, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            try {
+                $process->setTty(true);
+            } catch (RuntimeException $e) {
+                $this->output->writeln('Warning: '.$e->getMessage());
+            }
+        }
+
+        try {
+            $process->run(function ($type, $line) {
+                $this->output->write($line);
+            });
+        } catch (ProcessSignaledException $e) {
+            if (extension_loaded('pcntl') && $e->getSignal() !== SIGINT) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        $composerPath = getcwd().'/composer.phar';
+
+        if (file_exists($composerPath)) {
+            return '"'.PHP_BINARY.'" '.$composerPath;
+        }
+
+        return 'composer';
     }
 
     /**


### PR DESCRIPTION
This pull request makes "spiral/roadrunner" an optional dependency, as its only needed if the user actually uses "roadrunner".

<img width="1231" alt="octane" src="https://user-images.githubusercontent.com/5457236/112371390-7512fa00-8cd6-11eb-9852-d07bbb820a76.png">
