### PR TITLE
Fixes artisan commands exit code

### DIFF
--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -30,11 +30,9 @@ class ReloadCommand extends Command
     {
         $server = $this->option('server') ?: config('octane.server');
 
-        if ($server === 'swoole') {
-            return $this->reloadSwooleServer();
-        } elseif ($server === 'roadrunner') {
-            return $this->reloadRoadRunnerServer();
-        }
+        return $server == 'swoole'
+            ? $this->reloadSwooleServer()
+            : $this->reloadRoadRunnerServer();
     }
 
     /**
@@ -46,13 +44,17 @@ class ReloadCommand extends Command
     {
         $inspector = app(SwooleServerProcessInspector::class);
 
-        if ($inspector->serverIsRunning()) {
-            $this->info('Reloading workers...');
-
-            $inspector->reloadServer();
-        } else {
+        if (! $inspector->serverIsRunning()) {
             $this->error('Octane server is not running.');
+
+            return 1;
         }
+
+        $this->info('Reloading workers...');
+
+        $inspector->reloadServer();
+
+        return 0;
     }
 
     /**
@@ -64,12 +66,16 @@ class ReloadCommand extends Command
     {
         $inspector = app(RoadRunnerServerProcessInspector::class);
 
-        if ($inspector->serverIsRunning()) {
-            $this->info('Reloading workers...');
-
-            $inspector->reloadServer(base_path());
-        } else {
+        if (! $inspector->serverIsRunning()) {
             $this->error('Octane server is not running.');
+
+            return 1;
         }
+
+        $this->info('Reloading workers...');
+
+        $inspector->reloadServer(base_path());
+
+        return 0;
     }
 }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -34,11 +34,9 @@ class StartCommand extends Command
     {
         $server = $this->option('server') ?: config('octane.server');
 
-        if ($server === 'swoole') {
-            return $this->startSwooleServer();
-        } elseif ($server === 'roadrunner') {
-            return $this->startRoadRunnerServer();
-        }
+        return $server == 'swoole'
+            ? $this->startSwooleServer()
+            : $this->startRoadRunnerServer();
     }
 
     /**

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -32,11 +32,9 @@ class StopCommand extends Command
     {
         $server = $this->option('server') ?: config('octane.server');
 
-        if ($server === 'swoole') {
-            return $this->stopSwooleServer();
-        } elseif ($server === 'roadrunner') {
-            return $this->stopRoadRunnerServer();
-        }
+        return $server == 'swoole'
+            ? $this->stopSwooleServer()
+            : $this->stopRoadRunnerServer();
     }
 
     /**
@@ -48,15 +46,19 @@ class StopCommand extends Command
     {
         $inspector = app(SwooleServerProcessInspector::class);
 
-        if ($inspector->serverIsRunning()) {
-            $this->info('Stopping server...');
-
-            $inspector->stopServer();
-
-            app(SwooleServerStateFile::class)->delete();
-        } else {
+        if (! $inspector->serverIsRunning()) {
             $this->error('Swoole server is not running.');
+
+            return 1;
         }
+
+        $this->info('Stopping server...');
+
+        $inspector->stopServer();
+
+        app(SwooleServerStateFile::class)->delete();
+
+        return 0;
     }
 
     /**
@@ -68,14 +70,18 @@ class StopCommand extends Command
     {
         $inspector = app(RoadRunnerServerProcessInspector::class);
 
-        if ($inspector->serverIsRunning()) {
-            $this->info('Stopping server...');
-
-            $inspector->stopServer();
-
-            app(RoadRunnerServerStateFile::class)->delete();
-        } else {
+        if (! $inspector->serverIsRunning()) {
             $this->error('RoadRunner server is not running.');
+
+            return 1;
         }
+
+        $this->info('Stopping server...');
+
+        $inspector->stopServer();
+
+        app(RoadRunnerServerStateFile::class)->delete();
+
+        return 0;
     }
 }


### PR DESCRIPTION
This pull request addresses the exit code of Octane artisan commands.

Here is one example where the status code was "green => 0", but now is "red => 1" when the command `octane:reload` failed:

<img width="427" alt="Screenshot 2021-03-29 at 14 55 59" src="https://user-images.githubusercontent.com/5457236/112847351-e79d2480-909e-11eb-81f2-252c36fae36a.png">
