### PR TITLE
Uses rr binary in favour of rr cli

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use Exception;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -74,7 +75,9 @@ trait InstallsRoadRunnerDependencies
         }
 
         if (! is_null($roadRunnerBinary = (new ExecutableFinder)->find('rr', null, [base_path()]))) {
-            return $roadRunnerBinary;
+            if (! Str::contains($roadRunnerBinary, 'vendor/bin/rr')) {
+                return $roadRunnerBinary;
+            }
         }
 
         if ($this->confirm('Unable to locate RoadRunner binary. Should Octane download the binary for your operating system?', true)) {


### PR DESCRIPTION
Terminology:
- RR CLI - the CLI tool that allows to get the binary, usually within the the path "/vendor/bin/rr".
- RR Binary - the CLI tool that runs roadrunner.

This pull request addresses an issue when the user was the RR CLI tool available in the user's PATH with the name "rr". This can happen for multiple reasons like: roadrunner installed with composer globally, etc.

PS: This is the issue Dries was having.