### PR TITLE
Removes spatie/once dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "illuminate/contracts": "^8.0",
         "laminas/laminas-diactoros": "^2.5",
         "spatie/laravel-package-tools": "^1.4",
-        "spatie/once": "^3.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {

--- a/src/MarshalsPsr7RequestsAndResponses.php
+++ b/src/MarshalsPsr7RequestsAndResponses.php
@@ -14,6 +14,20 @@ use Symfony\Component\HttpFoundation\Response;
 trait MarshalsPsr7RequestsAndResponses
 {
     /**
+     * The Symfony PSR-7 factory.
+     *
+     * @var \Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface|null
+     */
+    protected $psrHttpFactory;
+
+    /**
+     * The Symfony HttpFoundation factory.
+     *
+     * @var \Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory|null
+     */
+    protected $httpFoundationFactory;
+
+    /**
      * Convert the given PSR-7 request to an HttpFoundation request.
      *
      * @param  \Psr\Http\Message\ServerRequestInterface  $request
@@ -44,7 +58,9 @@ trait MarshalsPsr7RequestsAndResponses
      */
     protected function httpFoundationRequestFactory(): HttpFoundationFactoryInterface
     {
-        return once(fn () => new HttpFoundationFactory);
+        return $this->httpFoundationFactory ?: (
+            $this->httpFoundationFactory = new HttpFoundationFactory
+        );
     }
 
     /**
@@ -56,7 +72,7 @@ trait MarshalsPsr7RequestsAndResponses
      */
     protected function psr7ResponseFactory(): HttpMessageFactoryInterface
     {
-        return once(fn () => new PsrHttpFactory(
+        return $this->psrHttpFactory ?: ($this->psrHttpFactory = new PsrHttpFactory(
             new \Spiral\RoadRunner\Diactoros\ServerRequestFactory,
             new \Spiral\RoadRunner\Diactoros\StreamFactory,
             new \Spiral\RoadRunner\Diactoros\UploadedFileFactory,


### PR DESCRIPTION
This pull request removes the `spatie/once` dependency.

**Reasoning**:

1. We are only using the function `once` twice.
2. In the long term, the version Laravel developers have of `spatie/once` will have to match the version used in this package, or we are going to be forced to support multiple versions of the `spatie/once` dependency. `"spatie/once": "^3.0|^4.0|^5.0...."`, etc.

**Question**: Its ok to equally perform pull request that removes the `spatie/laravel-package-tools` dependency too?