### PR TITLE
Removes "spatie/laravel-package-tools" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^8.0",
         "illuminate/contracts": "^8.0",
         "laminas/laminas-diactoros": "^2.5",
-        "spatie/laravel-package-tools": "^1.4",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request removes the "spatie/laravel-package-tools" dependency for the same reasons as https://github.com/laravel/octane/pull/24.