### PR TITLE
Fixes workers count on roadrunner

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -156,9 +156,9 @@ class StartRoadRunnerCommand extends Command
      */
     protected function workerCount()
     {
-        return $this->option('workers') === 'auto'
-                            ? 1
-                            : $this->option('workers', 1);
+        return $this->option('workers') == 'auto'
+                            ? 0
+                            : $this->option('workers', 0);
     }
 
     /**


### PR DESCRIPTION
Previously we were using all the time 1 worker on roadrunner. This pull request fixes that, by setting the number of workers to 0 by default. When the number of workers is "0", roadrunner will automatically calculate the number of available cores.