### PR TITLE
Kills swoole manager process when stopping server

### DIFF
--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -52,8 +52,10 @@ class ServerProcessInspector
     {
         [
             'masterProcessId' => $masterProcessId,
+            'managerProcessId' => $managerProcessId
         ] = $this->serverStateFile->read();
 
-        return $this->dispatcher->terminate($masterProcessId, 15);
+        return $this->dispatcher->terminate($masterProcessId, 15)
+            && $this->dispatcher->terminate($managerProcessId, 15);
     }
 }


### PR DESCRIPTION
This pull request makes "stop:swoole" server to kill the manager process. Otherwise, Swoole processes remain in background even after running a "stop:swoole".