### PR TITLE
Groups errors because of tasks

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -141,9 +141,9 @@ trait InteractsWithIO
             new WorkerExceptionInspector(
                 new WorkerException(
                     $throwable['message'],
-                    $throwable['code'],
+                    (int) $throwable['code'],
                     $throwable['file'],
-                    $throwable['line'],
+                    (int) $throwable['line'],
                 ),
                 $throwable['class'],
                 $throwable['trace'],

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -163,10 +163,24 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         Str::of($server->getIncrementalErrorOutput())
             ->explode("\n")
             ->filter()
-            ->each(function ($output) {
-                is_array($stream = json_decode($output, true))
+            ->groupBy(fn ($output) => $output)
+            ->each(function ($group) {
+                is_array($stream = json_decode($group->first(), true))
                     ? $this->handleStream($stream)
                     : $this->error($output);
+
+                if (($count = $group->count()) > 1) {
+                    $this->newLine();
+
+                    $count--;
+
+                    $this->line(sprintf('  <fg=red;options=bold>↑</>   %s %s',
+                        $count,
+                        $count > 1
+                            ? 'similar errors were reported.'
+                            : 'similar error was reported.'
+                    ));
+                }
             });
     }
 }


### PR DESCRIPTION
Previously I've removed the "group errors" feature because we now are killing the process on the first exception while booting the workers. But because exceptions from tasks get streamed to the console, the group tasks feature is relevant once again.

<img width="444" alt="Screenshot 2021-04-03 at 17 38 21" src="https://user-images.githubusercontent.com/5457236/113485014-63361180-94a3-11eb-8e1a-c618918f899f.png">