### PR TITLE
Only streams throwable when env is not local

### DIFF
--- a/src/Listeners/ReportException.php
+++ b/src/Listeners/ReportException.php
@@ -17,7 +17,7 @@ class ReportException
     {
         if ($event->exception) {
             tap($event->sandbox, function ($sandbox) use ($event) {
-                if ($sandbox->environment('local')) {
+                if ($sandbox->environment('local', 'testing')) {
                     Stream::throwable($event->exception);
                 }
 

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -84,7 +84,7 @@ class OnWorkerStart
     protected function streamRequestsToConsole($server)
     {
         $this->workerState->worker->onRequestHandled(function ($request, $response, $sandbox) {
-            if (! $sandbox->environment('local')) {
+            if (! $sandbox->environment('local', 'testing')) {
                 return;
             }
 


### PR DESCRIPTION
This pull request avoids that task exceptions are reported to the STDERR in production.