### PR TITLE
Move `FakeClient` and `FakeWorker` to `Laravel\Octane\Testing` namespace

### DIFF
--- a/src/Testing/Fakes/FakeClient.php
+++ b/src/Testing/Fakes/FakeClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Octane\Tests\Fakes;
+namespace Laravel\Octane\Testing\Fakes;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;

--- a/src/Testing/Fakes/FakeWorker.php
+++ b/src/Testing/Fakes/FakeWorker.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Octane\Tests\Fakes;
+namespace Laravel\Octane\Testing\Fakes;
 
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Worker;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneServiceProvider;
+use Laravel\Octane\Testing\Fakes\FakeClient;
+use Laravel\Octane\Testing\Fakes\FakeWorker;
 use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -19,7 +21,7 @@ class TestCase extends BaseTestCase
 
         $app->register(new OctaneServiceProvider($app));
 
-        $worker = new Fakes\FakeWorker($appFactory, $roadRunnerClient = new Fakes\FakeClient($requests));
+        $worker = new FakeWorker($appFactory, $roadRunnerClient = new FakeClient($requests));
         $app->bind(Client::class, fn () => $roadRunnerClient);
 
         $worker->boot();


### PR DESCRIPTION
It would be useful to have the classes available on every installation. 

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>