### PR TITLE
Makes the "SequentialTaskDispatcher" to behave like "SwooleTaskDispatcher" when errors occurs

### DIFF
--- a/src/SequentialTaskDispatcher.php
+++ b/src/SequentialTaskDispatcher.php
@@ -28,10 +28,14 @@ class SequentialTaskDispatcher implements DispatchesTasks
                 } catch (Throwable $e) {
                     report($e);
 
-                    throw TaskExceptionResult::from($e)->getOriginal();
+                    return TaskExceptionResult::from($e);
                 }
             })()]
-        )->all();
+        )->each(function ($result) {
+            if ($result instanceof TaskExceptionResult) {
+                throw $result->getOriginal();
+            }
+        })->all();
     }
 
     /**
@@ -42,6 +46,10 @@ class SequentialTaskDispatcher implements DispatchesTasks
      */
     public function dispatch(array $tasks): void
     {
-        $this->resolve($tasks);
+        try {
+            $this->resolve($tasks);
+        } catch (Throwable $e) {
+            // ..
+        }
     }
 }


### PR DESCRIPTION
This pull request makes the "SequentialTaskDispatcher" to behave like "SwooleTaskDispatcher" when errors occurs.