### PR TITLE
Add failing test for array cache should be flush between request.

### DIFF
--- a/tests/CacheArrayStateTest.php
+++ b/tests/CacheArrayStateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+class CacheArrayStateTest extends TestCase
+{
+    /** @test */
+    public function test_array_cache_is_flushed_between_requests()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/test-cache?remember=first', 'GET'),
+            Request::create('/test-cache?remember=second', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/test-cache', function (Application $app, Request $request) {
+            return $app['cache']->driver('array')->rememberForever('nitro', fn () => $request->query('remember'));
+        });
+
+        $worker->run();
+
+        $this->assertEquals('first', $client->responses[0]->getContent());
+        $this->assertEquals('second', $client->responses[1]->getContent());
+    }
+}


### PR DESCRIPTION
Similar to `spatie/once` you can use `array` cache to fetch and remember a value once until the request ended. However with Octane now persists the result between requests until the worker gets terminated/replaced.

Laravel Nova uses this to cache the current version (fetched from composer.json) which is not damaging, however other projects might already using it on production, including:

![image](https://user-images.githubusercontent.com/172966/113701930-64697780-970b-11eb-8f4f-4bfcc256c710.png)

See https://spatie.be/docs/laravel-permission/v4/advanced-usage/cache#disabling-cache

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
