### PR TITLE
Add testing helpers

### DIFF
--- a/src/Testing/OctaneRequest.php
+++ b/src/Testing/OctaneRequest.php
@@ -8,8 +8,6 @@ use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneServiceProvider;
-use Laravel\Octane\Testing\Fakes\FakeClient;
-use Laravel\Octane\Testing\Fakes\FakeWorker;
 use Mockery;
 
 class OctaneRequest
@@ -48,7 +46,7 @@ class OctaneRequest
 
         $app->register(new OctaneServiceProvider($app));
 
-        $worker = new FakeWorker($appFactory, $roadRunnerClient = new FakeClient($requests));
+        $worker = new Fakes\FakeWorker($appFactory, $roadRunnerClient = new Fakes\FakeClient($requests));
         $app->bind(Client::class, fn () => $roadRunnerClient);
 
         $worker->boot();

--- a/src/Testing/OctaneRequest.php
+++ b/src/Testing/OctaneRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Octane\Testing;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Testing\TestResponse;
+use Laravel\Octane\ApplicationFactory;
+use Laravel\Octane\Contracts\Client;
+use Laravel\Octane\Octane;
+use Laravel\Octane\OctaneServiceProvider;
+use Laravel\Octane\Testing\Fakes\FakeClient;
+use Laravel\Octane\Testing\Fakes\FakeWorker;
+use Mockery;
+
+class OctaneRequest
+{
+    public ApplicationFactory $factory;
+
+    public function __construct(public Application $app)
+    {
+        $this->factory = new ApplicationFactory($app->basePath());
+
+        $this->factory->warm($app, Octane::defaultServicesToWarm());
+    }
+
+    /**
+     * Create Octane Request handler from Application.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return static
+     */
+    public static function from(Application $app): static
+    {
+        return new static($app);
+    }
+
+    /**
+     * Handle requests using Octane.
+     *
+     * @param  array  $requests
+     * @return array
+     */
+    public function handle(array $requests): array
+    {
+        $appFactory = Mockery::mock(ApplicationFactory::class);
+
+        $appFactory->shouldReceive('createApplication')->andReturn($app = $this->app);
+
+        $app->register(new OctaneServiceProvider($app));
+
+        $worker = new FakeWorker($appFactory, $roadRunnerClient = new FakeClient($requests));
+        $app->bind(Client::class, fn () => $roadRunnerClient);
+
+        $worker->boot();
+
+        $worker->run();
+
+        return collect($roadRunnerClient->responses)
+                    ->transform(fn ($response) => new TestResponse($response))
+                    ->all();
+    }
+}

--- a/tests/RouterStateTest.php
+++ b/tests/RouterStateTest.php
@@ -9,7 +9,6 @@ class RouterStateTest extends TestCase
     /** @test */
     public function test_router_and_route_container_is_refreshed_across_subsequent_requests()
     {
-
         [$app, $worker, $client] = $this->createOctaneContext([
             Request::create('/first', 'GET'),
             Request::create('/second', 'GET'),

--- a/tests/RouterStateTest.php
+++ b/tests/RouterStateTest.php
@@ -9,6 +9,7 @@ class RouterStateTest extends TestCase
     /** @test */
     public function test_router_and_route_container_is_refreshed_across_subsequent_requests()
     {
+
         [$app, $worker, $client] = $this->createOctaneContext([
             Request::create('/first', 'GET'),
             Request::create('/second', 'GET'),

--- a/tests/TestingContextTest.php
+++ b/tests/TestingContextTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Laravel\Octane\Tests;
 
 use Illuminate\Http\Request;

--- a/tests/TestingContextTest.php
+++ b/tests/TestingContextTest.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Http\Request;
+use Illuminate\Testing\TestResponse;
+use Laravel\Octane\Testing\OctaneRequest;
+
+class TestingContextTest extends \Orchestra\Testbench\TestCase
+{
+    protected function defineRoutes($router)
+    {
+        $router->middleware('web')->get('/first', function (Request $request) {
+            return $request->url();
+        });
+
+        $router->middleware('web')->get('/second', function (Request $request) {
+            return $request->url();
+        });
+    }
+
+    /** @test */
+    public function test_router_and_route_container_is_refreshed_across_subsequent_requests()
+    {
+        $responses = OctaneRequest::from($this->app)->handle([
+            Request::create('/first', 'GET'),
+            Request::create('/second', 'GET'),
+        ]);
+
+        $this->assertInstanceOf(TestResponse::class, $responses[0]);
+        $this->assertInstanceOf(TestResponse::class, $responses[1]);
+
+        $this->assertEquals('http://localhost/first', $responses[0]->getContent());
+        $this->assertEquals('http://localhost/second', $responses[1]->getContent());
+    }
+}


### PR DESCRIPTION
```php
$responses = \Laravel\Octane\Testing\OctaneRequest::from($this->app)->handle([
    Request::create('/first', 'GET'),
    Request::create('/second', 'GET'),
]);

// $responses[0] and $responses[1] are instances of Illuminate\Testing\TestResponse
```

### Potential issues

* Shouldn't be able to use Event Fake during testing since it would be required to flush states between requests.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>


