### PR TITLE
Load deferred providers after bootstrapping

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -47,6 +47,8 @@ class ApplicationFactory
 
         $app->bootstrapWith($this->getBootstrappers($app));
 
+        $app->loadDeferredProviders();
+
         return $app;
     }
 


### PR DESCRIPTION
Loading the deferred providers initially ensure the'll be already loaded for every sandbox instance. Without this, deferred providers are registered on every request.