### PR TITLE
fix Octane::concurrently hangs when a task returns null

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -135,11 +135,11 @@ $server->on('request', function ($request, $response) use ($server, $workerState
 |
 */
 
-$server->on('task', fn (Server $server, int $taskId, int $fromWorkerId, $data) =>
+$server->on('task', function (Server $server, int $taskId, int $fromWorkerId, $data) use ($workerState) {
     $data === 'octane-tick'
             ? $workerState->worker->handleTick()
-            : $workerState->worker->handleTask($data)
-);
+            : $server->finish($workerState->worker->handleTask($data));
+});
 
 $server->on('finish', fn (Server $server, int $taskId, $result) => $result);
 


### PR DESCRIPTION
You either merge this, or this https://github.com/laravel/octane/pull/69