### PR TITLE
[WIP] Fix the RR reset command

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -38,7 +38,7 @@ class ServerProcessInspector
     public function reloadServer(string $basePath): void
     {
         $this->processFactory->createProcess([
-            './rr', 'http:reset',
+            './rr', 'reset',
         ], $basePath, null, null, null)->run();
     }
 


### PR DESCRIPTION
As per documentation the RR command is `reset {service}`, i.e. `reset http`. Command without args `reset` will reset all the plugins.

Current code uses older (v1) reset commands dedicated to HTTP only.

Reference: https://roadrunner.dev/docs/beep-beep-cli