### PR TITLE
Add methods to facade doc block

### DIFF
--- a/src/Facades/Octane.php
+++ b/src/Facades/Octane.php
@@ -5,6 +5,13 @@ namespace Laravel\Octane\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static \Laravel\Octane\Swoole\InvokeTickCallable tick(string $key, callable $callback, int $seconds = 1, bool $immediate = true)
+ * @method static \Swoole\Table table(string $name)
+ * @method static \Symfony\Component\HttpFoundation\Response invokeRoute(\Illuminate\Http\Request $request, string $method, string $uri)
+ * @method static array concurrently(array $tasks, int $waitMilliseconds = 3000)
+ * @method static bool hasRouteFor(string $method, string $uri)
+ * @method static void route(string $method, string $uri, \Closure $callback)
+ * 
  * @see \Laravel\Octane\Octane
  */
 class Octane extends Facade

--- a/src/Facades/Octane.php
+++ b/src/Facades/Octane.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array concurrently(array $tasks, int $waitMilliseconds = 3000)
  * @method static bool hasRouteFor(string $method, string $uri)
  * @method static void route(string $method, string $uri, \Closure $callback)
- * 
+ *
  * @see \Laravel\Octane\Octane
  */
 class Octane extends Facade


### PR DESCRIPTION
Adds the methods from the `\Laravel\Octane\Octane` class and concerns to the facade doc block for better IDE support, similar to other facades of the framework.

Not sure if all of the documented methods are already considered stable enough to be documented here, I primarily added it for the `concurrently($tasks)` method.