### PR TITLE
Handle invalid server option in `octane:start/reload/stop`

### DIFF
--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -30,9 +30,11 @@ class ReloadCommand extends Command
     {
         $server = $this->option('server') ?: config('octane.server');
 
-        return $server == 'swoole'
-            ? $this->reloadSwooleServer()
-            : $this->reloadRoadRunnerServer();
+        return match ($server) {
+            'swoole' => $this->reloadSwooleServer(),
+            'roadrunner' => $this->reloadRoadRunnerServer(),
+            default => $this->handleInvalidServer($server),
+        };
     }
 
     /**
@@ -77,5 +79,17 @@ class ReloadCommand extends Command
         $inspector->reloadServer(base_path());
 
         return 0;
+    }
+
+    /**
+     * Handle invalid server.
+     *
+     * @return int
+     */
+    protected function handleInvalidServer(string $server)
+    {
+        $this->error("Invalid server: {$server}.");
+
+        return 1;
     }
 }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -45,9 +45,11 @@ class StartCommand extends Command implements SignalableCommandInterface
 
         $server = $this->option('server') ?: config('octane.server');
 
-        return $server == 'swoole'
-            ? $this->startSwooleServer()
-            : $this->startRoadRunnerServer();
+        return match ($server) {
+            'swoole' => $this->startSwooleServer(),
+            'roadrunner' => $this->startRoadRunnerServer(),
+            default => $this->handleInvalidServer($server),
+        };
     }
 
     /**
@@ -81,5 +83,17 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
         ]);
+    }
+
+    /**
+     * Handle invalid server.
+     *
+     * @return int
+     */
+    protected function handleInvalidServer(string $server)
+    {
+        $this->error("Invalid server: {$server}.");
+
+        return 1;
     }
 }

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -32,9 +32,11 @@ class StopCommand extends Command
     {
         $server = $this->option('server') ?: config('octane.server');
 
-        return $server == 'swoole'
-            ? $this->stopSwooleServer()
-            : $this->stopRoadRunnerServer();
+        return match ($server) {
+            'swoole' => $this->stopSwooleServer(),
+            'roadrunner' => $this->stopRoadRunnerServer(),
+            default => $this->handleInvalidServer($server),
+        };
     }
 
     /**
@@ -87,5 +89,17 @@ class StopCommand extends Command
         app(RoadRunnerServerStateFile::class)->delete();
 
         return 0;
+    }
+
+    /**
+     * Handle invalid server.
+     *
+     * @return int
+     */
+    protected function handleInvalidServer(string $server)
+    {
+        $this->error("Invalid server: {$server}.");
+
+        return 1;
     }
 }


### PR DESCRIPTION
For example, if I type `php artisan octane:start --server=swole`, the `roadrunner` server is started.