### PR TITLE
Update octane.php

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -32,7 +32,7 @@ return [
     |
     */
 
-    'server' => env('OCTANE_SERVER', 'roadrunner'),
+    'server' => env('OCTANE_SERVER', 'swoole'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Set the default server to `swoole`, because now `roadrunner` has a known bug. see issue #102 