### PR TITLE
Use PhpExecutableFinder for Octane server command

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -64,8 +64,8 @@ trait InstallsRoadRunnerDependencies
         $composerPath = getcwd().'/composer.phar';
         $phpPath = (new PhpExecutableFinder)->find();
 
-        if (!file_exists($composerPath)) {
-           $composerPath = (new ExecutableFinder())->find('composer');
+        if (! file_exists($composerPath)) {
+            $composerPath = (new ExecutableFinder())->find('composer');
         }
 
         return '"'.$phpPath.'" '.$composerPath;

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -7,8 +7,8 @@ use RuntimeException;
 use Spiral\RoadRunner\Http\PSR7Worker;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
 
 trait InstallsRoadRunnerDependencies
 {

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -8,6 +8,7 @@ use Spiral\RoadRunner\Http\PSR7Worker;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 trait InstallsRoadRunnerDependencies
 {
@@ -61,12 +62,13 @@ trait InstallsRoadRunnerDependencies
     protected function findComposer()
     {
         $composerPath = getcwd().'/composer.phar';
+        $phpPath = (new PhpExecutableFinder)->find();
 
-        if (file_exists($composerPath)) {
-            return '"'.PHP_BINARY.'" '.$composerPath;
+        if (!file_exists($composerPath)) {
+           $composerPath = (new ExecutableFinder())->find('composer');
         }
 
-        return 'composer';
+        return '"'.$phpPath.'" '.$composerPath;
     }
 
     /**
@@ -88,6 +90,7 @@ trait InstallsRoadRunnerDependencies
 
         if ($this->confirm('Unable to locate RoadRunner binary. Should Octane download the binary for your operating system?', true)) {
             tap(new Process(array_filter([
+                (new PhpExecutableFinder)->find(),
                 './vendor/bin/rr',
                 'get-binary',
                 '-n',

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -7,6 +7,7 @@ use Laravel\Octane\RoadRunner\ServerProcessInspector;
 use Laravel\Octane\RoadRunner\ServerStateFile;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 class StartRoadRunnerCommand extends Command implements SignalableCommandInterface
 {
@@ -66,7 +67,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         $server = tap(new Process(array_filter([
             $roadRunnerBinary,
             '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
-            '-o', 'server.command=php ./vendor/bin/roadrunner-worker',
+            '-o', 'server.command='.(new PhpExecutableFinder)->find().' ./vendor/bin/roadrunner-worker',
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Str;
 use Laravel\Octane\RoadRunner\ServerProcessInspector;
 use Laravel\Octane\RoadRunner\ServerStateFile;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
 
 class StartRoadRunnerCommand extends Command implements SignalableCommandInterface
 {


### PR DESCRIPTION
This is similar to the Swoole command, makes sure the current PHP version is used (eg. when using multiple PHP versions)