### PR TITLE
Drop realpath to serve linked files

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -53,7 +53,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         return $this->fileIsServable(
             $publicPath,
-            realpath($publicPath.'/'.$request->path()),
+            $publicPath.'/'.$request->path()
         );
     }
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -53,7 +53,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         return $this->fileIsServable(
             $publicPath,
-            $publicPath.'/'.$request->path()
+            $publicPath.'/'.$request->path(),
         );
     }
 


### PR DESCRIPTION
This PR drops usage of `realpath() in favor of serving linked files. fixes #99 

I'm not sure what to do with the testcase. as this change would allow to read files out of public directory. and `is_link` only works if the file itself is symlinked. but in #99 case it's the parent directory that is symlinked. 

so up to the octane team to decide on that