### PR TITLE
Use cli_set_process_title instead of swoole_set_process_name

### DIFF
--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -32,7 +32,7 @@ class SwooleExtension
     public function setProcessName(string $appName, string $processName): void
     {
         if (PHP_OS_FAMILY === 'Linux') {
-            swoole_set_process_name('swoole_http_server: '.$processName.' for '.$appName);
+            cli_set_process_title('swoole_http_server: '.$processName.' for '.$appName);
         }
     }
 


### PR DESCRIPTION
`swoole_set_process_name` is actually also a call to `cli_set_process_title`

So it's better to use `cli_set_process_title` directly