### PR TITLE
Optimized the memory usage when writing chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
-.idea

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -18,10 +18,6 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
-    /**
-     * SwooleClient constructor.
-     * @param int $chunkSize The size of chunk to write, default 1MB. @see https://www.swoole.co.uk/docs/modules/swoole-server/configuration#socket_buffer_size
-     */
     public function __construct(protected int $chunkSize = 1048576)
     {
     }
@@ -171,6 +167,7 @@ class SwooleClient implements Client, ServesStaticFiles
         }
 
         $content = $response->getContent();
+
         $length = strlen($content);
 
         if ($length <= $this->chunkSize) {
@@ -180,8 +177,7 @@ class SwooleClient implements Client, ServesStaticFiles
         }
 
         for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
-            $chunk = substr($content, $offset, $this->chunkSize);
-            $swooleResponse->write($chunk);
+            $swooleResponse->write(substr($content, $offset, $this->chunkSize));
         }
 
         $swooleResponse->end();

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,11 +19,12 @@ use Throwable;
 class SwooleClient implements Client, ServesStaticFiles
 {
     /**
-     * The size of chunk to write, default 1MB.
-     * @see https://www.swoole.co.uk/docs/modules/swoole-server/configuration#socket_buffer_size
-     * @var int
+     * SwooleClient constructor.
+     * @param int $chunkSize The size of chunk to write, default 1MB. @see https://www.swoole.co.uk/docs/modules/swoole-server/configuration#socket_buffer_size
      */
-    protected int $chunkSize = 1048576;
+    public function __construct(protected int $chunkSize = 1048576)
+    {
+    }
 
     /**
      * Marshal the given request context into an Illuminate request.
@@ -203,24 +204,5 @@ class SwooleClient implements Client, ServesStaticFiles
         $context->swooleResponse->end(
             Octane::formatExceptionForClient($e, $app->make('config')->get('app.debug'))
         );
-    }
-
-    /**
-     * Set the size of chunk.
-     * @see https://www.swoole.co.uk/docs/modules/swoole-server/configuration#socket_buffer_size
-     * @param int $chunkSize
-     */
-    public function setChunkSize(int $chunkSize): void
-    {
-        $this->chunkSize = $chunkSize;
-    }
-
-    /**
-     * Get the size of chunk.
-     * @return int
-     */
-    public function getChunkSize(): int
-    {
-        return $this->chunkSize;
     }
 }


### PR DESCRIPTION
Hello guys, I did a test, substr() has no memory overhead and is more efficient than str_split().

```php
$bigStr = str_repeat('abcdefghijklmnopqrstuvwxyz0123456789', 1000000);
$memStart = memory_get_usage(true);
$timeStart = microtime(true);

// ----- substr()
$len = strlen($bigStr);
$chunkLimit = 4096;
for ($offset = 0; $offset < $len; $offset += $chunkLimit) {
    $chunk = substr($bigStr, $offset, $chunkLimit);
}

// ----- str_split()
//$chunkLimit = 4096;
//foreach (str_split($bigStr, $chunkLimit) as $chunk) {
//}

$costMem = memory_get_usage(true) - $memStart;
$costTime = microtime(true) - $timeStart;
echo "Memory: {$costMem} Time: {$costTime}\n";
```

```
// substr()
Memory: 0 Time: 0.0036599636077881

// str_split()
Memory: 2097152 Time: 0.043421983718872
```
[reference](https://github.com/hhxsv5/laravel-s/blob/master/src/Swoole/DynamicResponse.php#L31)