### PR TITLE
Use new class notation

### DIFF
--- a/src/Exceptions/TaskExceptionResult.php
+++ b/src/Exceptions/TaskExceptionResult.php
@@ -29,7 +29,7 @@ class TaskExceptionResult
             : null;
 
         return new static(
-            get_class($throwable),
+            $throwable::class,
             $throwable->getMessage(),
             (int) $throwable->getCode(),
             $fallbackTrace['file'] ?? $throwable->getFile(),

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -40,7 +40,7 @@ class Stream
 
         fwrite(STDERR, json_encode([
             'type' => 'throwable',
-            'class' => get_class($throwable),
+            'class' => $throwable::class,
             'code' => $throwable->getCode(),
             'file' => $fallbackTrace['file'] ?? $throwable->getFile(),
             'line' => $fallbackTrace['line'] ?? (int) $throwable->getLine(),
@@ -59,7 +59,7 @@ class Stream
     {
         fwrite(STDERR, json_encode([
             'type' => 'shutdown',
-            'class' => get_class($throwable),
+            'class' => $throwable::class,
             'code' => $throwable->getCode(),
             'file' => $throwable->getFile(),
             'line' => $throwable->getLine(),


### PR DESCRIPTION
In PHP 8 we can finally use the `::class` notation on objects to get their FQN.