### PR TITLE
Remove variables in catches

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -65,7 +65,7 @@ trait InteractsWithServers
             }
 
             $this->writeServerOutput($server);
-        } catch (ServerShutdownException $e) {
+        } catch (ServerShutdownException) {
             return 1;
         } finally {
             $this->stopServer();

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -185,11 +185,11 @@ class OctaneServiceProvider extends ServiceProvider
                     unserialize(Crypt::decryptString($request->input('tasks'))),
                     $request->input('wait')
                 )), 200);
-            } catch (DecryptException $e) {
+            } catch (DecryptException) {
                 return new Response('', 403);
-            } catch (TaskException $e) {
+            } catch (TaskException) {
                 return new Response('', 500);
-            } catch (TaskTimeoutException $e) {
+            } catch (TaskTimeoutException) {
                 return new Response('', 504);
             }
         });
@@ -199,7 +199,7 @@ class OctaneServiceProvider extends ServiceProvider
                 (new SwooleTaskDispatcher)->dispatch(
                     unserialize(Crypt::decryptString($request->input('tasks'))),
                 );
-            } catch (DecryptException $e) {
+            } catch (DecryptException) {
                 return new Response('', 403);
             }
 

--- a/src/SequentialTaskDispatcher.php
+++ b/src/SequentialTaskDispatcher.php
@@ -49,7 +49,7 @@ class SequentialTaskDispatcher implements DispatchesTasks
     {
         try {
             $this->resolve($tasks);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // ..
         }
     }

--- a/src/Swoole/SwooleHttpTaskDispatcher.php
+++ b/src/Swoole/SwooleHttpTaskDispatcher.php
@@ -53,7 +53,7 @@ class SwooleHttpTaskDispatcher implements DispatchesTasks
                     new Exception('Invalid response from task server.'),
                 )->getOriginal(),
             };
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException) {
             return $this->fallbackDispatcher->resolve($tasks, $waitMilliseconds);
         }
     }
@@ -76,7 +76,7 @@ class SwooleHttpTaskDispatcher implements DispatchesTasks
             Http::post("http://{$this->host}:{$this->port}/octane/dispatch-tasks", [
                 'tasks' => Crypt::encryptString(serialize($tasks)),
             ]);
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException) {
             $this->fallbackDispatcher->dispatch($tasks);
         }
     }

--- a/tests/SequentialTaskDispatcherTest.php
+++ b/tests/SequentialTaskDispatcherTest.php
@@ -39,7 +39,7 @@ class SequentialTaskDispatcherTest extends TestCase
                     $a = true;
                 },
             ]);
-        } catch (TaskException $e) {
+        } catch (TaskException) {
             //
         }
 


### PR DESCRIPTION
In PHP 8 it's no longer necessary to add these.