### PR TITLE
Makes `dd` compatible with Octane

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Octane\Exceptions\DdException;
+
 ini_set('display_errors', 'stderr');
 
 $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
@@ -21,6 +23,13 @@ if (! is_string($basePath)) {
     fwrite(STDERR, 'Cannot find application base path.'.PHP_EOL);
 
     exit(11);
+}
+
+if (! function_exists('dd')) {
+    function dd(...$vars)
+    {
+        throw new DdException($vars);
+    }
 }
 
 /*

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -3,10 +3,12 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use Illuminate\Support\Str;
+use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Exceptions\ServerShutdownException;
 use Laravel\Octane\Exceptions\WorkerException;
 use Laravel\Octane\WorkerExceptionInspector;
 use NunoMaduro\Collision\Writer;
+use Symfony\Component\VarDumper\VarDumper;
 
 trait InteractsWithIO
 {
@@ -123,6 +125,19 @@ trait InteractsWithIO
     }
 
     /**
+     * Write information about a dd to the console.
+     *
+     * @param  array  $throwable
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function ddInfo($throwable, $verbosity = null)
+    {
+        collect(json_decode($throwable['message'], true))
+            ->each(fn ($var) => VarDumper::dump($var));
+    }
+
+    /**
      * Write information about a throwable to the console.
      *
      * @param  array  $throwable
@@ -131,6 +146,10 @@ trait InteractsWithIO
      */
     public function throwableInfo($throwable, $verbosity = null)
     {
+        if ($throwable['class'] == DdException::class) {
+            return $this->ddInfo($throwable, $verbosity);
+        }
+
         if (! class_exists('NunoMaduro\Collision\Writer')) {
             $this->label($throwable['message'], $verbosity, $throwable['class'], 'red', 'white');
 

--- a/src/Exceptions/DdException.php
+++ b/src/Exceptions/DdException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Octane\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Support\Renderable;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
+class DdException extends Exception implements Renderable
+{
+    public function __construct(public array $vars)
+    {
+        $this->message = json_encode($vars);
+    }
+
+    /**
+     * Get the evaluated contents of the object.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $dump = function ($var) {
+            $data = (new VarCloner())->cloneVar($var)->withMaxDepth(3);
+
+            return (string) (new HtmlDumper(false))->dump($data, true, [
+                'maxDepth' => 3,
+                'maxStringLength' => 160,
+            ]);
+        };
+
+        return collect($this->vars)->map($dump)->implode('');
+    }
+}

--- a/src/Exceptions/TaskExceptionResult.php
+++ b/src/Exceptions/TaskExceptionResult.php
@@ -44,6 +44,12 @@ class TaskExceptionResult
      */
     public function getOriginal()
     {
+        if ($this->class == DdException::class) {
+            return new DdException(
+                json_decode($this->message, true)
+            );
+        }
+
         return new TaskException(
             $this->class,
             $this->message,

--- a/src/Listeners/ReportException.php
+++ b/src/Listeners/ReportException.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Listeners;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Stream;
 
 class ReportException
@@ -17,6 +18,10 @@ class ReportException
     {
         if ($event->exception) {
             tap($event->sandbox, function ($sandbox) use ($event) {
+                if ($event->exception instanceof DdException) {
+                    return;
+                }
+
                 if ($sandbox->environment('local', 'testing')) {
                     Stream::throwable($event->exception);
                 }

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -14,7 +14,7 @@ use Laravel\Octane\Cache\OctaneArrayStore;
 use Laravel\Octane\Cache\OctaneStore;
 use Laravel\Octane\Contracts\DispatchesCoroutines;
 use Laravel\Octane\Events\TickReceived;
-use Laravel\Octane\Exceptions\DieVarDumpException;
+use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Exceptions\TaskException;
 use Laravel\Octane\Exceptions\TaskTimeoutException;
 use Laravel\Octane\Facades\Octane as OctaneFacade;
@@ -188,7 +188,7 @@ class OctaneServiceProvider extends ServiceProvider
                 )), 200);
             } catch (DecryptException) {
                 return new Response('', 403);
-            } catch (TaskException | DieVarDumpException) {
+            } catch (TaskException | DdException) {
                 return new Response('', 500);
             } catch (TaskTimeoutException) {
                 return new Response('', 504);

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -14,6 +14,7 @@ use Laravel\Octane\Cache\OctaneArrayStore;
 use Laravel\Octane\Cache\OctaneStore;
 use Laravel\Octane\Contracts\DispatchesCoroutines;
 use Laravel\Octane\Events\TickReceived;
+use Laravel\Octane\Exceptions\DieVarDumpException;
 use Laravel\Octane\Exceptions\TaskException;
 use Laravel\Octane\Exceptions\TaskTimeoutException;
 use Laravel\Octane\Facades\Octane as OctaneFacade;
@@ -187,7 +188,7 @@ class OctaneServiceProvider extends ServiceProvider
                 )), 200);
             } catch (DecryptException) {
                 return new Response('', 403);
-            } catch (TaskException) {
+            } catch (TaskException | DieVarDumpException) {
                 return new Response('', 500);
             } catch (TaskTimeoutException) {
                 return new Response('', 504);

--- a/tests/Listeners/ReportExceptionTest.php
+++ b/tests/Listeners/ReportExceptionTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Listeners;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Octane\Events\WorkerErrorOccurred;
+use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Tests\TestCase;
 use Mockery;
@@ -44,6 +45,20 @@ class ReportExceptionTest extends TestCase
             ->with($exception);
 
         $app->bind(ExceptionHandler::class, fn () => $exceptionHandler);
+
+        $worker->dispatchEvent($app, new WorkerErrorOccurred($exception, $app));
+    }
+
+    /** @doesNotPerformAssertions @test */
+    public function test_dd_calls_are_not_streamed()
+    {
+        [$app, $worker] = $this->createOctaneContext([]);
+
+        $exception = new DdException(['foo' => 'bar']);
+
+        Mockery::mock('alias:'.Stream::class)
+            ->shouldReceive('throwable')
+            ->never();
 
         $worker->dispatchEvent($app, new WorkerErrorOccurred($exception, $app));
     }

--- a/tests/SequentialTaskDispatcherTest.php
+++ b/tests/SequentialTaskDispatcherTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Tests;
 
 use Exception;
+use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Exceptions\TaskException;
 use Laravel\Octane\SequentialTaskDispatcher;
 
@@ -87,6 +88,19 @@ class SequentialTaskDispatcherTest extends TestCase
 
         $dispatcher->resolve([
             'first' => fn () => throw new Exception('Something went wrong.'),
+        ]);
+    }
+
+    /** @test */
+    public function test_resolving_tasks_propagate_dd_calls()
+    {
+        $dispatcher = new SequentialTaskDispatcher();
+
+        $this->expectException(DdException::class);
+        $this->expectExceptionMessage(json_encode(['foo' => 'bar']));
+
+        $dispatcher->resolve([
+            'first' => fn () => throw new DdException(['foo' => 'bar']),
         ]);
     }
 }


### PR DESCRIPTION
This pull request makes `dd` compatible with Octane.

<img width="1348" alt="dd" src="https://user-images.githubusercontent.com/5457236/114084824-82201380-98a8-11eb-82a5-d4ef04e7e75b.png">
