### PR TITLE
Makes watch paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Before using this feature, you should ensure that [Node](https://nodejs.org) is 
 npm install --save-dev chokidar
 ```
 
+You may configure the list of directories/files under watch in your application's `config/octane.php` configuration file.
+
 #### Specifying The Worker Count
 
 By default, Octane will start an application request worker for each CPU core provided by your machine. However, you may manually specify how many workers you would like to start using the `--workers` option when invoking the `octane:start` command:

--- a/bin/file-watcher.js
+++ b/bin/file-watcher.js
@@ -1,23 +1,10 @@
 const chokidar = require('chokidar');
 
-const basePath = process.argv[2];
+const paths = JSON.parse(process.argv[2]);
 
-const watcher = chokidar.watch(
-    [
-        basePath + '/app',
-        basePath + '/bootstrap',
-        basePath + '/config',
-        basePath + '/database',
-        basePath + '/public',
-        basePath + '/resources',
-        basePath + '/routes',
-        basePath + '/composer.lock',
-        basePath + '/.env',
-    ],
-    {
-        ignoreInitial: true,
-    }
-);
+const watcher = chokidar.watch(paths, {
+    ignoreInitial: true,
+});
 
 watcher
     .on('add', () => console.log('File added...'))

--- a/config/octane.php
+++ b/config/octane.php
@@ -180,4 +180,27 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Lorem Ipsum
+    |--------------------------------------------------------------------------
+    |
+    | Lorem Ipsum has been the industry's standard dummy text ever since
+    | the 1500s, when an unknown printer took a galley of type and sc
+    | rambled it to make a type specimen book. It has survived not.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config',
+        'database',
+        'public',
+        'resources',
+        'routes',
+        'composer.lock',
+        '.env',
+    ],
+
 ];

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Commands\Concerns;
 
+use InvalidArgumentException;
 use Laravel\Octane\Exceptions\ServerShutdownException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -90,8 +91,16 @@ trait InteractsWithServers
             };
         }
 
+        if (empty($paths = config('octane.watch'))) {
+            throw new InvalidArgumentException(
+                'List of directories/files to watch not found. Please update your "config/octane.php" configuration file.',
+            );
+        }
+
         return tap(new Process([
-            (new ExecutableFinder)->find('node'), 'file-watcher.js', base_path(),
+            (new ExecutableFinder)->find('node'),
+            'file-watcher.js',
+            json_encode(collect(config('octane.watch'))->map(fn ($path) => base_path($path))),
         ], realpath(__DIR__.'/../../../bin'), null, null, null))->start();
     }
 


### PR DESCRIPTION
This pull request makes watch paths configurable. If we release this feature under the `0.1.x` series, people will need update their `config/octane` file to be able to use the watch feature.

**Note for @taylorotwell :** On the `config/octane.php` file, we need to adjust the configuration description.

Fixes https://github.com/laravel/octane/issues/118.