### PR TITLE
Added basic roadrunner configs for healthcheck and rr commands

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -66,6 +66,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
 
         $server = tap(new Process(array_filter([
             $roadRunnerBinary,
+            '-c', base_path('.rr.yaml'),
             '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
             '-o', 'server.command='.(new PhpExecutableFinder)->find().' ./vendor/bin/roadrunner-worker',
             '-o', 'http.pool.num_workers='.$this->workerCount(),

--- a/src/Commands/stubs/rr.yaml
+++ b/src/Commands/stubs/rr.yaml
@@ -1,9 +1,4 @@
-# RPC is required to run rr commands in the terminal
-# Ex: `rr workers` to view workers status
-# or `rr reset` to reset workers without restart Octane
 rpc:
   listen: tcp://127.0.0.1:6001
-# Healthcheck
 status:
-  # Ex: 127.0.0.1:2114/health?plugin=http
   address: 127.0.0.1:2114

--- a/src/Commands/stubs/rr.yaml
+++ b/src/Commands/stubs/rr.yaml
@@ -1,0 +1,9 @@
+# RPC is required to run rr commands in the terminal
+# Ex: `rr workers` to view workers status
+# or `rr reset` to reset workers without restart Octane
+rpc:
+  listen: tcp://127.0.0.1:6001
+# Healthcheck
+status:
+  # Ex: 127.0.0.1:2114/health?plugin=http
+  address: 127.0.0.1:2114


### PR DESCRIPTION
With the new basic Roadrunner config file .rr.yaml, it allows us to run [rr commands](https://roadrunner.dev/docs/beep-beep-cli) in the terminal and Octane Healthcheck endpoint. (This PR is for the issue #104)

Ex: To view the status of all active workers.
`rr workers`
![image](https://user-images.githubusercontent.com/1310539/114106634-0f04a600-9884-11eb-9178-d52268ecbd2f.png)

Ex: To reset without restart Octane 
`rr reset`
![image](https://user-images.githubusercontent.com/1310539/114106963-d0bbb680-9884-11eb-8681-ff3011f9e3d8.png)

Ex: Healthcheck - Includes a health check endpoint that returns the health of the workers.
http://localhost:2114/health?plugin=http
![image](https://user-images.githubusercontent.com/1310539/114106839-833f4980-9884-11eb-81c0-891293694ddb.png)

