### PR TITLE
[Swoole] Send StreamedResponse

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -156,11 +156,7 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     protected function sendResponseContent(Response $response, SwooleResponse $swooleResponse): void
     {
-        if ($response instanceof StreamedResponse && property_exists($response, 'output')) {
-            $swooleResponse->end($response->output);
-
-            return;
-        } elseif ($response instanceof BinaryFileResponse) {
+        if ($response instanceof BinaryFileResponse) {
             $swooleResponse->sendfile($response->getFile()->getPathname());
 
             return;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -166,7 +166,14 @@ class SwooleClient implements Client, ServesStaticFiles
             return;
         }
 
-        $content = $response->getContent();
+        if ($response instanceof StreamedResponse) {
+            ob_start();
+            $response->sendContent();
+            $content = ob_get_contents();
+            ob_end_clean();
+        } else {
+            $content = $response->getContent();
+        }
 
         $length = strlen($content);
 

--- a/tests/RoadRunnerClientTest.php
+++ b/tests/RoadRunnerClientTest.php
@@ -11,6 +11,7 @@ use Laravel\Octane\RoadRunner\RoadRunnerClient;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
 use Spiral\RoadRunner\Http\PSR7Worker;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class RoadRunnerClientTest extends TestCase
 {
@@ -43,6 +44,23 @@ class RoadRunnerClientTest extends TestCase
         $client->respond(new RequestContext([
             'psr7Request' => $psr7Request,
         ]), new Response('Hello World', 200));
+    }
+
+    /** @doesNotPerformAssertions @test */
+    public function test_respond_method_send_streamed_response_to_roadrunner()
+    {
+        $client = new RoadRunnerClient($psr7Client = Mockery::mock(PSR7Worker::class));
+
+        $psr7Request = (new ServerRequestFactory)->createServerRequest('GET', '/home');
+        $psr7Request = $psr7Request->withQueryParams(['name' => 'Taylor']);
+
+        $psr7Client->shouldReceive('respond')->once()->with(Mockery::type(ResponseInterface::class));
+
+        $client->respond(new RequestContext([
+            'psr7Request' => $psr7Request,
+        ]), new StreamedResponse(function () {
+            echo 'Hello World';
+        }, 200));
     }
 
     /** @doesNotPerformAssertions @test */

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -148,7 +148,7 @@ class SwooleClientTest extends TestCase
 
         $client->respond(new RequestContext([
             'swooleResponse' => $swooleResponse,
-        ]), new StreamedResponse(function(){
+        ]), new StreamedResponse(function () {
             echo 'Hello World';
         }, 200, ['Content-Type' => 'text/html']));
     }

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Swoole\SwooleClient;
 use Mockery;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SwooleClientTest extends TestCase
 {
@@ -130,6 +131,26 @@ class SwooleClientTest extends TestCase
         $client->respond(new RequestContext([
             'swooleResponse' => $swooleResponse,
         ]), new Response('Hello World', 200, ['Content-Type' => 'text/html']));
+    }
+
+    /** @doesNotPerformAssertions @test */
+    public function test_respond_method_send_streamed_response_to_swoole()
+    {
+        $client = new SwooleClient;
+
+        $swooleResponse = Mockery::mock('Swoole\Http\Response');
+
+        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('end')->once()->with('Hello World');
+
+        $client->respond(new RequestContext([
+            'swooleResponse' => $swooleResponse,
+        ]), new StreamedResponse(function(){
+            echo 'Hello World';
+        }, 200, ['Content-Type' => 'text/html']));
     }
 
     /** @doesNotPerformAssertions @test */


### PR DESCRIPTION
Capture the output from a StreamdResponse.  Fixes https://github.com/laravel/octane/issues/109

Note that this doesn't actually stream the contents anymore, but it does at least render the output (so after the callback is finished).