### PR TITLE
Collect output buffer so echo, var_dump(), and dump() work

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ You may gracefully restart the Octane server's application workers using the `oc
 php artisan octane:reload
 ```
 
-### Debugging
-
-Because Octane starts a long running process that continually serves requests to your application, it is not possible to use the `dump` helper. Instead, we recommend using [Telescope](https://github.com/laravel/telescope), [Ray](https://spatie.be/products/ray), [Debug Bar](https://github.com/barryvdh/laravel-debugbar), or [logging](https://laravel.com/docs/logging).
-
 ### Dependency Injection & Octane
 
 Since Octane boots your application once and keeps it in memory while serving requests, there are a few caveats you should consider while building your application. For example, the `register` and `boot` methods of your application's service providers will only be executed once when the request worker initially boots. On subsequent requests, the same application instance will be reused.

--- a/src/Contracts/Client.php
+++ b/src/Contracts/Client.php
@@ -4,6 +4,7 @@ namespace Laravel\Octane\Contracts;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -22,10 +23,10 @@ interface Client
      * Send the response to the server.
      *
      * @param  \Laravel\Octane\RequestContext  $context
-     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Laravel\Octane\OctaneResponse  $response
      * @return void
      */
-    public function respond(RequestContext $context, Response $response): void;
+    public function respond(RequestContext $context, OctaneResponse $response): void;
 
     /**
      * Send an error message to the server.

--- a/src/OctaneResponse.php
+++ b/src/OctaneResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Laravel\Octane;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OctaneResponse
+{
+    public function __construct(public Response $response, public ?string $outputBuffer = null)
+    {
+    }
+}

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -169,7 +169,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         if ($octaneResponse->response instanceof StreamedResponse) {
             ob_start(function ($data) use ($swooleResponse) {
-                logger('write ' . strlen($data));
+                logger('write '.strlen($data));
                 if (strlen($data) > 0) {
                     $swooleResponse->write($data);
                 }

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -169,12 +169,13 @@ class SwooleClient implements Client, ServesStaticFiles
 
         if ($octaneResponse->response instanceof StreamedResponse) {
             ob_start(function ($data) use ($swooleResponse) {
+                logger('write ' . strlen($data));
                 if (strlen($data) > 0) {
                     $swooleResponse->write($data);
                 }
 
                 return '';
-            }, 10);
+            }, 1);
 
             $octaneResponse->response->sendContent();
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -169,7 +169,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         if ($octaneResponse->response instanceof StreamedResponse) {
             ob_start(function ($data) use ($swooleResponse) {
-                if ($data) {
+                if (strlen($data) > 0) {
                     $swooleResponse->write($data);
                 }
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -167,7 +167,17 @@ class SwooleClient implements Client, ServesStaticFiles
             return;
         }
 
-        $content = $octaneResponse->response->getContent();
+        if ($octaneResponse->response instanceof StreamedResponse) {
+            ob_start();
+
+            $octaneResponse->response->sendContent();
+
+            $content = ob_get_contents();
+
+            ob_end_clean();
+        } else {
+            $content = $octaneResponse->response->getContent();
+        }
 
         if ($octaneResponse->outputBuffer) {
             $content = $octaneResponse->outputBuffer.$content;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -9,6 +9,7 @@ use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Contracts\ServesStaticFiles;
 use Laravel\Octane\MimeType;
 use Laravel\Octane\Octane;
+use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
 use Swoole\Http\Response as SwooleResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -98,13 +99,13 @@ class SwooleClient implements Client, ServesStaticFiles
      * Send the response to the server.
      *
      * @param  \Laravel\Octane\RequestContext  $context
-     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Laravel\Octane\OctaneResponse  $octaneResponse
      * @return void
      */
-    public function respond(RequestContext $context, Response $response): void
+    public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
     {
-        $this->sendResponseHeaders($response, $context->swooleResponse);
-        $this->sendResponseContent($response, $context->swooleResponse);
+        $this->sendResponseHeaders($octaneResponse->response, $context->swooleResponse);
+        $this->sendResponseContent($octaneResponse, $context->swooleResponse);
     }
 
     /**
@@ -150,23 +151,27 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param  \Symfony\Component\HtpFoundation\Response  $response
+     * @param  \Laravel\Octane\OctaneResponse  $response
      * @param  \Swoole\Http\Response  $response
      * @return void
      */
-    protected function sendResponseContent(Response $response, SwooleResponse $swooleResponse): void
+    protected function sendResponseContent(OctaneResponse $octaneResponse, SwooleResponse $swooleResponse): void
     {
-        if ($response instanceof StreamedResponse && property_exists($response, 'output')) {
-            $swooleResponse->end($response->output);
+        if ($octaneResponse->response instanceof StreamedResponse && property_exists($octaneResponse->response, 'output')) {
+            $swooleResponse->end($octaneResponse->response->output);
 
             return;
-        } elseif ($response instanceof BinaryFileResponse) {
-            $swooleResponse->sendfile($response->getFile()->getPathname());
+        } elseif ($octaneResponse->response instanceof BinaryFileResponse) {
+            $swooleResponse->sendfile($octaneResponse->response->getFile()->getPathname());
 
             return;
         }
 
-        $content = $response->getContent();
+        $content = $octaneResponse->response->getContent();
+
+        if ($octaneResponse->outputBuffer) {
+            $content = $octaneResponse->outputBuffer.$content;
+        }
 
         $length = strlen($content);
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -169,7 +169,6 @@ class SwooleClient implements Client, ServesStaticFiles
 
         if ($octaneResponse->response instanceof StreamedResponse) {
             ob_start(function ($data) use ($swooleResponse) {
-                logger('write '.strlen($data));
                 if (strlen($data) > 0) {
                     $swooleResponse->write($data);
                 }

--- a/src/Testing/Fakes/FakeClient.php
+++ b/src/Testing/Fakes/FakeClient.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Testing\Fakes;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Laravel\Octane\Contracts\Client;
+use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -24,9 +25,9 @@ class FakeClient implements Client
         return [$context->request, $context];
     }
 
-    public function respond(RequestContext $context, Response $response): void
+    public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
     {
-        $this->responses[] = $response;
+        $this->responses[] = $octaneResponse->response;
     }
 
     public function error(Throwable $e, Application $app, Request $request, RequestContext $context): void

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -99,7 +99,7 @@ class Worker implements WorkerContract
             // it can be returned to a browser. This gateway will also dispatch events.
             $this->client->respond(
                 $context,
-                $OctaneResponse = new OctaneResponse($response, $output),
+                $octaneResponse = new OctaneResponse($response, $output),
             );
 
             $responded = true;
@@ -113,7 +113,7 @@ class Worker implements WorkerContract
             // After the request handling process has completed we will unset some variables
             // plus reset the current application state back to its original state before
             // it was cloned. Then we will be ready for the next worker iteration loop.
-            unset($gateway, $sandbox, $request, $response, $OctaneResponse, $output);
+            unset($gateway, $sandbox, $request, $response, $octaneResponse, $output);
 
             CurrentApplication::set($this->app);
         }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -86,12 +86,20 @@ class Worker implements WorkerContract
         try {
             $responded = false;
 
+            ob_start();
+
+            $response = $gateway->handle($request);
+
+            $output = ob_get_contents();
+
+            ob_end_clean();
+
             // Here we will actually hand the incoming request to the Laravel application so
             // it can generate a response. We'll send this response back to the client so
             // it can be returned to a browser. This gateway will also dispatch events.
             $this->client->respond(
                 $context,
-                $response = $gateway->handle($request),
+                $OctaneResponse = new OctaneResponse($response, $output),
             );
 
             $responded = true;
@@ -105,7 +113,7 @@ class Worker implements WorkerContract
             // After the request handling process has completed we will unset some variables
             // plus reset the current application state back to its original state before
             // it was cloned. Then we will be ready for the next worker iteration loop.
-            unset($gateway, $sandbox, $request, $response);
+            unset($gateway, $sandbox, $request, $response, $OctaneResponse, $output);
 
             CurrentApplication::set($this->app);
         }

--- a/tests/RoadRunnerClientTest.php
+++ b/tests/RoadRunnerClientTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laminas\Diactoros\ServerRequestFactory;
+use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\RoadRunner\RoadRunnerClient;
 use Mockery;
@@ -42,7 +43,7 @@ class RoadRunnerClientTest extends TestCase
 
         $client->respond(new RequestContext([
             'psr7Request' => $psr7Request,
-        ]), new Response('Hello World', 200));
+        ]), new OctaneResponse(new Response('Hello World', 200)));
     }
 
     /** @doesNotPerformAssertions @test */

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Tests;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Swoole\SwooleClient;
 use Mockery;
@@ -129,7 +130,7 @@ class SwooleClientTest extends TestCase
 
         $client->respond(new RequestContext([
             'swooleResponse' => $swooleResponse,
-        ]), new Response('Hello World', 200, ['Content-Type' => 'text/html']));
+        ]), new OctaneResponse(new Response('Hello World', 200, ['Content-Type' => 'text/html'])));
     }
 
     /** @doesNotPerformAssertions @test */


### PR DESCRIPTION
This PR collects the output buffer and prepends it to the response.

It also handles StreamedResponses as reported in https://github.com/laravel/octane/issues/109. However, It'll collect the response and send it at the end of the request, it won't **stream** it.

<img width="1021" alt="Screen Shot 2021-04-09 at 12 52 02 PM" src="https://user-images.githubusercontent.com/4332182/114169859-66f9e600-9932-11eb-88f5-e39fc91ec571.png">
