### PR TITLE
Reformat multi-line constructors

### DIFF
--- a/src/Exceptions/TaskExceptionResult.php
+++ b/src/Exceptions/TaskExceptionResult.php
@@ -11,7 +11,6 @@ class TaskExceptionResult
         protected string $file,
         protected int $line,
     ) {
-        //
     }
 
     /**

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -6,10 +6,11 @@ use Laravel\Octane\Swoole\SwooleExtension;
 
 class EnsureRequestsDontExceedMaxExecutionTime
 {
-    public function __construct(protected SwooleExtension $extension,
-                                protected $timerTable,
-                                protected $maxExecutionTime)
-    {
+    public function __construct(
+        protected SwooleExtension $extension,
+        protected $timerTable,
+        protected $maxExecutionTime
+    ) {
     }
 
     /**

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -12,10 +12,11 @@ use Throwable;
 
 class OnWorkerStart
 {
-    public function __construct(protected $basePath,
-                                protected array $serverState,
-                                protected WorkerState $workerState)
-    {
+    public function __construct(
+        protected $basePath,
+        protected array $serverState,
+        protected WorkerState $workerState
+    ) {
     }
 
     /**

--- a/src/Swoole/InvokeTickCallable.php
+++ b/src/Swoole/InvokeTickCallable.php
@@ -8,13 +8,14 @@ use Throwable;
 
 class InvokeTickCallable
 {
-    public function __construct(protected string $key,
-                                protected $callback,
-                                protected int $seconds,
-                                protected bool $immediate,
-                                protected $cache,
-                                protected ExceptionHandler $exceptionHandler)
-    {
+    public function __construct(
+        protected string $key,
+        protected $callback,
+        protected int $seconds,
+        protected bool $immediate,
+        protected $cache,
+        protected ExceptionHandler $exceptionHandler
+    ) {
     }
 
     /**

--- a/src/Swoole/SwooleHttpTaskDispatcher.php
+++ b/src/Swoole/SwooleHttpTaskDispatcher.php
@@ -14,10 +14,11 @@ use Laravel\Octane\Exceptions\TaskTimeoutException;
 
 class SwooleHttpTaskDispatcher implements DispatchesTasks
 {
-    public function __construct(protected string $host,
-                                protected string $port,
-                                protected DispatchesTasks $fallbackDispatcher)
-    {
+    public function __construct(
+        protected string $host,
+        protected string $port,
+        protected DispatchesTasks $fallbackDispatcher
+    ) {
     }
 
     /**


### PR DESCRIPTION
Currently, two different multi-line constructor formats are used. This PR changes the format to a common one (which is used more frequently throughout the code base already).

Not very common:
https://github.com/laravel/octane/blob/c306e59ddcd2c6ffbd5ff5241ce58cdc9b5fa2b5/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php#L9-L13

Common:
https://github.com/laravel/octane/blob/c306e59ddcd2c6ffbd5ff5241ce58cdc9b5fa2b5/src/Swoole/ServerProcessInspector.php#L9-L13