### PR TITLE
Use swooleResponse->write() to write all output.

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -233,13 +233,11 @@ class SwooleClient implements Client, ServesStaticFiles
         $length = strlen($content);
 
         if ($length <= $this->chunkSize) {
-            $swooleResponse->end($content);
-
-            return;
-        }
-
-        for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
-            $swooleResponse->write(substr($content, $offset, $this->chunkSize));
+            $swooleResponse->write($content);
+        } else {
+            for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
+                $swooleResponse->write(substr($content, $offset, $this->chunkSize));
+            }
         }
 
         $swooleResponse->end();


### PR DESCRIPTION
It's not in the swoole docs but by testing, if we use `$swooleResponse->write($content);` once we cannot use `$swooleResponse->end($content);`. The content passed to `end()` will be ignored.

This PR does all writing with `write()`.