### PR TITLE
Reload must run, otherwise throw error

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -39,7 +39,7 @@ class ServerProcessInspector
     {
         $this->processFactory->createProcess([
             './rr', 'reset',
-        ], $basePath, null, null, null)->run();
+        ], $basePath, null, null, null)->mustRun();
     }
 
     /**


### PR DESCRIPTION
If the process exits, throw an error so it's more clear.
In my case it says this, but not sure if that's just me. At least for now show that it fails.

```
  INFO  Reloading workers...

   Symfony\Component\Process\Exception\ProcessFailedException 

  The command "'./rr' 'reset'" failed.

Exit Code: 1(General error)

Working directory: /home/barry/www/octane

Output:
================


Error Output:
================
rpc service disabled

```