### PR TITLE
Use start instead of run

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -38,7 +38,11 @@ class ServerProcessInspector
     {
         $this->processFactory->createProcess([
             './rr', 'reset',
-        ], base_path(), null, null, null)->mustRun();
+        ], base_path(), null, null, null)->start(function ($type, $buffer) {
+            if ($type === Process::ERR) {
+                throw new \RuntimeException('Cannot reload RoadRunner: '.$buffer);
+            }
+        });
     }
 
     /**

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -63,7 +63,7 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
             null
         )->andReturn($process = Mockery::mock('stdClass'));
 
-        $process->shouldReceive('mustRun')->once()->andReturn(0);
+        $process->shouldReceive('start')->once()->andReturn(0);
 
         $inspector->reloadServer();
     }


### PR DESCRIPTION
Sorry for the 2nd attempt after https://github.com/laravel/octane/pull/178, but `mustRun()` and the previous `run()` seem to not work in my server. Not sure why but it seems like this issue, where it exists to fast; https://github.com/symfony/symfony/issues/7237

In my case it just kept blocking. If I debugged the output, I only got a small part (`OUT > Res… `) and then just kept waiting.

This still throws an exception when something is passed on the error output.

(In my case `.rr.yaml` wasn't updated yet to start the rpc service, hence the failure)