### PR TITLE
Allow reuse the octane cache after stop the swoole server

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -3,6 +3,7 @@
 
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Swoole\Handlers\OnManagerStart;
+use Laravel\Octane\Swoole\Handlers\OnManagerStop;
 use Laravel\Octane\Swoole\Handlers\OnServerShutdown;
 use Laravel\Octane\Swoole\Handlers\OnServerStart;
 use Laravel\Octane\Swoole\Handlers\OnWorkerStart;
@@ -40,12 +41,12 @@ $timerTable = require __DIR__.'/createSwooleTimerTable.php';
 
 /*
 |--------------------------------------------------------------------------
-| Handle Server & Manager Start
+| Handle Server Start
 |--------------------------------------------------------------------------
 |
-| The following callbacks manage the master process and manager process
-| start events. These handlers primarily are responsible for writing
-| the process ID to the server state file so we can remember them.
+| The following callback manage the master process start event.
+| These handler primarily is responsible for writing the process ID
+| to the server state file so we can remember them.
 |
 */
 
@@ -57,10 +58,6 @@ $server->on('start', fn (Server $server) => $bootstrap($serverState) && (new OnS
     $timerTable,
     $serverState['octaneConfig']['tick'] ?? true
 ))($server));
-
-$server->on('managerstart', fn () => $bootstrap($serverState) && (new OnManagerStart(
-    new SwooleExtension, $serverState['appName']
-))());
 
 /*
 |--------------------------------------------------------------------------
@@ -90,6 +87,22 @@ $server->on('workerstart', fn (Server $server, $workerId) =>
         $basePath, $serverState, $workerState
     ))($server, $workerId))($bootstrap($serverState))
 );
+
+/*
+|--------------------------------------------------------------------------
+| Handle Manager Start
+|--------------------------------------------------------------------------
+|
+| The following callback manage the master process start event.
+| These handler primarily is responsible for writing the process ID
+| to the server state file so we can remember them. And restore the
+| octane cache.
+|
+*/
+
+$server->on('managerstart', fn () => $bootstrap($serverState) && (new OnManagerStart(
+    new SwooleExtension, $serverState, $bootstrap, $workerState
+))());
 
 /*
 |--------------------------------------------------------------------------
@@ -165,5 +178,7 @@ $server->on('workerstop', function () use ($workerState) {
 $server->on('shutdown', fn () => (new OnServerShutdown(
     new ServerStateFile($serverStateFile)
 ))());
+
+$server->on('managerstop', fn () => (new OnManagerStop($bootstrap($serverState), $workerState))());
 
 $server->start();

--- a/src/Swoole/Handlers/OnManagerStart.php
+++ b/src/Swoole/Handlers/OnManagerStart.php
@@ -43,7 +43,7 @@ class OnManagerStart
         $tmpApp = new ApplicationFactory($basePath);
         $tmpApp->createApplication();
 
-        $cache = (array) Cache::get("octane-cache");
+        $cache = (array) Cache::get('octane-cache');
 
         foreach ($cache as $key => $row) {
             $this->workerState->cacheTable[$key] = $row;

--- a/src/Swoole/Handlers/OnManagerStart.php
+++ b/src/Swoole/Handlers/OnManagerStart.php
@@ -2,13 +2,18 @@
 
 namespace Laravel\Octane\Swoole\Handlers;
 
+use Illuminate\Support\Facades\Cache;
+use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Swoole\SwooleExtension;
+use Laravel\Octane\Swoole\WorkerState;
 
 class OnManagerStart
 {
     public function __construct(
         protected SwooleExtension $extension,
-        protected string $appName,
+        protected array $serverState,
+        protected mixed $bootstrap,
+        protected WorkerState $workerState,
         protected bool $shouldSetProcessName = true
     ) {
     }
@@ -21,7 +26,29 @@ class OnManagerStart
     public function __invoke()
     {
         if ($this->shouldSetProcessName) {
-            $this->extension->setProcessName($this->appName, 'manager process');
+            $this->extension->setProcessName($this->serverState['appName'], 'manager process');
         }
+
+        $this->restoreOctaneCache(($this->bootstrap)($this->serverState));
+    }
+
+    /**
+     * Restore the octane cache that we stored on "managerstop" event.
+     *
+     * @param  string $basePath
+     * @return void
+     */
+    protected function restoreOctaneCache(string $basePath)
+    {
+        $tmpApp = new ApplicationFactory($basePath);
+        $tmpApp->createApplication();
+
+        $cache = (array) Cache::get("octane-cache");
+
+        foreach ($cache as $key => $row) {
+            $this->workerState->cacheTable[$key] = $row;
+        }
+
+        unset($tmpApp, $cache);
     }
 }

--- a/src/Swoole/Handlers/OnManagerStop.php
+++ b/src/Swoole/Handlers/OnManagerStop.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Octane\Swoole\Handlers;
+
+use Exception;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Octane\ApplicationFactory;
+use Laravel\Octane\Swoole\WorkerState;
+
+class OnManagerStop
+{
+    public function __construct(
+        protected string $basePath,
+        protected WorkerState $workerState
+    ) {
+    }
+
+    /**
+     * Handle the "managerstop" Swoole event.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        $tmpApp = new ApplicationFactory($this->basePath);
+        $tmpApp->createApplication();
+
+        $cache = [];
+
+        foreach ($this->workerState->cacheTable as $key => $row) {
+            $cache[$key] = $row;
+        }
+
+        Cache::put("octane-cache", $cache);
+
+        unset($tmpApp, $cache);
+    }
+}

--- a/src/Swoole/Handlers/OnManagerStop.php
+++ b/src/Swoole/Handlers/OnManagerStop.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Octane\Swoole\Handlers;
 
-use Exception;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Swoole\WorkerState;
@@ -31,7 +30,7 @@ class OnManagerStop
             $cache[$key] = $row;
         }
 
-        Cache::put("octane-cache", $cache);
+        Cache::put('octane-cache', $cache);
 
         unset($tmpApp, $cache);
     }


### PR DESCRIPTION
This PR allow reuse the octane cache after the swoole server stop.
---
The issue is when we stop the swoole server the cached data will be flushed.

To solve that i stored the cached data when we call the command `php artisan octane:stop` into the default cache driver.

And on `managerstart` event we restore this cached data and put it again in swoole cache table.

```php
Route::get('/', function () {

    var_dump(Cache::store('octane')->get('name'));

    Cache::store('octane')->put('name', 'mohamed samir');

    return view('welcome');
});

```
The first time `var_dump(Cache::store('octane')->get('name'));` will return `null` because we don't have any cached value. Other than that we can get the cached value, even if we stopped the server.

You can try this example
1. run `php artisan octane:start`
2. open `http://localhost:8000` you will see `null`. refresh the page you will see the cached value.
3. run `php artisan octane:stop` then `php artisan octane:start`
4. open `http://localhost:8000` you will see the cached value.