### PR TITLE
Set the process name when worker starts

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -87,7 +87,7 @@ $workerState->tables = require __DIR__.'/createSwooleTables.php';
 
 $server->on('workerstart', fn (Server $server, $workerId) =>
     (fn ($basePath) => (new OnWorkerStart(
-        new SwooleExtension(), $basePath, $serverState, $workerState
+        new SwooleExtension, $basePath, $serverState, $workerState
     ))($server, $workerId))($bootstrap($serverState))
 );
 

--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -87,7 +87,7 @@ $workerState->tables = require __DIR__.'/createSwooleTables.php';
 
 $server->on('workerstart', fn (Server $server, $workerId) =>
     (fn ($basePath) => (new OnWorkerStart(
-        $basePath, $serverState, $workerState
+        new SwooleExtension(), $basePath, $serverState, $workerState
     ))($server, $workerId))($bootstrap($serverState))
 );
 

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -40,6 +40,7 @@ class OnWorkerStart
 
         if ($this->shouldSetProcessName) {
             $isTaskWorker = $workerId >= $server->setting['worker_num'];
+
             $this->extension->setProcessName(
                 $this->serverState['appName'],
                 $isTaskWorker ? 'task worker process' : 'worker process',

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Swoole\Handlers;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Swoole\SwooleClient;
+use Laravel\Octane\Swoole\SwooleExtension;
 use Laravel\Octane\Swoole\WorkerState;
 use Laravel\Octane\Worker;
 use Swoole\Http\Server;
@@ -13,9 +14,11 @@ use Throwable;
 class OnWorkerStart
 {
     public function __construct(
+        protected SwooleExtension $extension,
         protected $basePath,
         protected array $serverState,
-        protected WorkerState $workerState
+        protected WorkerState $workerState,
+        protected bool $shouldSetProcessName = true
     ) {
     }
 
@@ -34,6 +37,14 @@ class OnWorkerStart
 
         $this->dispatchServerTickTaskEverySecond($server);
         $this->streamRequestsToConsole($server);
+
+        if ($this->shouldSetProcessName) {
+            $isTaskWorker = $workerId >= $server->setting['worker_num'];
+            $this->extension->setProcessName(
+                $this->serverState['appName'],
+                $isTaskWorker ? 'task worker process' : 'worker process',
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Set the process name when worker starts. In this way, we can clearly know how many worker processes there are and how many task worker processes there are.