### PR TITLE
Handle empty responses

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -230,7 +230,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         $content = $octaneResponse->response->getContent();
 
-        if($length = strlen($content) === 0){
+        if ($length = strlen($content) === 0) {
             $swooleResponse->end();
 
             return;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -230,7 +230,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
         $content = $octaneResponse->response->getContent();
 
-        if ($length = strlen($content) === 0) {
+        if (($length = strlen($content)) === 0) {
             $swooleResponse->end();
 
             return;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -230,7 +230,11 @@ class SwooleClient implements Client, ServesStaticFiles
 
         $content = $octaneResponse->response->getContent();
 
-        $length = strlen($content);
+        if($length = strlen($content) === 0){
+            $swooleResponse->end();
+
+            return;
+        }
 
         if ($length <= $this->chunkSize) {
             $swooleResponse->write($content);


### PR DESCRIPTION
Without this, the following exception is thrown.

<img width="853" alt="Screen Shot 2021-04-14 at 11 54 47 AM" src="https://user-images.githubusercontent.com/4332182/114691692-3c37d500-9d18-11eb-85c6-5327ea5c039a.png">
