### PR TITLE
Add querystring to request uri

### DIFF
--- a/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
+++ b/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
@@ -64,12 +64,10 @@ class ConvertSwooleRequestToIlluminateRequest
             $this->formatHttpHeadersIntoServerVariables($headers)
         );
 
-        if (
-            isset($results['REQUEST_URI'], $results['QUERY_STRING'])
-            && strlen($results['QUERY_STRING']) > 0
-            && strpos($results['REQUEST_URI'], '?') === false
-        ) {
-            $results['REQUEST_URI'] .= '?' . $results['QUERY_STRING'];
+        if (isset($results['REQUEST_URI'], $results['QUERY_STRING']) &&
+            strlen($results['QUERY_STRING']) > 0 &&
+            strpos($results['REQUEST_URI'], '?') === false) {
+            $results['REQUEST_URI'] .= '?'.$results['QUERY_STRING'];
         }
 
         return $phpSapi === 'cli-server'

--- a/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
+++ b/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
@@ -64,6 +64,14 @@ class ConvertSwooleRequestToIlluminateRequest
             $this->formatHttpHeadersIntoServerVariables($headers)
         );
 
+        if (
+            isset($results['REQUEST_URI'], $results['QUERY_STRING'])
+            && strlen($results['QUERY_STRING']) > 0
+            && strpos($results['REQUEST_URI'], '?') === false
+        ) {
+            $results['REQUEST_URI'] .= '?' . $results['QUERY_STRING'];
+        }
+
         return $phpSapi === 'cli-server'
                 ? $this->correctHeadersSetIncorrectlyByPhpDevServer($results)
                 : $results;

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -32,7 +32,8 @@ class SwooleClientTest extends TestCase
                 'PATH_INFO' => '/foo/bar',
                 'REMOTE_ADDR' => '127.0.0.1',
                 'REQUEST_METHOD' => 'POST',
-                'REQUEST_URI' => '/foo/bar?name=Taylor',
+                'REQUEST_URI' => '/foo/bar',
+                'QUERY_STRING' => 'name=Taylor',
             ];
 
             public function rawContent()
@@ -50,6 +51,7 @@ class SwooleClientTest extends TestCase
         $this->assertEquals('Hello World', $request->getContent());
         $this->assertEquals('127.0.0.1', $request->ip());
         $this->assertEquals('foo/bar', $request->path());
+        $this->assertEquals('/foo/bar?name=Taylor', $request->getRequestUri());
         $this->assertEquals('Taylor', $request->query('name'));
         $this->assertEquals('blue', $request->cookies->get('color'));
         $this->assertSame($givenContext, $context);


### PR DESCRIPTION
Fixes Request URI from Swoole, fixes https://github.com/laravel/octane/issues/188

See also https://github.com/swooletw/laravel-swoole/issues/311 for a related issue. It seems Swoole doesn't correctly set the REQUEST_URI, but I can't really understand the discussion in Chinese..