### PR TITLE
Adjust reload command

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -4,6 +4,7 @@ namespace Laravel\Octane\RoadRunner;
 
 use Laravel\Octane\PosixExtension;
 use Laravel\Octane\SymfonyProcessFactory;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 
 class ServerProcessInspector
@@ -36,12 +37,15 @@ class ServerProcessInspector
      */
     public function reloadServer(): void
     {
-        $this->processFactory->createProcess([
-            './rr', 'reset',
-        ], base_path(), null, null, null)->start(function ($type, $buffer) {
+        tap($this->processFactory->createProcess(
+            ['./rr', 'reset'],
+            base_path()
+        ))->start()->waitUntil(function ($type, $buffer) {
             if ($type === Process::ERR) {
-                throw new \RuntimeException('Cannot reload RoadRunner: '.$buffer);
+                throw new RuntimeException('Cannot reload RoadRunner: '.$buffer);
             }
+
+            return true;
         });
     }
 

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -58,12 +58,11 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
         $processFactory->shouldReceive('createProcess')->with(
             ['./rr', 'reset'],
             base_path(),
-            null,
-            null,
-            null
         )->andReturn($process = Mockery::mock('stdClass'));
 
         $process->shouldReceive('start')->once()->andReturn(0);
+
+        $process->shouldReceive('waitUntil')->once();
 
         $inspector->reloadServer();
     }


### PR DESCRIPTION
This pull request adjusts the RR ReloadCommand so it only considers the process "started" when some output is printed.