### PR TITLE
Report error when server fails to stop, waits server to stop.

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -44,18 +44,12 @@ if (! function_exists('dd')) {
 |
 */
 
-$loaded = false;
-
-if (is_string($basePath) && is_file($autoload_file = $basePath.'/vendor/autoload.php')) {
-    require $autoload_file;
-
-    $loaded = true;
-}
-
-if ($loaded !== true) {
+if (! is_file($autoload_file = $basePath.'/vendor/autoload.php')) {
     fwrite(STDERR, "Composer autoload file was not found. Did you install the project's dependencies?".PHP_EOL);
 
     exit(10);
 }
+
+require_once $autoload_file;
 
 return $basePath;

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -58,7 +58,11 @@ class StopCommand extends Command
 
         $this->info('Stopping server...');
 
-        $inspector->stopServer();
+        if (! $inspector->stopServer()) {
+            $this->error('Failed not stop swoole server.');
+
+            return 1;
+        }
 
         app(SwooleServerStateFile::class)->delete();
 

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -59,7 +59,7 @@ class StopCommand extends Command
         $this->info('Stopping server...');
 
         if (! $inspector->stopServer()) {
-            $this->error('Failed not stop swoole server.');
+            $this->error('Failed to stop Swoole server.');
 
             return 1;
         }

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Octane\Swoole;
 
-use Swoole\Process;
-
 class ServerProcessInspector
 {
     public function __construct(

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -36,9 +36,11 @@ class SignalDispatcher
             $start = time();
 
             do {
-                if ($this->canCommunicateWith($processId)) {
+                if (!$this->canCommunicateWith($processId)) {
                     return true;
                 }
+
+                $this->extension->dispatchProcessSignal($processId, SIGTERM);
 
                 sleep(1);
             } while (time() < $start + $wait);

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Octane\Swoole;
 
-use Swoole\Process;
-
 class SignalDispatcher
 {
     public function __construct(protected SwooleExtension $extension)
@@ -36,7 +34,7 @@ class SignalDispatcher
             $start = time();
 
             do {
-                if (!$this->canCommunicateWith($processId)) {
+                if (! $this->canCommunicateWith($processId)) {
                     return true;
                 }
 


### PR DESCRIPTION
* In the old terminate method, when `$this->canCommunicateWith($processId)` is true, it returns true directly, but this actually indicates that the process still exists.

* The current `octane:stop` command does not determine whether the process exits successfully, and the user does not know whether the process finally exits successfully.
