### PR TITLE
Fixes "octane:stop" not being called when TERM signal is sent from supervisor

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -10,13 +10,6 @@ use Symfony\Component\Process\Process;
 trait InteractsWithServers
 {
     /**
-     * The callable used to stop the server, if any.
-     *
-     * @var \Closure|null
-     */
-    protected $stopServerUsing;
-
-    /**
      * Run the given server process.
      *
      * @param  \Symfony\Component\Process\Process  $server
@@ -33,16 +26,6 @@ trait InteractsWithServers
         $this->writeServerRunningMessage();
 
         $watcher = $this->startServerWatcher();
-
-        $this->stopServerUsing = function () use ($type, $watcher) {
-            $watcher->stop();
-
-            $this->callSilent('octane:stop', [
-                '--server' => $type,
-            ]);
-
-            $this->stopServerUsing = null;
-        };
 
         try {
             while ($server->isRunning()) {
@@ -102,18 +85,6 @@ trait InteractsWithServers
             'file-watcher.js',
             json_encode(collect(config('octane.watch'))->map(fn ($path) => base_path($path))),
         ], realpath(__DIR__.'/../../../bin'), null, null, null))->start();
-    }
-
-    /**
-     * Stop the server.
-     *
-     * @return void
-     */
-    protected function stopServer()
-    {
-        if ($this->stopServerUsing) {
-            $this->stopServerUsing->__invoke();
-        }
     }
 
     /**

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -97,4 +97,18 @@ class StartCommand extends Command implements SignalableCommandInterface
 
         return 1;
     }
+
+    /**
+     * Stop the server.
+     *
+     * @return void
+     */
+    protected function stopServer()
+    {
+        $server = $this->option('server') ?: config('octane.server');
+
+        $this->callSilent('octane:stop', [
+            '--server' => $server,
+        ]);
+    }
 }

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -172,4 +172,16 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                 }
             });
     }
+
+    /**
+     * Stop the server.
+     *
+     * @return void
+     */
+    protected function stopServer()
+    {
+        $this->callSilent('octane:stop', [
+            '--server' => 'roadrunner',
+        ]);
+    }
 }

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -183,4 +183,16 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                 }
             });
     }
+
+    /**
+     * Stop the server.
+     *
+     * @return void
+     */
+    protected function stopServer()
+    {
+        $this->callSilent('octane:stop', [
+            '--server' => 'swoole',
+        ]);
+    }
 }


### PR DESCRIPTION
This pull request fixes the fact that "octane:stop" was not being called when signals were sent from the supervisor. 