### PR TITLE
Fix option param error

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -114,7 +114,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     {
         return $this->option('workers') == 'auto'
                             ? 0
-                            : $this->option('workers', 0);
+                            : $this->option('workers');
     }
 
     /**

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -128,7 +128,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     {
         return $this->option('workers') === 'auto'
                     ? $extension->cpuCount()
-                    : $this->option('workers', 1);
+                    : $this->option('workers');
     }
 
     /**
@@ -141,7 +141,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     {
         return $this->option('task-workers') === 'auto'
                     ? $extension->cpuCount()
-                    : $this->option('task-workers', 1);
+                    : $this->option('task-workers');
     }
 
     /**


### PR DESCRIPTION
Method call is provided 2 parameters, but the method signature uses 1 parameters 