### PR TITLE
Adds `octane:status` command

### DIFF
--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Laravel\Octane\Commands;
+
+use Laravel\Octane\RoadRunner\ServerProcessInspector as RoadRunnerServerProcessInspector;
+use Laravel\Octane\Swoole\ServerProcessInspector as SwooleServerProcessInspector;
+
+class StatusCommand extends Command
+{
+    /**
+     * The command's signature.
+     *
+     * @var string
+     */
+    public $signature = 'octane:status {--server= : The server that is running the application}';
+
+    /**
+     * The command's description.
+     *
+     * @var string
+     */
+    public $description = 'Get the current status of the Octane server';
+
+    /**
+     * Handle the command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $server = $this->option('server') ?: config('octane.server');
+
+        $isRunning = match ($server) {
+            'swoole' => $this->isSwooleServerRunning(),
+            'roadrunner' => $this->isRoadRunnerServerRunning(),
+            default => $this->invalidServer($server),
+        };
+
+        return ! tap($isRunning, function ($isRunning) {
+            $isRunning
+                ? $this->info('Octane server is running.')
+                : $this->info('Octane server is not running.');
+        });
+    }
+
+    /**
+     * Check if the Swoole server is running.
+     *
+     * @return bool
+     */
+    protected function isSwooleServerRunning()
+    {
+        return app(SwooleServerProcessInspector::class)
+            ->serverIsRunning();
+    }
+
+    /**
+     * Check if the RoadRunner server is running.
+     *
+     * @return bool
+     */
+    protected function isRoadRunnerServerRunning()
+    {
+        return app(RoadRunnerServerProcessInspector::class)
+            ->serverIsRunning();
+    }
+
+    /**
+     * Inform the user that the server type is invalid.
+     *
+     * @param  string  $server
+     * @return bool
+     */
+    protected function invalidServer(string $server)
+    {
+        $this->error("Invalid server: {$server}.");
+
+        return false;
+    }
+}

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -168,6 +168,7 @@ class OctaneServiceProvider extends ServiceProvider
                 Commands\StartRoadRunnerCommand::class,
                 Commands\StartSwooleCommand::class,
                 Commands\ReloadCommand::class,
+                Commands\StatusCommand::class,
                 Commands\StopCommand::class,
             ]);
         }


### PR DESCRIPTION
This pull request adds the command `octane:status` - just like `horizon:status`. The goal is allow the user to check the current status of an octane server without having to use the `stop` or `start` commands.

<img width="967" alt="Screenshot 2021-04-16 at 11 12 11" src="https://user-images.githubusercontent.com/5457236/115009816-98c7fb00-9ea4-11eb-8ac5-4dfaa6742e26.png">