### PR TITLE
Fixes starting multiple roadrunner servers

### DIFF
--- a/src/Commands/stubs/rr.yaml
+++ b/src/Commands/stubs/rr.yaml
@@ -1,4 +1,0 @@
-rpc:
-  listen: tcp://127.0.0.1:6001
-status:
-  address: 127.0.0.1:2114


### PR DESCRIPTION
This pull request reverts:  https://github.com/laravel/octane/pull/149.

If multiple roadrunner servers are running in the same server, the `octane:start` command will fail because of:

```
   ERROR  2021-04-16T12:11:38.712+0100	ERROR	container/poller.go:16	vertex got an error	{"vertex id": "status.Plugin", "error": "listen tcp4 127.0.0.1:2114: bind: address already in use"}
```
