### PR TITLE
Improves `octane:install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ After installing Octane, you may execute the `octane:install` Artisan command:
 php artisan octane:install
 ```
 
-Finally, specify your preferred application server (`roadrunner` or `swoole`) in your application's `config/octane.php` configuration file.
-
 ### Server Prerequisites
 
 > **Laravel Octane requires [PHP 8.0+](https://php.net/releases/)**

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -13,7 +13,7 @@ use Symfony\Component\Process\Process;
 trait InstallsRoadRunnerDependencies
 {
     /**
-     * Checks if RoadRunner is installed.
+     * Determine if RoadRunner is installed.
      *
      * @return bool
      */

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -13,13 +13,23 @@ use Symfony\Component\Process\Process;
 trait InstallsRoadRunnerDependencies
 {
     /**
+     * Checks if RoadRunner is installed.
+     *
+     * @return bool
+     */
+    protected function isRoadRunnerInstalled()
+    {
+        return class_exists(PSR7Worker::class);
+    }
+
+    /**
      * Ensure the RoadRunner package is installed into the project.
      *
      * @return bool
      */
     protected function ensureRoadRunnerPackageIsInstalled()
     {
-        if (class_exists(PSR7Worker::class)) {
+        if ($this->isRoadRunnerInstalled()) {
             return true;
         }
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,15 +4,19 @@ namespace Laravel\Octane\Commands;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Laravel\Octane\Swoole\SwooleExtension;
 
 class InstallCommand extends Command
 {
+    use Concerns\InstallsRoadRunnerDependencies;
+
     /**
      * The command's signature.
      *
      * @var string
      */
-    public $signature = 'octane:install';
+    public $signature = 'octane:install
+                    {--server= : The server that should be used to serve the application}';
 
     /**
      * The command's description.
@@ -28,9 +32,59 @@ class InstallCommand extends Command
      */
     public function handle()
     {
-        $this->callSilent('vendor:publish', ['--tag' => 'octane-config', '--force' => true]);
+        $server = $this->option('server') ?: $this->choice(
+            'Which application server you would like to use?',
+            ['roadrunner', 'swoole'],
+        );
 
-        // Update .gitignore...
+        return (int) ! tap(match ($server) {
+            'swoole' => $this->installSwooleServer(),
+            'roadrunner' => $this->installRoadRunnerServer(),
+            default => $this->invalidServer($server),
+        }, function ($installed) use ($server) {
+            if ($installed) {
+                $this->updateEnvironmentFile($server);
+
+                $this->callSilent('vendor:publish', ['--tag' => 'octane-config', '--force' => true]);
+
+                $this->info('Octane installed successfully.');
+            }
+        });
+    }
+
+    /**
+     * Updates the environment file with the given server.
+     *
+     * @param  string  $server
+     * @return void
+     */
+    public function updateEnvironmentFile($server)
+    {
+        if (File::exists($env = app()->environmentFile())) {
+            $contents = File::get($env);
+
+            if (! Str::contains($contents, 'OCTANE_SERVER=')) {
+                File::append(
+                    $env,
+                    PHP_EOL.'OCTANE_SERVER='.$server.PHP_EOL,
+                );
+            } else {
+                $this->warn('Please adjust the `OCTANE_SERVER` environment variable.');
+            }
+        }
+    }
+
+    /**
+     * Install the RoadRunner dependencies.
+     *
+     * @return bool
+     */
+    public function installRoadRunnerServer()
+    {
+        if (! $this->ensureRoadRunnerPackageIsInstalled()) {
+            return false;
+        }
+
         if (File::exists(base_path('.gitignore'))) {
             collect(['rr', '.rr.yaml'])
                 ->each(function ($file) {
@@ -44,6 +98,35 @@ class InstallCommand extends Command
                 });
         }
 
-        $this->info('Octane installed successfully.');
+        return $this->ensureRoadRunnerBinaryIsInstalled();
+    }
+
+    /**
+     * Install the RoadRunner dependencies.
+     *
+     * @return bool
+     */
+    public function installSwooleServer()
+    {
+        if (! resolve(SwooleExtension::class)->isInstalled()) {
+            $this->error('The Swoole extension is missing.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Inform the user that the server type is invalid.
+     *
+     * @param  string  $server
+     * @return bool
+     */
+    protected function invalidServer(string $server)
+    {
+        $this->error("Invalid server: {$server}.");
+
+        return false;
     }
 }

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -48,7 +48,9 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     public function handle(ServerProcessInspector $inspector, ServerStateFile $serverStateFile)
     {
-        if (! $this->ensureRoadRunnerPackageIsInstalled()) {
+        if (! $this->isRoadRunnerInstalled()) {
+            $this->error('RoadRunner not installed. Please execute the `octane:install` Artisan command.');
+
             return 1;
         }
 

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -54,6 +54,12 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         ServerStateFile $serverStateFile,
         SwooleExtension $extension
     ) {
+        if (! $extension->isInstalled()) {
+            $this->error('The Swoole extension is missing.');
+
+            return 1;
+        }
+
         if ($inspector->serverIsRunning()) {
             $this->error('Server is already running.');
 

--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -23,6 +23,16 @@ class SwooleExtension
     }
 
     /**
+     * Checks if the Swoole extension is installed.
+     *
+     * @return int
+     */
+    public function isInstalled(): bool
+    {
+        return function_exists('swoole_cpu_num');
+    }
+
+    /**
      * Set the current process name.
      *
      * @param  string  $appName

--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -7,6 +7,16 @@ use Swoole\Process;
 class SwooleExtension
 {
     /**
+     * Determine if the Swoole extension is installed.
+     *
+     * @return int
+     */
+    public function isInstalled(): bool
+    {
+        return function_exists('swoole_cpu_num');
+    }
+
+    /**
      * Send a signal to the given process.
      *
      * @param  int  $processId
@@ -20,16 +30,6 @@ class SwooleExtension
         }
 
         return false;
-    }
-
-    /**
-     * Checks if the Swoole extension is installed.
-     *
-     * @return int
-     */
-    public function isInstalled(): bool
-    {
-        return function_exists('swoole_cpu_num');
     }
 
     /**


### PR DESCRIPTION
This pull request improves the install command by:

1. Asking the user `Which application server you would like to use?`.
<img width="577" alt="Screenshot 2021-04-16 at 13 51 49" src="https://user-images.githubusercontent.com/5457236/115026861-e51e3580-9eba-11eb-974f-d291625c736e.png">

2. Installing the needed dependencies for the chosen server.
<img width="565" alt="Screenshot 2021-04-16 at 13 52 14" src="https://user-images.githubusercontent.com/5457236/115026924-f5361500-9eba-11eb-80ec-05afe1afe5f9.png">

3. Adding the needed environment variables, such as `OCTANE_SERVER`.
<img width="308" alt="Screenshot 2021-04-16 at 13 52 59" src="https://user-images.githubusercontent.com/5457236/115027000-0ed75c80-9ebb-11eb-80b8-a9b787d71def.png">

4. And, by not allowing to run a server if the server dependencies are not installed correctly:
<img width="542" alt="Screenshot 2021-04-16 at 13 53 39" src="https://user-images.githubusercontent.com/5457236/115027070-2878a400-9ebb-11eb-8b79-7d08863dd562.png">
