### PR TITLE
Adds docs about the `octane:status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ You may gracefully restart the Octane server's application workers using the `oc
 php artisan octane:reload
 ```
 
+#### Checking The Server Status
+
+You may check the current status of the Octane server using the `octane:status` Artisan command:
+
+```bash
+php artisan octane:status
+```
+
 ### Dependency Injection & Octane
 
 Since Octane boots your application once and keeps it in memory while serving requests, there are a few caveats you should consider while building your application. For example, the `register` and `boot` methods of your application's service providers will only be executed once when the request worker initially boots. On subsequent requests, the same application instance will be reused.


### PR DESCRIPTION
This pull request adds docs about the `octane:status` command.