### PR TITLE
Fixes RoadRunner `octane:reload` by setting a different RPC port per server

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,6 +17,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port=8000 : The port the server should be available on}
+                    {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -79,6 +80,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->option('host'),
             '--port' => $this->option('port'),
+            '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -21,6 +21,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     public $signature = 'octane:roadrunner
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port=8000 : The port the server should be available on}
+                    {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--watch : Automatically reload the server when the application is modified}';
@@ -73,6 +74,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'server.command='.(new PhpExecutableFinder)->find().' ./vendor/bin/roadrunner-worker',
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
+            '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir=public',
             '-o', 'http.middleware=static',
@@ -101,6 +103,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             'appName' => config('app.name', 'Laravel'),
             'host' => $this->option('host'),
             'port' => $this->option('port'),
+            'rpcPort' => $this->rpcPort(),
             'workers' => $this->workerCount(),
             'maxRequests' => $this->option('max-requests'),
             'octaneConfig' => config('octane'),
@@ -127,6 +130,16 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function maxExecutionTime()
     {
         return config('octane.max_execution_time', '30').'s';
+    }
+
+    /**
+     * Get the RPC port the server should be available on.
+     *
+     * @return int
+     */
+    protected function rpcPort()
+    {
+        return $this->option('rpc-port') ?: $this->option('port') - 1999;
     }
 
     /**

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -37,10 +37,18 @@ class ServerProcessInspector
      */
     public function reloadServer(): void
     {
-        tap($this->processFactory->createProcess(
-            ['./rr', 'reset'],
-            base_path()
-        ))->start()->waitUntil(function ($type, $buffer) {
+        [
+            'state' => [
+                'host' => $host,
+                'rpcPort' => $rpcPort,
+            ],
+        ] = $this->serverStateFile->read();
+
+        tap($this->processFactory->createProcess([
+            './rr',
+            'reset',
+            '-o', "rpc.listen=tcp://$host:$rpcPort",
+        ], base_path()))->start()->waitUntil(function ($type, $buffer) {
             if ($type === Process::ERR) {
                 throw new RuntimeException('Cannot reload RoadRunner: '.$buffer);
             }

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -55,8 +55,13 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
             new PosixExtension
         );
 
+        $processIdFile->writeState([
+            'host' => '127.0.0.1',
+            'rpcPort' => '6002',
+        ]);
+
         $processFactory->shouldReceive('createProcess')->with(
-            ['./rr', 'reset'],
+            ['./rr', 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002'],
             base_path(),
         )->andReturn($process = Mockery::mock('stdClass'));
 


### PR DESCRIPTION
This pull request makes RoadRunner start command to set a different RPC port foreach RoadRunner server. Note that, just like `host` or `port` artisan options, the `rpc-port` can not be set using the `.rr.yaml` file.