### PR TITLE
Ensure RoadRunner binary is up-to-date

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -145,11 +145,11 @@ trait InstallsRoadRunnerDependencies
                 try {
                     $this->downloadRoadRunnerBinary();
                 } catch (Throwable $e) {
+                    report($e);
+
                     rename("$roadRunnerBinary.backup", $roadRunnerBinary);
 
-                    return $this->warn(
-                        'Unable to download RoadRunner binary. Reason: '.$e->getMessage(),
-                    );
+                    return $this->warn('Unable to download RoadRunner binary. The error has been reported to the exception logger.');
                 }
 
                 unlink("$roadRunnerBinary.backup");

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -63,6 +63,8 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             return 1;
         }
 
+        $this->ensureRoadRunnerBinaryMeetsRequirements($roadRunnerBinary);
+
         $this->writeServerStateFile($serverStateFile);
 
         touch(base_path('.rr.yaml'));


### PR DESCRIPTION
This pull request ensures the RR binary people download always meet Octane's requirements.

So when people run `octane:start`, and a binary already exists, we are going to check if the binary contains a version equal or superior to `$requiredVersion = '2.0.4';`. If the version is below these requirements, we are going to download the most recent version:
<img width="1022" alt="Screenshot 2021-04-20 at 17 20 37" src="https://user-images.githubusercontent.com/5457236/115433275-487fce80-a1ff-11eb-811e-09013de892dc.png">

Note that, by default the answer is `yes`. So Deamons/Supervisors will eventually update the `rr` binary if needed when they run `octane:start`.

<img width="1572" alt="Screenshot 2021-04-20 at 17 48 06" src="https://user-images.githubusercontent.com/5457236/115434421-93e6ac80-a200-11eb-8a13-cf3fee83a713.png">

If something fails in the process ( no internet, wtv ) we keep using the outdated version:
<img width="1363" alt="Screenshot 2021-04-20 at 17 46 50" src="https://user-images.githubusercontent.com/5457236/115434288-70236680-a200-11eb-9f33-b49d7483542c.png">

@taylorotwell Note that we don't always update the binary ( only when is really needed ). I've done this so if RoadRunner releases a version with a "bug", only new users using octane will be impacted.