### PR TITLE
Use constants instead of hard coding

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -119,7 +119,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'enable_coroutine' => false,
             'daemonize' => false,
             'log_file' => storage_path('logs/swoole_http.log'),
-            'log_level' => app()->environment('local') ? 1 : 5,
+            'log_level' => app()->environment('local') ? SWOOLE_LOG_INFO : SWOOLE_LOG_ERROR,
             'max_request' => $this->option('max-requests'),
             'package_max_length' => 20 * 1024 * 1024,
             'reactor_num' => $this->workerCount($extension),


### PR DESCRIPTION
`SWOOLE_LOG_TRACE` => 1
`SWOOLE_LOG_INFO` => 2
`SWOOLE_LOG_ERROR` => 5


When using `1` you need to add the `-enable-trace-log` option to compile Swoole, Default is `2`.

