### PR TITLE
Remove µs string before multiply, fix return type

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -196,7 +196,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      * Calculate the elapsed time for a request.
      *
      * @param  string  $elapsed
-     * @return int
+     * @return float
      */
     protected function calculateElapsedTime(string $elapsed): float
     {
@@ -205,10 +205,10 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         }
 
         if (Str::endsWith($elapsed, 'µs')) {
-            return $elapsed * 0.001;
+            return mb_substr($elapsed, 0, -2) * 0.001;
         }
 
-        return $elapsed * 1000;
+        return (float)$elapsed * 1000;
     }
 
     /**


### PR DESCRIPTION
Hi,

we are getting errors in `calculateElapsedTime` method since it is not removing string before multiply. 

```
ErrorException 

  A non-numeric value encountered

  at vendor/laravel/octane/src/Commands/StartRoadRunnerCommand.php:209
    205▕         if (Str::endsWith($elapsed, 'µs')) {
    206▕             return $elapsed * 0.001;
    207▕         }
    208▕ 
  ➜ 209▕         return $elapsed * 1000;
    210▕     }
    211▕ 
    212▕     /**
    213▕      * Stop the server.
```

This PR also fixes return type and force input string value to be float.