### PR TITLE
Use extension_loaded instead of function_exists

### DIFF
--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -9,11 +9,11 @@ class SwooleExtension
     /**
      * Determine if the Swoole extension is installed.
      *
-     * @return int
+     * @return bool
      */
     public function isInstalled(): bool
     {
-        return function_exists('swoole_cpu_num');
+        return extension_loaded('swoole');
     }
 
     /**


### PR DESCRIPTION
If the Swoole extension is not loaded, but there is code in other composer packages such as:

```php
var_dump(extension_loaded('swoole'));

if (!function_exists('swoole_cpu_num')) {
    function swoole_cpu_num()
    {
        return 1;
    }
}

var_dump(function_exists('swoole_cpu_num'));
//bool(false)
//bool(true)
```

This creates an error.