### PR TITLE
Use signal method instead of dispatchProcessSignal method

### DIFF
--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -28,17 +28,15 @@ class SignalDispatcher
      */
     public function terminate(int $processId, int $wait = 0): bool
     {
-        $this->extension->dispatchProcessSignal($processId, SIGTERM);
+        $this->signal($processId, SIGTERM);
 
         if ($wait) {
             $start = time();
 
             do {
-                if (! $this->canCommunicateWith($processId)) {
+                if (! $this->signal($processId, SIGTERM)) {
                     return true;
                 }
-
-                $this->extension->dispatchProcessSignal($processId, SIGTERM);
 
                 sleep(1);
             } while (time() < $start + $wait);


### PR DESCRIPTION
It is not necessary to call `canCommunicateWith`, Judgment exists in the `dispatchProcessSignal` method, so that the modified behavior is consistent.

https://github.com/laravel/octane/blob/e4a02d62b649f4eec24d677bd6101e8f820b49af/src/Swoole/SwooleExtension.php#L26-L33