### PR TITLE
Fixes global environment variables not being taken in by workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/laravel/octane/compare/v0.4.0...master)
 
+> **Requires to stop, and re-start your Octane server**
+
+### Fixed
+- Global environment variables not being taken in by workers ([#257](https://github.com/laravel/octane/pull/257))
 
 ## [v0.4.0 (2021-04-27)](https://github.com/laravel/octane/compare/v0.3.2...v0.4.0)
 

--- a/src/Commands/Concerns/InteractsWithEnvironmentVariables.php
+++ b/src/Commands/Concerns/InteractsWithEnvironmentVariables.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Octane\Commands\Concerns;
+
+use Dotenv\Exception\InvalidPathException;
+use Dotenv\Parser\Parser;
+use Dotenv\Store\StoreBuilder;
+use Illuminate\Support\Env;
+
+trait InteractsWithEnvironmentVariables
+{
+    /**
+     * Forgets the current process environment variables.
+     *
+     * @return void
+     */
+    public function forgetEnvironmentVariables()
+    {
+        $variables = collect();
+
+        try {
+            $content = StoreBuilder::createWithNoNames()
+                ->addPath(app()->environmentPath())
+                ->addName(app()->environmentFile())
+                ->make()
+                ->read();
+
+            foreach ((new Parser())->parse($content) as $entry) {
+                $variables->push($entry->getName());
+            }
+        } catch (InvalidPathException $e) {
+            // ..
+        }
+
+        $variables->each(fn ($name) => Env::getRepository()->clear($name));
+    }
+}


### PR DESCRIPTION
This pull request fixes global environment variables not being taken in by workers. In addition, it fixes the fact that the `environment` value was not being taken by workers too.

Fixes #244.