### PR TITLE
Removes non needed "dotenv" option in roadrunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Fixed
 - Global environment variables not being taken in by workers ([#257](https://github.com/laravel/octane/pull/257))
 
+### Changed
+- The new minimum RoadRunner binary version is now 2.1.1 ([#258](https://github.com/laravel/octane/pull/258))
+
+
 ## [v0.4.0 (2021-04-27)](https://github.com/laravel/octane/compare/v0.3.2...v0.4.0)
 
 Various fixes and changes.

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -18,7 +18,7 @@ trait InstallsRoadRunnerDependencies
      *
      * @var string
      */
-    protected $requiredVersion = '2.0.4';
+    protected $requiredVersion = '2.1.1';
 
     /**
      * Determine if RoadRunner is installed.

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -88,7 +88,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warning',
             '-o', 'logs.output=stdout',
             '-o', 'logs.encoding=json',
-            '--dotenv=""', 'serve',
+            'serve',
         ]), base_path(), [
             'APP_ENV' => app()->environment(),
             'APP_BASE_PATH' => base_path(),


### PR DESCRIPTION
This pull request removes a non needed "dotenv" option in RoadRunner.