### PR TITLE
Fixed rpc-port default port in RoadRunner start command

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -149,7 +149,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     protected function rpcPort()
     {
-        return $this->option('rpc-port') ?: $this->option('port') - 1999;
+        return $this->option('rpc-port') ?: 6001;
     }
 
     /**


### PR DESCRIPTION
The default port strictly depends on running the application on port 8000, which is incorrect.