### PR TITLE
Remove buffer_output_size from Swoole's default options

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -115,7 +115,6 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     protected function defaultServerOptions(SwooleExtension $extension)
     {
         return [
-            'buffer_output_size' => 10 * 1024 * 1024,
             'enable_coroutine' => false,
             'daemonize' => false,
             'log_file' => storage_path('logs/swoole_http.log'),


### PR DESCRIPTION
Fix #260

Swoole v4.6.7 is released, The limitation of `output_buffer_size` is removed and default value `output_buffer_size` is changed from 2MB to UINT_MAX.