### PR TITLE
Reload RoadRunner using the global executable if it's present

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -3,9 +3,9 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use Illuminate\Support\Str;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 use RuntimeException;
 use Spiral\RoadRunner\Http\PSR7Worker;
-use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Commands\Concerns;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Spiral\RoadRunner\Http\PSR7Worker;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -13,6 +14,8 @@ use Throwable;
 
 trait InstallsRoadRunnerDependencies
 {
+    use FindsRoadRunnerBinary;
+
     /**
      * The minimum required version of the RoadRunner binary.
      *
@@ -97,14 +100,8 @@ trait InstallsRoadRunnerDependencies
      */
     protected function ensureRoadRunnerBinaryIsInstalled(): string
     {
-        if (file_exists(base_path('rr'))) {
-            return base_path('rr');
-        }
-
-        if (! is_null($roadRunnerBinary = (new ExecutableFinder)->find('rr', null, [base_path()]))) {
-            if (! Str::contains($roadRunnerBinary, 'vendor/bin/rr')) {
-                return $roadRunnerBinary;
-            }
+        if (! is_null($roadRunnerBinary = $this->findRoadRunnerBinary())) {
+            return $roadRunnerBinary;
         }
 
         if ($this->confirm('Unable to locate RoadRunner binary. Should Octane download the binary for your operating system?', true)) {

--- a/src/RoadRunner/Concerns/FindsRoadRunnerBinary.php
+++ b/src/RoadRunner/Concerns/FindsRoadRunnerBinary.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Octane\RoadRunner\Concerns;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Process\ExecutableFinder;
+
+trait FindsRoadRunnerBinary
+{
+    protected function findRoadRunnerBinary(): ?string
+    {
+        if (file_exists(base_path('rr'))) {
+            return base_path('rr');
+        }
+
+        if (! is_null($roadRunnerBinary = (new ExecutableFinder)->find('rr', null, [base_path()]))) {
+            if (! Str::contains($roadRunnerBinary, 'vendor/bin/rr')) {
+                return $roadRunnerBinary;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -3,10 +3,10 @@
 namespace Laravel\Octane\RoadRunner;
 
 use Laravel\Octane\PosixExtension;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 use Laravel\Octane\SymfonyProcessFactory;
 use RuntimeException;
 use Symfony\Component\Process\Process;
-use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 
 class ServerProcessInspector
 {

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -6,9 +6,12 @@ use Laravel\Octane\PosixExtension;
 use Laravel\Octane\SymfonyProcessFactory;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 
 class ServerProcessInspector
 {
+    use FindsRoadRunnerBinary;
+
     public function __construct(
         protected ServerStateFile $serverStateFile,
         protected SymfonyProcessFactory $processFactory,
@@ -45,7 +48,7 @@ class ServerProcessInspector
         ] = $this->serverStateFile->read();
 
         tap($this->processFactory->createProcess([
-            './rr',
+            $this->findRoadRunnerBinary(),
             'reset',
             '-o', "rpc.listen=tcp://$host:$rpcPort",
         ], base_path()))->start()->waitUntil(function ($type, $buffer) {

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -3,11 +3,11 @@
 namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\PosixExtension;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 use Laravel\Octane\RoadRunner\ServerProcessInspector;
 use Laravel\Octane\RoadRunner\ServerStateFile;
 use Laravel\Octane\SymfonyProcessFactory;
 use Mockery;
-use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 
 class RoadRunnerServerProcessInspectorTest extends TestCase
 {

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -7,9 +7,12 @@ use Laravel\Octane\RoadRunner\ServerProcessInspector;
 use Laravel\Octane\RoadRunner\ServerStateFile;
 use Laravel\Octane\SymfonyProcessFactory;
 use Mockery;
+use Laravel\Octane\RoadRunner\Concerns\FindsRoadRunnerBinary;
 
 class RoadRunnerServerProcessInspectorTest extends TestCase
 {
+    use FindsRoadRunnerBinary;
+
     public function test_can_determine_if_roadrunner_server_process_is_running_when_master_is_running()
     {
         $inspector = new ServerProcessInspector(
@@ -59,7 +62,7 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
         ]);
 
         $processFactory->shouldReceive('createProcess')->with(
-            ['./rr', 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002'],
+            [$this->findRoadRunnerBinary(), 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002'],
             base_path(),
         )->andReturn($process = Mockery::mock('stdClass'));
 


### PR DESCRIPTION
This PR fixes issue #287 by introducing a new trait to find the RoadRunner binary if present, otherwise return null.