### PR TITLE
[1.x] Fix TokenMismatchException returns HTTP status code 200 instead of 419

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -176,7 +176,7 @@ class SwooleClient implements Client, ServesStaticFiles
             }
         }
 
-        $swooleResponse->status($response->getStatusCode());
+        $swooleResponse->status($response->getStatusCode(), Response::$statusTexts[$response->getStatusCode()] ?? 'unknown status');
 
         foreach ($response->headers->getCookies() as $cookie) {
             $swooleResponse->{$cookie->isRaw() ? 'rawcookie' : 'cookie'}(

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -148,7 +148,7 @@ class SwooleClientTest extends TestCase
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
-        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('status')->once()->with(200, 'OK');
         $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
         $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
@@ -167,7 +167,7 @@ class SwooleClientTest extends TestCase
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
-        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('status')->once()->with(200, 'OK');
         $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
         $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));


### PR DESCRIPTION
The status method if the second parameter is set, code can be any value, including the undefined HttpCode, such as 419.

fix #291