### PR TITLE
Fixes issue related to changing non-standard HTTP status codes to 200 OK

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,6 +19,10 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
+    const STATUS_CODE_REASONS = [
+        419 => 'Page Expired',
+    ];
+
     public function __construct(protected int $chunkSize = 1048576)
     {
     }
@@ -176,7 +180,11 @@ class SwooleClient implements Client, ServesStaticFiles
             }
         }
 
-        $swooleResponse->status($response->getStatusCode());
+        if (! is_null($reason = $this->getReasonFromStatusCode($response->getStatusCode()))) {
+            $swooleResponse->status($response->getStatusCode(), $reason);
+        } else {
+            $swooleResponse->status($response->getStatusCode());
+        }
 
         foreach ($response->headers->getCookies() as $cookie) {
             $swooleResponse->{$cookie->isRaw() ? 'rawcookie' : 'cookie'}(
@@ -264,5 +272,20 @@ class SwooleClient implements Client, ServesStaticFiles
         $context->swooleResponse->end(
             Octane::formatExceptionForClient($e, $app->make('config')->get('app.debug'))
         );
+    }
+
+    /**
+     * Get the HTTP reason clause for non-standard status codes.
+     *
+     * @param int $code
+     * @return string|null
+     */
+    protected function getReasonFromStatusCode(int $code): ?string
+    {
+        if (array_key_exists($code, self::STATUS_CODE_REASONS)) {
+            return self::STATUS_CODE_REASONS[$code];
+        }
+
+        return null;
     }
 }

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -277,7 +277,7 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Get the HTTP reason clause for non-standard status codes.
      *
-     * @param int $code
+     * @param  int  $code
      * @return string|null
      */
     protected function getReasonFromStatusCode(int $code): ?string

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -182,6 +182,25 @@ class SwooleClientTest extends TestCase
     }
 
     /** @doesNotPerformAssertions @test */
+    public function test_respond_method_with_laravel_specific_status_code_sends_response_to_swoole()
+    {
+        $client = new SwooleClient;
+
+        $swooleResponse = Mockery::mock('Swoole\Http\Response');
+
+        $swooleResponse->shouldReceive('status')->once()->with(419, 'Page Expired');
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('write')->with('Hello World');
+        $swooleResponse->shouldReceive('end')->once();
+
+        $client->respond(new RequestContext([
+            'swooleResponse' => $swooleResponse,
+        ]), new OctaneResponse(new Response('Hello World', 419, ['Content-Type' => 'text/html'])));
+    }
+
+    /** @doesNotPerformAssertions @test */
     public function test_error_method_sends_error_response_to_swoole()
     {
         $client = new SwooleClient;


### PR DESCRIPTION
This PR fixes #291 by passing an extra parameter `$reason` for non-standard HTTP codes.