### PR TITLE
[1.x] Inject dependencies in Octane routes

### DIFF
--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -3,7 +3,9 @@
 namespace Laravel\Octane\Concerns;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ProvidesRouting
@@ -25,7 +27,9 @@ trait ProvidesRouting
      */
     public function route(string $method, string $uri, Closure $callback): void
     {
-        $this->routes[$method.$uri] = $callback;
+        $route = $method . Str::start($uri, '/');
+
+        $this->routes[$route] = $callback;
     }
 
     /**
@@ -37,7 +41,9 @@ trait ProvidesRouting
      */
     public function hasRouteFor(string $method, string $uri): bool
     {
-        return isset($this->routes[$method.$uri]);
+        $route = $method . Str::start($uri, '/');
+
+        return isset($this->routes[$route]);
     }
 
     /**
@@ -50,6 +56,8 @@ trait ProvidesRouting
      */
     public function invokeRoute(Request $request, string $method, string $uri): Response
     {
-        return call_user_func($this->routes[$method.$uri], $request);
+        $route = $method . Str::start($uri, '/');
+
+        return Container::getInstance()->call($this->routes[$route]);
     }
 }

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -27,7 +27,7 @@ trait ProvidesRouting
      */
     public function route(string $method, string $uri, Closure $callback): void
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         $this->routes[$route] = $callback;
     }
@@ -41,7 +41,7 @@ trait ProvidesRouting
      */
     public function hasRouteFor(string $method, string $uri): bool
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         return isset($this->routes[$route]);
     }
@@ -56,7 +56,7 @@ trait ProvidesRouting
      */
     public function invokeRoute(Request $request, string $method, string $uri): Response
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         return Container::getInstance()->call($this->routes[$route]);
     }

--- a/tests/OctaneRouteTest.php
+++ b/tests/OctaneRouteTest.php
@@ -40,4 +40,6 @@ class OctaneRouteTest extends TestCase
     }
 }
 
-class OctaneRouteTestDependency {}
+class OctaneRouteTestDependency
+{
+}

--- a/tests/OctaneRouteTest.php
+++ b/tests/OctaneRouteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OctaneRouteTest extends TestCase
+{
+    public function test_dependency_injection_in_octane_routes()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/autowire', 'GET'),
+        ]);
+
+        $stub = new OctaneRouteTestDependency();
+
+        $app->bind(OctaneRouteTestDependency::class, fn () => $stub);
+
+        $app['octane']->route('GET', '/autowire', function (OctaneRouteTestDependency $foo) {
+            return new Response(spl_object_hash($foo));
+        });
+
+        $worker->run();
+
+        $this->assertSame(spl_object_hash($stub), $client->responses[0]->getContent());
+    }
+
+    public function test_octane_routes_without_leading_slash()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('no_leading_slash', 'GET'),
+        ]);
+
+        $app['octane']->route('GET', 'no_leading_slash', fn () => new Response('no leading slash'));
+
+        $worker->run();
+
+        $this->assertSame('no leading slash', $client->responses[0]->getContent());
+    }
+}
+
+class OctaneRouteTestDependency {}


### PR DESCRIPTION
This PR allows Octane routes to have their dependencies injected:

```php
use Some\Bound\Service;
use Symfony\Component\HttpFoundation\Response;

Octane::route('GET', '/uri', fn (Service $service) => new Response($service->run()));
```

It also allows to define Octane routes without the leading `/`.

Usually I don't define routes with the leading slash so the first time I used Octane it took me some minutes to realize that Octane routes don't work if they don't begin with a slash. Of course this second feature is optional and can be discarded if you reckon it's an extra.