### PR TITLE
[2.x] Let Octane routes call actions

### DIFF
--- a/src/ApplicationGateway.php
+++ b/src/ApplicationGateway.php
@@ -30,7 +30,7 @@ class ApplicationGateway
         $this->dispatchEvent($this->sandbox, new RequestReceived($this->app, $this->sandbox, $request));
 
         if (Octane::hasRouteFor($request->getMethod(), '/'.$request->path())) {
-            return Octane::invokeRoute($request, $request->getMethod(), '/'.$request->path());
+            return Octane::invokeRoute($request->getMethod(), '/'.$request->path());
         }
 
         return tap($this->sandbox->make(Kernel::class)->handle($request), function ($response) use ($request) {

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -3,7 +3,9 @@
 namespace Laravel\Octane\Concerns;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ProvidesRouting
@@ -25,7 +27,9 @@ trait ProvidesRouting
      */
     public function route(string $method, string $uri, Closure $callback): void
     {
-        $this->routes[$method.$uri] = $callback;
+        $route = $method . Str::start($uri, '/');
+
+        $this->routes[$route] = $callback;
     }
 
     /**
@@ -37,7 +41,9 @@ trait ProvidesRouting
      */
     public function hasRouteFor(string $method, string $uri): bool
     {
-        return isset($this->routes[$method.$uri]);
+        $route = $method . Str::start($uri, '/');
+
+        return isset($this->routes[$route]);
     }
 
     /**
@@ -50,6 +56,8 @@ trait ProvidesRouting
      */
     public function invokeRoute(Request $request, string $method, string $uri): Response
     {
-        return call_user_func($this->routes[$method.$uri], $request);
+        $route = $method . Str::start($uri, '/');
+
+        return Container::getInstance()->call($this->routes[$route]);
     }
 }

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Octane\Concerns;
 
-use Closure;
 use Illuminate\Container\Container;
-use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -18,18 +16,18 @@ trait ProvidesRouting
     protected $routes = [];
 
     /**
-     * Register a Octane route.
+     * Register an Octane route.
      *
      * @param  string  $method
      * @param  string  $uri
-     * @param  \Closure  $callback
+     * @param  array|string|callable  $action
      * @return void
      */
-    public function route(string $method, string $uri, Closure $callback): void
+    public function route(string $method, string $uri, array|string|callable $action): void
     {
         $route = $method.Str::start($uri, '/');
 
-        $this->routes[$route] = $callback;
+        $this->routes[$route] = $action;
     }
 
     /**
@@ -49,12 +47,11 @@ trait ProvidesRouting
     /**
      * Invoke the route for the given method and URI.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  string  $method
      * @param  string  $uri
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function invokeRoute(Request $request, string $method, string $uri): Response
+    public function invokeRoute(string $method, string $uri): Response
     {
         $route = $method.Str::start($uri, '/');
 

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -23,7 +23,7 @@ trait ProvidesRouting
      * @param  array|string|callable  $action
      * @return void
      */
-    public function route(string $method, string $uri, array|string|callable $action): void
+    public function route(string $method, string $uri, array | string | callable $action): void
     {
         $route = $method.Str::start($uri, '/');
 

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -27,7 +27,7 @@ trait ProvidesRouting
      */
     public function route(string $method, string $uri, Closure $callback): void
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         $this->routes[$route] = $callback;
     }
@@ -41,7 +41,7 @@ trait ProvidesRouting
      */
     public function hasRouteFor(string $method, string $uri): bool
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         return isset($this->routes[$route]);
     }
@@ -56,7 +56,7 @@ trait ProvidesRouting
      */
     public function invokeRoute(Request $request, string $method, string $uri): Response
     {
-        $route = $method . Str::start($uri, '/');
+        $route = $method.Str::start($uri, '/');
 
         return Container::getInstance()->call($this->routes[$route]);
     }

--- a/src/Facades/Octane.php
+++ b/src/Facades/Octane.php
@@ -7,10 +7,10 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static \Laravel\Octane\Swoole\InvokeTickCallable tick(string $key, callable $callback, int $seconds = 1, bool $immediate = true)
  * @method static \Swoole\Table table(string $name)
- * @method static \Symfony\Component\HttpFoundation\Response invokeRoute(\Illuminate\Http\Request $request, string $method, string $uri)
+ * @method static \Symfony\Component\HttpFoundation\Response invokeRoute(string $method, string $uri)
  * @method static array concurrently(array $tasks, int $waitMilliseconds = 3000)
  * @method static bool hasRouteFor(string $method, string $uri)
- * @method static void route(string $method, string $uri, \Closure $callback)
+ * @method static void route(string $method, string $uri, array|string|callable $action)
  *
  * @see \Laravel\Octane\Octane
  */

--- a/tests/OctaneRouteTest.php
+++ b/tests/OctaneRouteTest.php
@@ -40,4 +40,6 @@ class OctaneRouteTest extends TestCase
     }
 }
 
-class OctaneRouteTestDependency {}
+class OctaneRouteTestDependency
+{
+}

--- a/tests/OctaneRouteTest.php
+++ b/tests/OctaneRouteTest.php
@@ -49,7 +49,7 @@ class OctaneRouteTest extends TestCase
 
         $app->bind(OctaneRouteTestDependency::class, fn () => $stub);
 
-        $app['octane']->route('GET', '/autowire_action', OctaneRouteTestController::class . '@action');
+        $app['octane']->route('GET', '/autowire_action', OctaneRouteTestController::class.'@action');
 
         $worker->run();
 
@@ -63,7 +63,8 @@ class OctaneRouteTestDependency
 
 class OctaneRouteTestController
 {
-    public function action(OctaneRouteTestDependency $foo) {
+    public function action(OctaneRouteTestDependency $foo)
+    {
         return new Response(spl_object_hash($foo));
     }
 }

--- a/tests/OctaneRouteTest.php
+++ b/tests/OctaneRouteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OctaneRouteTest extends TestCase
+{
+    public function test_dependency_injection_in_octane_routes()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/autowire', 'GET'),
+        ]);
+
+        $stub = new OctaneRouteTestDependency();
+
+        $app->bind(OctaneRouteTestDependency::class, fn () => $stub);
+
+        $app['octane']->route('GET', '/autowire', function (OctaneRouteTestDependency $foo) {
+            return new Response(spl_object_hash($foo));
+        });
+
+        $worker->run();
+
+        $this->assertSame(spl_object_hash($stub), $client->responses[0]->getContent());
+    }
+
+    public function test_octane_routes_without_leading_slash()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('no_leading_slash', 'GET'),
+        ]);
+
+        $app['octane']->route('GET', 'no_leading_slash', fn () => new Response('no leading slash'));
+
+        $worker->run();
+
+        $this->assertSame('no leading slash', $client->responses[0]->getContent());
+    }
+}
+
+class OctaneRouteTestDependency {}


### PR DESCRIPTION
Based on https://github.com/laravel/octane/pull/295, this PR let Octane routes call actions similarly to the classic Laravel routes:

```php
Octane::route('GET', '/uri', 'Controller@action');
```
The supported actions are the same as classic routes: arrays, callables and strings.

This PR introduces breaking changes as it needs to slightly modify a couple of existing signatures.