### PR TITLE
Display memory usage

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -95,7 +95,7 @@ trait InteractsWithIO
 
         $url = parse_url($request['url'], PHP_URL_PATH) ?: '/';
 
-        $memory = number_format(round(memory_get_usage() /1024 /1204, 2), 2, '.', '');
+        $memory = number_format(round(memory_get_usage() / 1024 / 1204, 2), 2, '.', '');
 
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -95,11 +95,13 @@ trait InteractsWithIO
 
         $url = parse_url($request['url'], PHP_URL_PATH) ?: '/';
 
+        $memory = number_format(round(memory_get_usage()/1024/1204, 2), 2, '.', '');
+
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 
         ['method' => $method, 'statusCode' => $statusCode] = $request;
 
-        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration) - 16, 0));
+        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration.$memory ) - 19, 0));
 
         if (empty($dots) && ! $this->output->isVerbose()) {
             $url = substr($url, 0, $terminalWidth - strlen($method.$duration) - 15 - 3).'...';
@@ -108,7 +110,7 @@ trait InteractsWithIO
         }
 
         $this->output->writeln(sprintf(
-           '  <fg=%s;options=bold>%s </>   <fg=cyan;options=bold>%s</> <options=bold>%s</><fg=#6C7280> %s%s ms</>',
+           '  <fg=%s;options=bold>%s </>   <fg=cyan;options=bold>%s</> <options=bold>%s</><fg=#6C7280> %s%s mb %s ms</>',
             match (true) {
                 $statusCode >= 500 => 'red',
                 $statusCode >= 400 => 'yellow',
@@ -120,6 +122,7 @@ trait InteractsWithIO
            $method,
            $url,
            $dots,
+           $memory,
            $duration,
         ), $this->parseVerbosity($verbosity));
     }

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -95,7 +95,7 @@ trait InteractsWithIO
 
         $url = parse_url($request['url'], PHP_URL_PATH) ?: '/';
 
-        $memory = number_format(round(memory_get_usage() / 1024 / 1204, 2), 2, '.', '');
+        $memory = number_format(round($request['memory'] ?? memory_get_usage() / 1024 / 1204, 2), 2, '.', '');
 
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -95,13 +95,13 @@ trait InteractsWithIO
 
         $url = parse_url($request['url'], PHP_URL_PATH) ?: '/';
 
-        $memory = number_format(round(memory_get_usage()/1024/1204, 2), 2, '.', '');
+        $memory = number_format(round(memory_get_usage() /1024 /1204, 2), 2, '.', '');
 
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 
         ['method' => $method, 'statusCode' => $statusCode] = $request;
 
-        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration.$memory ) - 19, 0));
+        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration.$memory) - 19, 0));
 
         if (empty($dots) && ! $this->output->isVerbose()) {
             $url = substr($url, 0, $terminalWidth - strlen($method.$duration) - 15 - 3).'...';

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -54,6 +54,7 @@ EOF, $output->fetch());
             'method' => 'GET',
             'url' => 'http://127.0.0.1/welcome',
             'statusCode' => '200',
+            'memory' => 23.43,
             'duration' => 10,
         ]);
 
@@ -61,6 +62,7 @@ EOF, $output->fetch());
             'method' => 'POST',
             'url' => 'http://127.0.0.1:8080',
             'statusCode' => '404',
+            'memory' => 26.43,
             'duration' => 1234,
         ]);
 
@@ -68,13 +70,14 @@ EOF, $output->fetch());
             'method' => 'POST',
             'url' => 'http://127.0.0.1:8080/'.str_repeat('foo', 100),
             'statusCode' => 500,
+            'memory' => 28.43,
             'duration' => 4567854,
         ]);
 
         $this->assertEquals(<<<'EOF'
-  200    GET /welcome .................. 10.00 ms
-  404    POST / ...................... 1234.00 ms
-  500    POST /foofoofoofoofoofo... 4567854.00 ms
+  200    GET /welcome ..........23.43 mb 10.00 ms
+  404    POST / ..............26.43 mb 1234.00 ms
+  500    POST /foofoofoofoofoofo... 23.46 mb 4567854.00 ms
 
 EOF, $output->fetch());
     }


### PR DESCRIPTION
Since the Laravel documentation does not provide how to check for memory leaks, many developers will opt in to use the Laravel debug bar, but i found out that the debug bar it has a memory leak itself,  so displaying the memory usage besides the duration of each request will help to easy spot memory leaks without external tools.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
