### PR TITLE
Displays memory usage from workers and only on swoole

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -95,20 +95,23 @@ trait InteractsWithIO
 
         $url = parse_url($request['url'], PHP_URL_PATH) ?: '/';
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
-        $memory = number_format(round($request['memory'] ?? memory_get_usage() / 1024 / 1204, 2), 2, '.', '');
+
+        $memory = isset($request['memory'])
+            ? (number_format($request['memory'] / 1024 / 1204, 2, '.', '') . ' mb ')
+            : '';
 
         ['method' => $method, 'statusCode' => $statusCode] = $request;
 
-        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration.$memory) - 19, 0));
+        $dots = str_repeat('.', max($terminalWidth - strlen($method.$url.$duration.$memory) - 16, 0));
 
         if (empty($dots) && ! $this->output->isVerbose()) {
-            $url = substr($url, 0, $terminalWidth - strlen($method.$duration) - 15 - 3).'...';
+            $url = substr($url, 0, $terminalWidth - strlen($method.$duration.$memory) - 15 - 3).'...';
         } else {
             $dots .= ' ';
         }
 
         $this->output->writeln(sprintf(
-           '  <fg=%s;options=bold>%s </>   <fg=cyan;options=bold>%s</> <options=bold>%s</><fg=#6C7280> %s%s mb %s ms</>',
+           '  <fg=%s;options=bold>%s </>   <fg=cyan;options=bold>%s</> <options=bold>%s</><fg=#6C7280> %s%s%s ms</>',
             match (true) {
                 $statusCode >= 500 => 'red',
                 $statusCode >= 400 => 'yellow',

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -97,7 +97,7 @@ trait InteractsWithIO
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 
         $memory = isset($request['memory'])
-            ? (number_format($request['memory'] / 1024 / 1204, 2, '.', '') . ' mb ')
+            ? (number_format($request['memory'] / 1024 / 1204, 2, '.', '').' mb ')
             : '';
 
         ['method' => $method, 'statusCode' => $statusCode] = $request;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -21,6 +21,7 @@ class Stream
             'type' => 'request',
             'method' => $method,
             'url' => $url,
+            'memory' => memory_get_usage(),
             'statusCode' => $statusCode,
             'duration' => $duration,
         ])."\n");

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -54,7 +54,7 @@ EOF, $output->fetch());
             'method' => 'GET',
             'url' => 'http://127.0.0.1/welcome',
             'statusCode' => '200',
-            'memory' => 23.43,
+            'memory' => 17393560,
             'duration' => 10,
         ]);
 
@@ -62,7 +62,7 @@ EOF, $output->fetch());
             'method' => 'POST',
             'url' => 'http://127.0.0.1:8080',
             'statusCode' => '404',
-            'memory' => 26.43,
+            'memory' => 20393560,
             'duration' => 1234,
         ]);
 
@@ -70,14 +70,14 @@ EOF, $output->fetch());
             'method' => 'POST',
             'url' => 'http://127.0.0.1:8080/'.str_repeat('foo', 100),
             'statusCode' => 500,
-            'memory' => 28.43,
+            'memory' => 30393560,
             'duration' => 4567854,
         ]);
 
         $this->assertEquals(<<<'EOF'
-  200    GET /welcome .......... 23.43 mb 10.00 ms
-  404    POST / .............. 26.43 mb 1234.00 ms
-  500    POST /foofoofoofoofoofo... 28.43 mb 4567854.00 ms
+  200    GET /welcome ......... 14.11 mb 10.00 ms
+  404    POST / ............. 16.54 mb 1234.00 ms
+  500    POST /foofoofo... 24.65 mb 4567854.00 ms
 
 EOF, $output->fetch());
     }


### PR DESCRIPTION
This pull request improves the https://github.com/laravel/octane/pull/297 pull request by displaying the memory usage from workers instead of the memory of the "output" process.

In addition, it **only displays the memory** while using Swoole. As the memory output seems not be available when using Roadrunner.

