### PR TITLE
[1.x] Normalize the file watcher mechanism to add support for alternatives

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -65,7 +65,8 @@ trait InteractsWithServers
     protected function createFileWatcher(): FileWatcher
     {
         if (! $this->option('watch')) {
-            return new class implements FileWatcher {
+            return new class implements FileWatcher
+            {
                 public function hasChanges(): bool
                 {
                     return false;

--- a/src/Contracts/FileWatcher.php
+++ b/src/Contracts/FileWatcher.php
@@ -5,7 +5,7 @@ namespace Laravel\Octane\Contracts;
 interface FileWatcher
 {
     /**
-     * Determine if there are any file changes occurred
+     * Determine if any file changes occurred.
      *
      * @return bool
      */

--- a/src/Contracts/FileWatcher.php
+++ b/src/Contracts/FileWatcher.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Octane\Contracts;
+
+interface FileWatcher
+{
+    /**
+     * Determine if there are any file changes occurred
+     *
+     * @return bool
+     */
+    public function hasChanges(): bool;
+}

--- a/src/Exceptions/FileWatcherException.php
+++ b/src/Exceptions/FileWatcherException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Laravel\Octane\Exceptions;
+
+use Exception;
+
+class FileWatcherException extends Exception
+{
+}

--- a/src/FileWatchers/ChokidarFileWatcher.php
+++ b/src/FileWatchers/ChokidarFileWatcher.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Octane\FileWatchers;
+
+use Laravel\Octane\Contracts\FileWatcher;
+use Laravel\Octane\Exceptions\FileWatcherException;
+use Symfony\Component\Process\Process;
+
+class ChokidarFileWatcher implements FileWatcher
+{
+    protected Process $process;
+
+    public function __construct(string $executable, array $paths)
+    {
+        $this->process = tap(new Process([
+            $executable, 'file-watcher.js', json_encode($paths),
+        ], realpath(__DIR__.'/../../bin'), null, null, null))->start();
+    }
+
+    /**
+     * Determine if there are any file changes occurred
+     *
+     * @return bool
+     * @throws FileWatcherException
+     */
+    public function hasChanges(): bool
+    {
+        if ($this->process->isTerminated()) {
+            throw new FileWatcherException(
+                'Watcher process has terminated. Please ensure chokidar is installed.'.PHP_EOL.
+                $this->process->getErrorOutput()
+            );
+        }
+
+        return ! empty($this->process->getIncrementalOutput());
+    }
+}

--- a/src/FileWatchers/ChokidarFileWatcher.php
+++ b/src/FileWatchers/ChokidarFileWatcher.php
@@ -18,7 +18,7 @@ class ChokidarFileWatcher implements FileWatcher
     }
 
     /**
-     * Determine if there are any file changes occurred
+     * Determine if any file changes occurred.
      *
      * @return bool
      * @throws FileWatcherException


### PR DESCRIPTION
This PR normalizes the file watching mechanism so that other alternatives can be added. I am currently working on adding **inotify** support using the new interface.

The reason behind this PR is mainly due to the fact that the projects I create using Laravel is strictly "backend" with zero inclusion of NodeJS dependency and I would like to keep it that way still have the ability to automatically reload the workers for file changes.