### PR TITLE
[1.x] Fix Swoole breaks when log is a valid JSON

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -177,7 +177,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             ->filter()
             ->groupBy(fn ($output) => $output)
             ->each(function ($group) {
-                is_array($stream = json_decode($output = $group->first(), true))
+                is_array($stream = json_decode($output = $group->first(), true)) && isset($stream['type'])
                     ? $this->handleStream($stream)
                     : $this->error($output);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The swoole server acknowledges a log entry as something else (a request I guess) and routes it to handleStream when the log entry is a valid JSON.

I don't know if there is any other better way to solve it, but when receiving a json before routing it to handleStream, adding a check for the required type key as well at least solves the issue for the format in Monolog\Formatter\JsonFormatter

It would still conflict with other logs that:

1. Are valid json
2. Contains the key type