### PR TITLE
Add config option `request_class` for Swoole client.

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -52,6 +52,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTTP request class
+    |--------------------------------------------------------------------------
+    |
+    | You could set your own class for every incoming HTTP request created by
+    | swoole server.
+    |
+    */
+
+    'request_class' => env('OCTANE_REQUEST_CLASS', \Illuminate\Http\Request::class),
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Listeners
     |--------------------------------------------------------------------------
     |

--- a/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
+++ b/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
@@ -11,11 +11,12 @@ class ConvertSwooleRequestToIlluminateRequest
     /**
      * Convert the given Swoole request into an Illuminate request.
      *
-     * @param  \Swoole\Http\Request  $swooleRequest
-     * @param  string  $phpSapi
+     * @param  \Swoole\Http\Request $swooleRequest
+     * @param  string               $phpSapi
+     * @param  string               $appRequestClass
      * @return \Illuminate\Http\Request
      */
-    public function __invoke($swooleRequest, string $phpSapi): Request
+    public function __invoke($swooleRequest, string $appRequestClass, string $phpSapi): Request
     {
         $serverVariables = $this->prepareServerVariables(
             $swooleRequest->server ?? [],
@@ -39,8 +40,9 @@ class ConvertSwooleRequestToIlluminateRequest
 
             $request->request = new ParameterBag($data);
         }
+        /** @var \Illuminate\Http\Request|string $appRequestClass */
 
-        return Request::createFromBase($request);
+        return $appRequestClass::createFromBase($request);
     }
 
     /**

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -35,9 +35,12 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     public function marshalRequest(RequestContext $context): array
     {
+        $requestClass = $context->octaneConfig['request_class'] ?? \Illuminate\Http\Request::class;
+
         return [
             (new Actions\ConvertSwooleRequestToIlluminateRequest)(
                 $context->swooleRequest,
+                $requestClass,
                 PHP_SAPI
             ),
             $context,


### PR DESCRIPTION
Hi, I want to propose one usefull (at least for me) option, like `set app request class name`.
It changes incoming laravel request class into one that use gives, like `\App\Http\Request`.

PR for issue #318 