### PR TITLE
Added basic handling for application logs

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -182,6 +182,10 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                         'duration' => $this->calculateElapsedTime($debug['elapsed']),
                     ]);
                 }
+
+                if ($debug['level'] === 'info' && $debug['logger'] === 'server') {
+                    return $this->info(trim($debug['msg']));
+                }
             });
 
         Str::of($server->getIncrementalErrorOutput())


### PR DESCRIPTION
This PR adds support for application logs written to stderr, as described in #320. As it stands, logging to stderr isn't possible in Octane, defeating best practices for Docker deployments.

For reference, here's my last post in that issue:
> For context on the issue itself, as Roadrunner uses stdout as its response transmission channel, it files all stderr output as application logs, with a level of `INFO`. This does not match any condition in the `getIncrementalOutput` line handler callback, and is discarded. So we can get application logs into the output by simply adding the following: [...]
>
> This has a few downsides, however:
> - **It prints noise messages:** Unfortunately, RR sends additional, non-app logs under the same channel ("INFO  scan command"). There's not really a good way to prevent this other than blacklisting them.
> - **It hard-codes INFO as the log level:** As we don't know which formatter the user has configured for the stderr logger, we can't simply parse the application-generated log line to extract the actual log level, and thus are forced to use INFO.
> - **It relies on an implementation detail:** This is of lesser concern, but (ab)using the `logger` field of the Roadrunner output for something it probably isn't intended for seems brittle to me.
>
> The first two points could be solved by adding special handling to Laravel itself: If it is running within Octane, log lines could be prefixed by some unique identifier, independently of the configured line formatter. That would allow checking for a substring match on the info lines received and only printing those.  
> Another option might be for Roadrunner itself to label application output differently, or adding a meta field to the log JSON.  
>
> Alternatively, we could simply add the three lines above and call it a day.

Anyone has ideas on how to go forward?