### PR TITLE
Prints server logs to "stderr"

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -60,7 +60,7 @@ trait InteractsWithIO
      */
     public function raw($string)
     {
-        if (! Str::contains($string, $this->ignoreMessages)) {
+        if (! Str::startsWith($string, $this->ignoreMessages)) {
             $this->output instanceof OutputStyle
                 ? fwrite(STDERR, $string."\n")
                 : $this->output->writeln($string);

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -84,7 +84,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir=public',
             '-o', 'http.middleware=static',
-            '-o', app()->environment('local') ? 'logs.mode=production' : 'logs.mode=none',
+            '-o', 'logs.mode=production',
             '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warning',
             '-o', 'logs.output=stdout',
             '-o', 'logs.encoding=json',
@@ -170,6 +170,10 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
 
                 if (is_array($stream = json_decode($debug['msg'], true))) {
                     return $this->handleStream($stream);
+                }
+
+                if ($debug['logger'] == 'server') {
+                    return $this->raw($debug['msg']);
                 }
 
                 if ($debug['level'] == 'debug' && isset($debug['remote'])) {

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -179,20 +179,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             ->each(function ($group) {
                 is_array($stream = json_decode($output = $group->first(), true)) && isset($stream['type'])
                     ? $this->handleStream($stream)
-                    : $this->error($output);
-
-                if (($count = $group->count()) > 1) {
-                    $this->newLine();
-
-                    $count--;
-
-                    $this->line(sprintf('  <fg=red;options=bold>↑</>   %s %s',
-                        $count,
-                        $count > 1
-                            ? 'similar errors were reported.'
-                            : 'similar error was reported.'
-                    ));
-                }
+                    : $this->raw($output);
             });
     }
 


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/octane/issues/320, https://github.com/laravel/octane/pull/325, by proxy applications logs (using `stderr` driver) to `stderr`.

<img width="1122" alt="Screenshot 2021-06-15 at 14 22 46" src="https://user-images.githubusercontent.com/5457236/122060099-30829080-cde5-11eb-97d6-ac48eae7157b.png">