### PR TITLE
Set roadrunner http.middlware as an option

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -136,20 +136,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | RoadRunner middleware option
-    |--------------------------------------------------------------------------
-    |
-    | While using Roadrunner, you may change the http middleware setting.
-    | From https://roadrunner.dev/docs/intro-config:
-    | Middlewares for the http plugin, order is important. Allowed values: "headers", "static", "gzip"
-    | Multiple values have to be coma separated
-    |
-    */
-
-    'http_middleware' => 'static',
-
-    /*
-    |--------------------------------------------------------------------------
     | Octane Cache Table
     |--------------------------------------------------------------------------
     |

--- a/config/octane.php
+++ b/config/octane.php
@@ -136,6 +136,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | RoadRunner middleware option
+    |--------------------------------------------------------------------------
+    |
+    | While using Roadrunner, you may change the http middleware setting.
+    | From https://roadrunner.dev/docs/intro-config:
+    | Middlewares for the http plugin, order is important. Allowed values: "headers", "static", "gzip"
+    | Multiple values have to be coma separated
+    |
+    */
+
+    'http_middleware' => 'static',
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Cache Table
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -83,7 +83,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir=public',
-            '-o', 'http.middleware=static',
+            '-o', 'http.middleware='.$this->httpMiddleware(),
             '-o', 'logs.mode=production',
             '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warning',
             '-o', 'logs.output=stdout',
@@ -140,6 +140,16 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function maxExecutionTime()
     {
         return config('octane.max_execution_time', '30').'s';
+    }
+
+    /**
+     * Get roadrunner http.middleware option
+     *
+     * @return string
+     */
+    protected function httpMiddleware()
+    {
+        return config('octane.http_middleware', 'static');
     }
 
     /**

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -83,7 +83,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir=public',
-            '-o', 'http.middleware='.$this->httpMiddleware(),
+            '-o', 'http.middleware='.config('octane.http_middleware', 'static'),
             '-o', 'logs.mode=production',
             '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warning',
             '-o', 'logs.output=stdout',
@@ -140,16 +140,6 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function maxExecutionTime()
     {
         return config('octane.max_execution_time', '30').'s';
-    }
-
-    /**
-     * Get roadrunner http.middleware option.
-     *
-     * @return string
-     */
-    protected function httpMiddleware()
-    {
-        return config('octane.http_middleware', 'static');
     }
 
     /**

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -143,7 +143,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     }
 
     /**
-     * Get roadrunner http.middleware option
+     * Get roadrunner http.middleware option.
      *
      * @return string
      */

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -83,7 +83,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir=public',
-            '-o', 'http.middleware='.config('octane.http_middleware', 'static'),
+            '-o', 'http.middleware='.config('octane.swoole.http_middleware', 'static'),
             '-o', 'logs.mode=production',
             '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warning',
             '-o', 'logs.output=stdout',


### PR DESCRIPTION
Roadrunner `http.middlware` config is currently hardcoded to "static" in  `src/Commands/StartRoadRunnerCommand.php` file, and thus cannot be changed via .rr.yaml file

This pull request set this as an option in `config/octane` file in order to customize it following the official conf : https://roadrunner.dev/docs/intro-config

The main purpose is to allow to enable gzip as this is one the supported middleware option.
Ex : `    'http_middleware' => 'static,gzip'`