### PR TITLE
Addresses #332: pass config-file path for roadrunner

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -15,13 +15,13 @@ class StartCommand extends Command implements SignalableCommandInterface
      */
     public $signature = 'octane:start
                     {--server= : The server that should be used to serve the application}
-                    {--config-path= : The full config path for roadrunner .rr.yaml file. Default .rr.yaml in app dir}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port=8000 : The port the server should be available on}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
+                    {--config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}';
 
     /**
@@ -74,10 +74,10 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->option('host'),
             '--port' => $this->option('port'),
-            '--config-path' => $this->option('config-path'),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),
+            '--config' => $this->option('config'),
             '--watch' => $this->option('watch'),
         ]);
     }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -15,6 +15,7 @@ class StartCommand extends Command implements SignalableCommandInterface
      */
     public $signature = 'octane:start
                     {--server= : The server that should be used to serve the application}
+                    {--config-path= : The full config path for roadrunner .rr.yaml file. Default .rr.yaml in app dir}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port=8000 : The port the server should be available on}
                     {--rpc-port= : The RPC port the server should be available on}
@@ -73,6 +74,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->option('host'),
             '--port' => $this->option('port'),
+            '--config-path' => $this->option('config-path'),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -126,7 +126,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     protected function configPath()
     {
-        if (!$this->option('config-path')) {
+        if (! $this->option('config-path')) {
             touch(base_path('.rr.yaml'));
             return base_path('.rr.yaml');
         }

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -126,13 +126,33 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     protected function configPath()
     {
-        if (! $this->option('config-path')) {
+        $path =  $this->option('config-path');
+        if (! $path) {
             touch(base_path('.rr.yaml'));
             return base_path('.rr.yaml');
         }
-        return $this->option('config-path');
+
+        if (! $this->isAbsolutePath($path)) {
+            return base_path($path);
+        }
+        return $path;
     }
 
+    /**
+     * Check if path is absolute
+     * Example:
+     * '.rr.yaml' returns false
+     * '~/.rr.yaml' returns false
+     * '/.rr.yaml' returns true
+     * './.rr.yaml' returns false
+     *
+     * @return bool
+     */
+    protected function isAbsolutePath($path)
+    {
+        return $path[0] === DIRECTORY_SEPARATOR
+            || preg_match('~\A[A-Z]:(?![^/\\\\])~i', $path) > 0;
+    }
     /**
      * Get the number of workers that should be started.
      *


### PR DESCRIPTION
Submitted with intentions for a first review and consideration.

Reasons for this pull request:

1. As mentioned in #332: to be able use different ``.rr.yaml`` based on different environments
2. We use ``deployer``. As this is symbolic link deployment, the ``base_path()`` picks up the path from the ``releases/<id>`` reference instead of the symb link. It'd be nice if we could provide a path via cli.

The first option is more encouraging, as this config file is most likely to be on the server in a different location.