### PR TITLE
expose the flag to turn on SWOOLE_SSL

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -7,7 +7,7 @@ try {
         $serverState['host'] ?? '127.0.0.1',
         $serverState['port'] ?? '8080',
         SWOOLE_PROCESS,
-        SWOOLE_SOCK_TCP | ((bool)$config['swoole']['enable-openssl'] ?? 0) * SWOOLE_SSL,
+        SWOOLE_SOCK_TCP | ((bool) $config['swoole']['enable-openssl'] ?? 0) * SWOOLE_SSL,
     );
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);

--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -7,7 +7,7 @@ try {
         $serverState['host'] ?? '127.0.0.1',
         $serverState['port'] ?? '8080',
         SWOOLE_PROCESS,
-        SWOOLE_SOCK_TCP,
+        SWOOLE_SOCK_TCP | ((bool)$config['swoole']['enable-openssl'] ?? 0) * SWOOLE_SSL,
     );
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);

--- a/config/octane.php
+++ b/config/octane.php
@@ -184,7 +184,7 @@ return [
         'options' => [
             // 'ssl_cert_file' => '/etc/swoole/ssl/certs/sail-selfsigned.crt',
             // 'ssl_key_file' => '/etc/swoole/ssl/private/sail-selfsigned.key',
-        ]
+        ],
     ],    
 
     /*

--- a/config/octane.php
+++ b/config/octane.php
@@ -186,7 +186,7 @@ return [
             // 'ssl_key_file' => '/etc/swoole/ssl/private/sail-selfsigned.key',
         ],
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | File Watching

--- a/config/octane.php
+++ b/config/octane.php
@@ -170,6 +170,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Octane Swoole Configuration Options
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may define additional configuration options as
+    | required by the application. You maycheck which options you need from:
+    | https://www.swoole.co.uk/docs/modules/swoole-server/configuration
+    |
+    */
+
+    'swoole' => [
+        'enable-openssl' => false,
+        'options' => [
+            // 'ssl_cert_file' => '/etc/swoole/ssl/certs/sail-selfsigned.crt',
+            // 'ssl_key_file' => '/etc/swoole/ssl/private/sail-selfsigned.key',
+        ]
+    ],    
+
+    /*
+    |--------------------------------------------------------------------------
     | File Watching
     |--------------------------------------------------------------------------
     |

--- a/config/octane.php
+++ b/config/octane.php
@@ -185,8 +185,8 @@ return [
             // 'ssl_cert_file' => '/etc/swoole/ssl/certs/sail-selfsigned.crt',
             // 'ssl_key_file' => '/etc/swoole/ssl/private/sail-selfsigned.key',
         ],
-    ],    
-
+    ],
+    
     /*
     |--------------------------------------------------------------------------
     | File Watching


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I find no PR for this issue #155, so i create this.

Propose to expose SWOOLE_SSL flag and configurable in `config/octane.php`. 
User can just toggle the flag then `sail down` and `up` to turning HTTPS on/off without docker re-build.

Since the latest Sail using `php8.0-swoole`, [Sail PR](https://github.com/laravel/sail/pull/177), 
User should be able to turn on HTTPS support easily by just editing `Dockerfile` & `docker-compose.yml`

Adding the flag `octane.swoole.enable-openssl` & `octane.swoole.options` in the config, so it will not affect default Swoole HTTP setup but easy for user to configure swoole.