### PR TITLE
Fix does not work Swoole\Table

### DIFF
--- a/src/Cache/OctaneStore.php
+++ b/src/Cache/OctaneStore.php
@@ -31,7 +31,7 @@ class OctaneStore implements Store
      */
     public function get($key)
     {
-        $record = $this->table[$key] ?? null;
+        $record = $this->table->$key ?? null;
 
         if (! $this->recordIsNullOrExpired($record)) {
             return unserialize($record['value']);
@@ -79,7 +79,7 @@ class OctaneStore implements Store
      */
     public function put($key, $value, $seconds)
     {
-        $this->table[$key] = [
+        $this->table->$key = [
             'value' => serialize($value),
             'expiration' => Carbon::now()->getTimestamp() + $seconds,
         ];
@@ -112,7 +112,7 @@ class OctaneStore implements Store
      */
     public function increment($key, $value = 1)
     {
-        $record = $this->table[$key] ?? null;
+        $record = $this->table->$key ?? null;
 
         if ($this->recordIsNullOrExpired($record)) {
             return tap($value, fn ($value) => $this->put($key, $value, static::ONE_YEAR));
@@ -216,7 +216,7 @@ class OctaneStore implements Store
      */
     public function forget($key)
     {
-        unset($this->table[$key]);
+        unset($this->table->$key);
 
         return true;
     }

--- a/tests/OctaneStoreTest.php
+++ b/tests/OctaneStoreTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Octane\Tests;
 
-use ArrayObject;
+use stdClass;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Octane\Cache\OctaneStore;
@@ -11,9 +11,9 @@ class OctaneStoreTest extends TestCase
 {
     public function test_can_retrieve_items_from_store()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() + 100];
+        $table->foo = ['value' => serialize('bar'), 'expiration' => time() + 100];
 
         $store = new OctaneStore($table);
 
@@ -22,7 +22,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_missing_items_return_null()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -31,18 +31,18 @@ class OctaneStoreTest extends TestCase
 
     public function test_expired_items_return_null()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() - 100];
+        $table->foo = ['value' => serialize('bar'), 'expiration' => time() - 100];
 
         $this->assertNull($store->get('foo'));
     }
 
     public function test_get_method_can_resolve_pending_interval()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -53,10 +53,10 @@ class OctaneStoreTest extends TestCase
 
     public function test_many_method_can_return_many_values()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() + 100];
-        $table['bar'] = ['value' => serialize('baz'), 'expiration' => time() + 100];
+        $table->foo = ['value' => serialize('bar'), 'expiration' => time() + 100];
+        $table->bar = ['value' => serialize('baz'), 'expiration' => time() + 100];
 
         $store = new OctaneStore($table);
 
@@ -65,7 +65,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_put_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -76,7 +76,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_put_many_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -88,7 +88,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_increment_and_decrement_operations()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -104,7 +104,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_forever_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -115,7 +115,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_intervals_can_be_refreshed()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -135,7 +135,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_can_forget_cache_items()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 
@@ -152,7 +152,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_intervals_are_not_flushed()
     {
-        $table = new ArrayObject;
+        $table = new stdClass;
 
         $store = new OctaneStore($table);
 

--- a/tests/OctaneStoreTest.php
+++ b/tests/OctaneStoreTest.php
@@ -2,10 +2,10 @@
 
 namespace Laravel\Octane\Tests;
 
-use stdClass;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Octane\Cache\OctaneStore;
+use stdClass;
 
 class OctaneStoreTest extends TestCase
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


I'm using `Octane::tick` but it does not work.
It occurred an error is below:

```
 Cannot use object of type Swoole\Table as array

  at vendor/laravel/octane/src/Cache/OctaneStore.php:82
     78▕      * @return bool
     79▕      */
     80▕     public function put($key, $value, $seconds)
     81▕     {
  ➜  82▕         $this->table[$key] = [
     83▕             'value' => serialize($value),
     84▕             'expiration' => Carbon::now()->getTimestamp() + $seconds,
     85▕         ];
     86▕
```

In the Swoole version is 4.7.0-dev; you can access `\Swoole\Table` as an object, not an array.


### php -v

```
PHP 8.0.8 (cli) (built: Jun 29 2021 07:41:19) ( NTS gcc x86_64 )
Copyright (c) The PHP Group
Zend Engine v4.0.8, Copyright (c) Zend Technologies
```

### php --ri swoole

```

swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 4.7.0-dev
Built => Jul 10 2021 08:41:11
coroutine => enabled with boost asm context
epoll => enabled
eventfd => enabled
signalfd => enabled
cpu_affinity => enabled
spinlock => enabled
rwlock => enabled
openssl => OpenSSL 1.0.2k-fips  26 Jan 2017
json => enabled
curl-native => enabled
pcre => enabled
zlib => 1.2.7
mutex_timedlock => enabled
pthread_barrier => enabled
futex => enabled
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => On => On
swoole.unixsock_buffer_size => 8388608 => 8388608
```

