### PR TITLE
[1.x] Fix typo and Fix Undefined constant SWOOLE_SSL

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -102,7 +102,7 @@ class InstallCommand extends Command
     }
 
     /**
-     * Install the RoadRunner dependencies.
+     * Install the Swoole dependencies.
      *
      * @return bool
      */

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -66,6 +66,12 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             return 1;
         }
 
+        if (config('octane.swoole.ssl', false) === true && ! defined('SWOOLE_SSL')) {
+            $this->error('You must configure with `--enable-openssl` to support ssl connection when compiling Swoole.');
+
+            return 1;
+        }
+
         $this->writeServerStateFile($serverStateFile, $extension);
 
         $this->forgetEnvironmentVariables();


### PR DESCRIPTION
Fix https://github.com/laravel/octane/issues/155#issuecomment-892926746

When compiling Swoole you must configure `-enable-openssl` to support ssl connections.