### PR TITLE
[1.x] Avoids usage of `SWOOLE_SSL` when `openssl` is not configured on swoole

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -7,7 +7,9 @@ try {
         $serverState['host'] ?? '127.0.0.1',
         $serverState['port'] ?? '8080',
         SWOOLE_PROCESS,
-        SWOOLE_SOCK_TCP | ((bool) ($config['swoole']['ssl'] ?? 0)) * SWOOLE_SSL,
+        ($config['swoole']['ssl'] ?? false)
+            ? SWOOLE_SOCK_TCP | SWOOLE_SSL
+            : SWOOLE_SOCK_TCP,
     );
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -66,6 +66,12 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             return 1;
         }
 
+        if (config('octane.swoole.ssl', false) === true && ! defined('SWOOLE_SSL')) {
+            $this->error('You must configure Swoole with `--enable-openssl` to support ssl.');
+
+            return 1;
+        }
+
         $this->writeServerStateFile($serverStateFile, $extension);
 
         $this->forgetEnvironmentVariables();


### PR DESCRIPTION
This pull request addresses an issue where `SWOOLE_SSL` constant was being used even if the `openssl` was not configured on swoole causing the following error: `Undefined constant SWOOLE_SSL`.

With this pull request, the `SWOOLE_SSL` is only used if the user have enabled `openssl` on swoole and configured octane to use ssl.