### PR TITLE
[1.x] Fix the bug of Swoole\Table using array access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, swoole
           tools: composer:v2
           coverage: none
 

--- a/tests/OctaneStoreTest.php
+++ b/tests/OctaneStoreTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Octane\Tests;
 
-use ArrayObject;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Octane\Cache\OctaneStore;

--- a/tests/OctaneStoreTest.php
+++ b/tests/OctaneStoreTest.php
@@ -11,9 +11,9 @@ class OctaneStoreTest extends TestCase
 {
     public function test_can_retrieve_items_from_store()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() + 100];
+        $table->set('foo', ['value' => serialize('bar'), 'expiration' => time() + 100]);
 
         $store = new OctaneStore($table);
 
@@ -22,7 +22,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_missing_items_return_null()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -31,18 +31,18 @@ class OctaneStoreTest extends TestCase
 
     public function test_expired_items_return_null()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() - 100];
+        $table->set('foo', ['value' => serialize('bar'), 'expiration' => time() - 100]);
 
         $this->assertNull($store->get('foo'));
     }
 
     public function test_get_method_can_resolve_pending_interval()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -53,10 +53,10 @@ class OctaneStoreTest extends TestCase
 
     public function test_many_method_can_return_many_values()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
-        $table['foo'] = ['value' => serialize('bar'), 'expiration' => time() + 100];
-        $table['bar'] = ['value' => serialize('baz'), 'expiration' => time() + 100];
+        $table->set('foo', ['value' => serialize('bar'), 'expiration' => time() + 100]);
+        $table->set('bar', ['value' => serialize('baz'), 'expiration' => time() + 100]);
 
         $store = new OctaneStore($table);
 
@@ -65,7 +65,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_put_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -76,7 +76,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_put_many_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -88,7 +88,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_increment_and_decrement_operations()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -104,7 +104,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_forever_stores_value_in_table()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -115,7 +115,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_intervals_can_be_refreshed()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -135,7 +135,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_can_forget_cache_items()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 
@@ -152,7 +152,7 @@ class OctaneStoreTest extends TestCase
 
     public function test_intervals_are_not_flushed()
     {
-        $table = new ArrayObject;
+        $table = $this->createSwooleTable();
 
         $store = new OctaneStore($table);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Laravel\Octane\Testing\Fakes\FakeClient;
 use Laravel\Octane\Testing\Fakes\FakeWorker;
 use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Swoole\Table;
 
 class TestCase extends BaseTestCase
 {
@@ -38,6 +39,20 @@ class TestCase extends BaseTestCase
         $factory->warm($app, Octane::defaultServicesToWarm());
 
         return $app;
+    }
+
+    protected function createSwooleTable()
+    {
+        $config = $this->config();
+
+        $cacheTable = new Table($config['cache']['rows'] ?? 1000);
+
+        $cacheTable->column('value', Table::TYPE_STRING, $config['cache']['bytes'] ?? 10000);
+        $cacheTable->column('expiration', Table::TYPE_INT);
+
+        $cacheTable->create();
+
+        return $cacheTable;
     }
 
     protected function appFactory()


### PR DESCRIPTION
Swoole has removed `Swoole\Table\Row` since v4.7.0 (https://github.com/swoole/swoole-src/pull/4297), so you can't read or write `Table` as an array anymore.

This PR is compatible with lower versions of Swoole. 

Of course, Swoole doesn't recommend using arrays for reading and writing, but rather using `API`.
