### PR TITLE
Uses `laravel/serializable-closure`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^8.0",
         "laravel/framework": "^8.37",
         "laminas/laminas-diactoros": "^2.5",
+        "laravel/serializable-closure": "^1.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {

--- a/src/Cache/OctaneStore.php
+++ b/src/Cache/OctaneStore.php
@@ -4,8 +4,8 @@ namespace Laravel\Octane\Cache;
 
 use Closure;
 use Illuminate\Contracts\Cache\Store;
-use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Carbon;
+use Laravel\SerializableClosure\SerializableClosure;
 use Throwable;
 
 class OctaneStore implements Store

--- a/src/Swoole/SwooleHttpTaskDispatcher.php
+++ b/src/Swoole/SwooleHttpTaskDispatcher.php
@@ -5,12 +5,12 @@ namespace Laravel\Octane\Swoole;
 use Closure;
 use Exception;
 use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
 use Laravel\Octane\Contracts\DispatchesTasks;
 use Laravel\Octane\Exceptions\TaskExceptionResult;
 use Laravel\Octane\Exceptions\TaskTimeoutException;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class SwooleHttpTaskDispatcher implements DispatchesTasks
 {

--- a/src/Swoole/SwooleTaskDispatcher.php
+++ b/src/Swoole/SwooleTaskDispatcher.php
@@ -3,11 +3,11 @@
 namespace Laravel\Octane\Swoole;
 
 use Closure;
-use Illuminate\Queue\SerializableClosure;
 use InvalidArgumentException;
 use Laravel\Octane\Contracts\DispatchesTasks;
 use Laravel\Octane\Exceptions\TaskExceptionResult;
 use Laravel\Octane\Exceptions\TaskTimeoutException;
+use Laravel\SerializableClosure\SerializableClosure;
 use Swoole\Http\Server;
 
 class SwooleTaskDispatcher implements DispatchesTasks


### PR DESCRIPTION
This pull request makes Octane use the new `laravel/serializable-closure` package. There is no breaking changes, yet we need to wait for:

- [ ] https://github.com/laravel/framework/pull/38404.
- [ ] Update required framework version on Octane's `composer.json`.