### PR TITLE
Fix timeout value passed to taskWaitMulti

### DIFF
--- a/src/Swoole/SwooleTaskDispatcher.php
+++ b/src/Swoole/SwooleTaskDispatcher.php
@@ -34,7 +34,7 @@ class SwooleTaskDispatcher implements DispatchesTasks
             return [$key => $task instanceof Closure
                             ? new SerializableClosure($task)
                             : $task, ];
-        })->all(), $waitMilliseconds);
+        })->all(), $waitMilliseconds / 1000);
 
         if ($results === false) {
             throw TaskTimeoutException::after($waitMilliseconds);

--- a/tests/SwooleTaskDispatcherTest.php
+++ b/tests/SwooleTaskDispatcherTest.php
@@ -40,6 +40,7 @@ class SwooleTaskDispatcherTest extends TestCase
 
         $this->instance(Server::class, Mockery::mock(Server::class, function ($mock) {
             $mock->shouldReceive('taskWaitMulti')
+                ->with(\Mockery::any(), 2)
                 ->once()
                 ->andReturn(false);
         }));


### PR DESCRIPTION
Swoole's `taskWaitMulti` method expects a timeout value in seconds, however, Octane is providing a timeout value in milliseconds: https://www.swoole.co.uk/docs/modules/swoole-server-taskWaitMulti

This PR divides the given millisecond value by 1000 when passing into `taskWaitMulti`.