### PR TITLE
Add clear the cache of APCu and Opcache

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -37,6 +37,7 @@ class OnWorkerStart
 
         $this->dispatchServerTickTaskEverySecond($server);
         $this->streamRequestsToConsole($server);
+        $this->clearCache();
 
         if ($this->shouldSetProcessName) {
             $isTaskWorker = $workerId >= $server->setting['worker_num'];
@@ -108,5 +109,26 @@ class OnWorkerStart
                 (microtime(true) - $this->workerState->lastRequestTime) * 1000,
             );
         });
+    }
+
+    /**
+     * Clear the cache of APCu and Opcache.
+     *
+     * @return void
+     */
+    protected function clearCache()
+    {
+        static $functions = [
+            'apcu_clear_cache',
+            'opcache_reset',
+        ];
+
+        foreach ($functions as $function)
+        {
+            if (function_exists($function))
+            {
+                $function();
+            }
+        }
     }
 }

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -123,10 +123,8 @@ class OnWorkerStart
             'opcache_reset',
         ];
 
-        foreach ($functions as $function)
-        {
-            if (function_exists($function))
-            {
+        foreach ($functions as $function) {
+            if (function_exists($function)) {
                 $function();
             }
         }


### PR DESCRIPTION
Fix #384

If PHP has APCu/OPcache enabled, reloads will be affected when reloading, so you need to clear the cache