### PR TITLE
add FlushDatabaseQueryLog for cleaning up database query log

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -45,6 +45,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToValidationFactory::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToViewFactory::class,
             \Laravel\Octane\Listeners\FlushDatabaseRecordModificationState::class,
+            \Laravel\Octane\Listeners\FlushDatabaseQueryLog::class,
             \Laravel\Octane\Listeners\FlushLogContext::class,
             \Laravel\Octane\Listeners\FlushArrayCache::class,
 

--- a/src/Listeners/FlushDatabaseQueryLog.php
+++ b/src/Listeners/FlushDatabaseQueryLog.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class FlushDatabaseQueryLog
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('db')) {
+            return;
+        }
+
+        foreach ($event->sandbox->make('db')->getConnections() as $connection) {
+            $connection->flushQueryLog();
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #392 , when database query logging is enabled, the logs are not cleared after a request is handled. This PR fixes that issue by introducing a new listener([FlushDatabaseQueryLog](https://github.com/nazmulpcc/octane/blob/a6f462573f975452cf486e8473d8b4adc2202858/src/Listeners/FlushDatabaseQueryLog.php) ) that calls `flushQueryLog` on each db connections.