### PR TITLE
Add Swoole Configuration to octane.php

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -216,5 +216,21 @@ return [
     */
 
     'max_execution_time' => 30,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Swoole Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The following setting allows you to modify Swoole's configuration.
+    |
+    */
+
+    'swoole' => [
+        'options' => [
+            // 'package_max_length' => 20 * 1024 * 1024,
+        ],
+    ],
+
 
 ];


### PR DESCRIPTION
I recently had the problem of finding out how to increase package_max_length on Octane, so I had to read the code to understand what's happening in the background.
I believe this change could help one or many to change the server's options according to their needs.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
