### PR TITLE
Adds partial PHP 8.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0]
+        php: [8.0, 8.1]
         laravel: [^8.35]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "orchestra/testbench": "^6.16",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.14",
-        "spiral/roadrunner": "^2.0",
-        "swoole/ide-helper": "^4.6"
+        "spiral/roadrunner": "^2.0"
     },
     "bin": [
         "bin/roadrunner-worker",

--- a/src/RequestContext.php
+++ b/src/RequestContext.php
@@ -10,21 +10,25 @@ class RequestContext implements ArrayAccess
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);

--- a/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
+++ b/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
@@ -33,7 +33,7 @@ class ConvertSwooleRequestToIlluminateRequest
             $swooleRequest->rawContent(),
         );
 
-        if (str_starts_with($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded') &&
+        if (str_starts_with((string) $request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded') &&
             in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'PATCH', 'DELETE'])) {
             parse_str($request->getContent(), $data);
 

--- a/tests/BinaryBootstrapTest.php
+++ b/tests/BinaryBootstrapTest.php
@@ -17,7 +17,17 @@ class BinaryBootstrapTest extends TestCase
 
         $process->mustRun();
 
-        $this->assertSame($basePath, $process->getOutput());
+        $output = $process->getOutput();
+
+        if (\PHP_VERSION_ID >= 80100) {
+            $output = array_filter(explode("\n", $output), function ($output) {
+                return ! empty($output) && ! str_starts_with($output, 'Deprecated:');
+            });
+
+            $output = implode('', $output);
+        }
+
+        $this->assertSame($basePath, $output);
     }
 
     /**


### PR DESCRIPTION
This pull request adds partial PHP 8.1 support to Octane.

Swoole, and features that depend on Swoole were not tested, as Swoole does not support PHP 8.1 yet. That's why I've added "partial" to the pull request title.

@driesvints Don't consider this task done, once this pull request is merged, as we still need to test Octane with Swoole and its related features.