### PR TITLE
Since 4.1.7, swoole is called openswoole

### DIFF
--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -13,7 +13,7 @@ class SwooleExtension
      */
     public function isInstalled(): bool
     {
-        return extension_loaded('swoole');
+        return extension_loaded('swoole') || extension_loaded('openswoole');
     }
 
     /**


### PR DESCRIPTION
Since 4.1.7, swoole is called openswoole