### PR TITLE
Fix undefined array key "type" on empty array dump

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -226,7 +226,7 @@ trait InteractsWithIO
      */
     public function handleStream($stream, $verbosity = null)
     {
-        match ($type ?? null) {
+        match ($stream['type'] ?? null) {
             'request' => $this->requestInfo($stream, $verbosity),
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -226,7 +226,9 @@ trait InteractsWithIO
      */
     public function handleStream($stream, $verbosity = null)
     {
-        match ($stream['type']) {
+        $type = (isset($stream['type'])) ? $stream['type'] : null;
+
+        match ($type) {
             'request' => $this->requestInfo($stream, $verbosity),
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -226,9 +226,7 @@ trait InteractsWithIO
      */
     public function handleStream($stream, $verbosity = null)
     {
-        $type = (isset($stream['type'])) ? $stream['type'] : null;
-
-        match ($type) {
+        match ($type ?? null) {
             'request' => $this->requestInfo($stream, $verbosity),
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),


### PR DESCRIPTION
This PR fixes an edge case where the stream type is undefined when using the `dump` function, with an empty array.

For example

This works without problems
```php
    public function foo()
    {
       // ...do something

        dump(['foo'=>'bar']);
    }
```

But this crashed the swoole server
```php
    public function foo()
    {
       // ...do something

        dump([]);
    }
```

With the followring error:
```

   ErrorException 

  Undefined array key "type"

  at vendor/laravel/octane/src/Commands/Concerns/InteractsWithIO.php:231
    227▕     public function handleStream($stream, $verbosity = null)
    228▕     {
    229▕       
    230▕ 
  ➜ 231▕         match ($stream['type']) {
    232▕             'request' => $this->requestInfo($stream, $verbosity),
    233▕             'throwable' => $this->throwableInfo($stream, $verbosity),
    234▕             'shutdown' => $this->shutdownInfo($stream, $verbosity),
    235▕             default => $this->info(json_encode($stream, $verbosity))

      +31 vendor frames 
  32  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

* PHP Version: 8.1
* Laravel Framework v8.68.1
* Octane v1.0.16