### PR TITLE
[1.x] Fixes memory leak on Translator implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.62",
+        "laravel/framework": "^8.70",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -48,6 +48,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\FlushDatabaseQueryLog::class,
             \Laravel\Octane\Listeners\FlushLogContext::class,
             \Laravel\Octane\Listeners\FlushArrayCache::class,
+            \Laravel\Octane\Listeners\FlushTranslatorCache::class,
 
             // First-Party Packages...
             \Laravel\Octane\Listeners\PrepareInertiaForNextOperation::class,

--- a/src/Listeners/FlushTranslatorCache.php
+++ b/src/Listeners/FlushTranslatorCache.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Support\NamespacedItemResolver;
+
+class FlushTranslatorCache
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        if (! $event->sandbox->resolved('translator')) {
+            return;
+        }
+
+        $translator = $event->sandbox->make('translator');
+
+        if ($translator instanceof NamespacedItemResolver) {
+            $translator->flushParsedKeys();
+        }
+    }
+}

--- a/tests/Listeners/FlushTranslatorCacheTest.php
+++ b/tests/Listeners/FlushTranslatorCacheTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Translation\Translator;
+use Laravel\Octane\Tests\TestCase;
+use Mockery;
+use Illuminate\Http\Request;
+
+class FlushTranslatorCacheTest extends TestCase
+{
+    /** @doesNotPerformAssertions */
+    public function test_parsed_keys_cache_is_flushed()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/test-translator', 'GET'),
+            Request::create('/test-translator', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/test-cache', function () {
+            Validator::make($data, [
+                'name' => 'string|max:50',
+            ])->validate();
+        });
+
+        $translator = $app['translator'];
+
+        $app['translator'] = tap(Mockery::mock($translator), function ($translator) {
+            $translator->shouldReceive('flushParsedKeys')->twice();
+        });
+
+        $worker->run();
+    }
+}

--- a/tests/Listeners/FlushTranslatorCacheTest.php
+++ b/tests/Listeners/FlushTranslatorCacheTest.php
@@ -2,10 +2,9 @@
 
 namespace Laravel\Octane\Listeners;
 
-use Illuminate\Translation\Translator;
+use Illuminate\Http\Request;
 use Laravel\Octane\Tests\TestCase;
 use Mockery;
-use Illuminate\Http\Request;
 
 class FlushTranslatorCacheTest extends TestCase
 {


### PR DESCRIPTION
This pull request fixes a memory leak on the `Translator` implementation where the `parsed` translation keys cache was not being "flush" on each request.

Fixes https://github.com/laravel/octane/issues/415.

- [x] Waiting for https://github.com/laravel/framework/pull/39490.
- [x] Update framework version on `composer.json` file.