### PR TITLE
[1.x] Fixes server shutting down on concurrently when exceptions are reported at root level of the task

### DIFF
--- a/src/Exceptions/TaskExceptionResult.php
+++ b/src/Exceptions/TaskExceptionResult.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Octane\Exceptions;
 
+use Laravel\SerializableClosure\Support\ClosureStream;
+
 class TaskExceptionResult
 {
     public function __construct(
@@ -21,7 +23,7 @@ class TaskExceptionResult
      */
     public static function from($throwable)
     {
-        $fallbackTrace = str_starts_with($throwable->getFile(), 'closure://')
+        $fallbackTrace = str_starts_with($throwable->getFile(), ClosureStream::STREAM_PROTO.'://')
             ? collect($throwable->getTrace())->whereNotNull('file')->first()
             : null;
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane;
 
+use Laravel\SerializableClosure\Support\ClosureStream;
 use Throwable;
 
 class Stream
@@ -35,7 +36,7 @@ class Stream
      */
     public static function throwable(Throwable $throwable)
     {
-        $fallbackTrace = str_starts_with($throwable->getFile(), 'closure://')
+        $fallbackTrace = str_starts_with($throwable->getFile(), ClosureStream::STREAM_PROTO.'://')
             ? collect($throwable->getTrace())->whereNotNull('file')->first()
             : null;
 


### PR DESCRIPTION
This pull request fixes an issue introduced when migrating to https://github.com/laravel/serializable-closure, where errors reported from concurrently ( at the root level of the task ) were causing the server to shutdown.

Fixes #418 