### PR TITLE
Added default values for RoadRunner and Swoole to the config file

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -49,7 +49,7 @@ return [
     */
 
     'roadrunner' => [
-        'http_middleware' => 'static'
+        'http_middleware' => 'static',
     ],
 
     /*
@@ -60,7 +60,7 @@ return [
 
     'swoole' => [
         'ssl' => false,
-        'options' => []
+        'options' => [],
     ],
 
     /*

--- a/config/octane.php
+++ b/config/octane.php
@@ -39,6 +39,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | RoadRunner Defaults
+    |--------------------------------------------------------------------------
+    | RoadRunner HTTP server uses default Golang middleware model which allows
+    | you to extend it using custom or community-driven middleware.
+    |
+    | The basic package includes: "static", "gzip", "headers"
+    |
+    */
+
+    'roadrunner' => [
+        'http_middleware' => 'static'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Swoole Defaults
+    |--------------------------------------------------------------------------
+    */
+
+    'swoole' => [
+        'ssl' => false,
+        'options' => []
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Force HTTPS
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
`config('octane.roadrunner.http_middleware')` is used in the file:
`vendor/laravel/octane/src/Commands/StartRoadRunnerCommand.php` on line 86

`config('octane.swoole.ssl')` is used in the files:
`vendor/laravel/octane/src/Commands/StartSwooleCommand.php` on line 69
`vendor/laravel/octane/bin/createSwooleServer.php` on line 10

`config('octane.swoole.options')` is used in the file:
`vendor/laravel/octane/bin/createSwooleServer.php` on line 22