### PR TITLE
[1.x] Updates `octane:install` command when Swoole extension is missing

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -109,9 +109,7 @@ class InstallCommand extends Command
     public function installSwooleServer()
     {
         if (! resolve(SwooleExtension::class)->isInstalled()) {
-            $this->error('The Swoole extension is missing.');
-
-            return false;
+            $this->warn('The Swoole extension is missing.');
         }
 
         return true;


### PR DESCRIPTION
This pull request updates `octane:install` command when Swoole extension is missing. 

With this pull request, if the extension is missing, we display a warning saying that the extension is missing, yet the installation proceeds by adding the necessary environment variable the `.env` file. This is necessary as people usually, install Octane in their OS, but run Octane in their Sail environment.

<img width="746" alt="Screenshot 2021-11-26 at 17 01 10" src="https://user-images.githubusercontent.com/5457236/143612903-341eb2cc-68a6-4532-8450-99565063906e.png">
g 