### PR TITLE
[1.x] Fixes Octane's process output not being flushed

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -107,7 +107,7 @@ trait InteractsWithServers
     }
 
     /**
-     * Gets the given server output, and flushes it.
+     * Retrieve the given server output and flush it.
      *
      * @return array
      */

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -107,6 +107,19 @@ trait InteractsWithServers
     }
 
     /**
+     * Gets the given server output, and flushes it.
+     *
+     * @return array
+     */
+    protected function getServerOutput($server)
+    {
+        return tap([
+            $server->getIncrementalOutput(),
+            $server->getIncrementalErrorOutput(),
+        ], fn () => $server->clearOutput()->clearErrorOutput());
+    }
+
+    /**
      * Returns the list of signals to subscribe.
      *
      * @return array

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -182,7 +182,9 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     protected function writeServerOutput($server)
     {
-        Str::of($server->getIncrementalOutput())
+        [$output, $errorOutput] = $this->getServerOutput($server);
+
+        Str::of($output)
             ->explode("\n")
             ->filter()
             ->each(function ($output) {
@@ -210,7 +212,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                 }
             });
 
-        Str::of($server->getIncrementalErrorOutput())
+        Str::of($errorOutput)
             ->explode("\n")
             ->filter()
             ->each(function ($output) {

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -170,7 +170,9 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
      */
     protected function writeServerOutput($server)
     {
-        Str::of($server->getIncrementalOutput())
+        [$output, $errorOutput] = $this->getServerOutput($server);
+
+        Str::of($output)
             ->explode("\n")
             ->filter()
             ->each(fn ($output) => is_array($stream = json_decode($output, true))
@@ -178,7 +180,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                 : $this->info($output)
             );
 
-        Str::of($server->getIncrementalErrorOutput())
+        Str::of($errorOutput)
             ->explode("\n")
             ->filter()
             ->groupBy(fn ($output) => $output)


### PR DESCRIPTION
This pull request fixes an edge case where the temporary file created by Octane's Symfony process for the process's output, may take a considerable disk space, if the process is running for too long. In addition, we don't really need that full output, as we already use it the `getIncrementalOutput` for getting incrementally the output.

So, the solution in this pull request is simple, we just clear the output - the temporary file - every time we grab information from the output.

Closes https://github.com/laravel/octane/issues/426