### PR TITLE
[1.x] Skip tests on Open Swoole that require mocking Open Swoole's Response class

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,3 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
-        continue-on-error: ${{ matrix.php > 8 && matrix.driver == 'swoole' }}

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -146,6 +146,10 @@ class SwooleClientTest extends TestCase
     {
         $client = new SwooleClient;
 
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
+
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
@@ -164,6 +168,10 @@ class SwooleClientTest extends TestCase
     public function test_respond_method_send_streamed_response_to_swoole()
     {
         $client = new SwooleClient;
+
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
@@ -186,6 +194,10 @@ class SwooleClientTest extends TestCase
     {
         $client = new SwooleClient;
 
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
+
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(419, 'Page Expired');
@@ -205,6 +217,10 @@ class SwooleClientTest extends TestCase
     {
         $client = new SwooleClient;
 
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
+
         $swooleResponse = Mockery::spy('Swoole\Http\Response');
 
         $app = $this->createApplication();
@@ -222,6 +238,10 @@ class SwooleClientTest extends TestCase
     public function test_error_method_sends_detailed_error_response_to_swoole_in_debug_mode()
     {
         $client = new SwooleClient;
+
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
 
         $swooleResponse = Mockery::spy('Swoole\Http\Response');
 


### PR DESCRIPTION
This pull request fixes the Octane's test suite by skipping tests - regarding Open Swoole workflow - that require to mock Open Swoole's Response class. The issue relies on mockery or phpunit not being able to mock that Open Swoole's Response class because of some weird `eval` error that tries to declare a function like so: `public function header(): false;`.

In addition, this pull request also removes the "continue-on-error" that we have added for Swoole with PHP 8.1.