### PR TITLE
add Swoole runtime hook flags config

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -13,7 +13,7 @@ try {
             ? SWOOLE_SOCK_TCP | SWOOLE_SSL
             : SWOOLE_SOCK_TCP,
     );
-    Coroutine::set(['hook_flags' => $config['swoole']['hooks'] ?? []]);
+    Coroutine::set(['hook_flags' => $config['swoole']['hooks'] ?? 0]);
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);
 

--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -1,5 +1,7 @@
 <?php
 
+use Swoole\Coroutine;
+
 $config = $serverState['octaneConfig'];
 
 try {
@@ -11,6 +13,7 @@ try {
             ? SWOOLE_SOCK_TCP | SWOOLE_SSL
             : SWOOLE_SOCK_TCP,
     );
+    Coroutine::set(['hook_flags' => $config['swoole']['hooks'] ?? []]);
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);
 


### PR DESCRIPTION
This PR aims to add  [Swoole runtime hook flags](https://www.swoole.co.uk/docs/modules/swoole-runtime-flags) to `octane.php` config file.