### PR TITLE
[1.x] Add new option that strict raw server output for swoole.

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -22,7 +22,8 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--raw-server-output : Only use raw format for server output}';
 
     /**
      * The command's description.
@@ -61,6 +62,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
+            '--raw-server-output' => $this->option('raw-server-output'),
         ]);
     }
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -23,7 +23,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--raw-server-output : Only use raw format for server output}';
+                    {--log-format=default : Server log format, One of: default|raw}';
 
     /**
      * The command's description.
@@ -62,7 +62,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
-            '--raw-server-output' => $this->option('raw-server-output'),
+            '--log-format' => $this->option('log-format'),
         ]);
     }
 
@@ -81,6 +81,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--rr-config' => $this->option('rr-config'),
             '--watch' => $this->option('watch'),
+            '--log-format' => $this->option('log-format'),
         ]);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request addresses #341 for the swoole part. And this introduce the new option - `raw-server-output` to make sure we only use raw format for method `writeServerOutput` in `StartSwooleCommand`