### PR TITLE
[1.x] Adds `json` log formatter

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use Illuminate\Support\Str;
+use Laravel\Octane\Commands\Command;
 use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Exceptions\ServerShutdownException;
 use Laravel\Octane\Exceptions\WorkerException;
@@ -119,7 +120,7 @@ trait InteractsWithIO
         $duration = number_format(round($request['duration'], 2), 2, '.', '');
 
         $memory = isset($request['memory'])
-            ? number_format($request['memory'] / 1024 / 1204, 2, '.', '')
+            ? (number_format($request['memory'] / 1024 / 1204, 2, '.', '').' mb ')
             : '';
 
         ['method' => $method, 'statusCode' => $statusCode] = $request;
@@ -153,7 +154,7 @@ trait InteractsWithIO
                $method,
                $url,
                $dots,
-               empty($memory) ? $memory : ($memory.' mb '),
+               $memory,
                $duration,
             ), $this->parseVerbosity($verbosity)),
         };

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -3,7 +3,6 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use Illuminate\Support\Str;
-use Laravel\Octane\Commands\Command;
 use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Exceptions\ServerShutdownException;
 use Laravel\Octane\Exceptions\WorkerException;

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -23,7 +23,9 @@ trait InteractsWithServers
             sleep(1);
         }
 
-        $this->writeServerRunningMessage();
+        if (is_null($this->logFormat())) {
+            $this->writeServerRunningMessage();
+        }
 
         $watcher = $this->startServerWatcher();
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -22,7 +22,8 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--log-format=default : Server log format, One of: default|json}';
 
     /**
      * The command's description.
@@ -61,6 +62,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
+            '--log-format' => $this->option('log-format'),
         ]);
     }
 
@@ -79,6 +81,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--rr-config' => $this->option('rr-config'),
             '--watch' => $this->option('watch'),
+            '--log-format' => $this->option('log-format'),
         ]);
     }
 

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -28,7 +28,8 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--log-format=default : Server log format, One of: default|json}';
 
     /**
      * The command's description.

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -25,7 +25,8 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--log-format=default : Server log format, One of: default|json}';
 
     /**
      * The command's description.

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\Commands\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class CommandTest extends TestCase
@@ -92,6 +93,7 @@ EOF, $output->fetch());
             {
                 parent::__construct('foo');
 
+                $this->input = new ArrayInput([]);
                 $this->output = $output;
             }
 


### PR DESCRIPTION
This pull request **is a work in progress**, and it adds a `json` log formatter instead of the original `raw` proposed one. It also simplifies the original pull request a little bit.

@Namoshek , @chris-lee-lb can you let me know if this satisfies the original needs you had? If yes, I will polish this pull request, add tests, etc.

<img width="513" alt="Screenshot 2021-12-14 at 11 08 03" src="https://user-images.githubusercontent.com/5457236/146035311-0236e3c1-6096-42e6-b92a-86dde1b24043.png">
.