### PR TITLE
[1.x] Fixes `call terminate() on null` when worker is not booted

### DIFF
--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -58,4 +58,6 @@ while ($psr7Request = $psr7Client->waitRequest()) {
     $worker->handle($request, $context);
 }
 
-$worker->terminate();
+if (! is_null($worker)) {
+    $worker->terminate();
+}


### PR DESCRIPTION
When using Roadrunner, users may use `http.pool.supervisor.ttl` configuration option to restart workers every X seconds.

This pull request fixes an issue when workers are being restarted without ever been booted - this happens a worker receives 0 requests.

Fixes #443