### PR TITLE
[1.x] Adds support for RoadRunner `v2.6.x`

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -21,7 +21,7 @@ trait InstallsRoadRunnerDependencies
      *
      * @var string
      */
-    protected $requiredVersion = '2.1.1';
+    protected $requiredVersion = '2.6.6';
 
     /**
      * Determine if RoadRunner is installed.

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -24,8 +24,10 @@ trait InteractsWithIO
         'scan command',
         'stop signal received, grace timeout is: ',
         'exit forced',
+        'worker allocated',
         'worker constructed',
         'worker destructed',
+        '[INFO] RoadRunner server started; version:',
     ];
 
     /**

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -200,14 +200,22 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     return $this->raw($debug['msg']);
                 }
 
-                if ($debug['level'] == 'debug' && isset($debug['remote'])) {
-                    [$statusCode, $method, $url] = explode(' ', $debug['msg']);
+                if ($debug['level'] == 'info'
+                    && isset($debug['remote_address'])
+                    && isset($debug['msg'])
+                    && $debug['msg'] == 'http log') {
+                    [
+                        'elapsed' => $elapsed,
+                        'method' => $method,
+                        'status' => $statusCode,
+                        'URI' => $url,
+                    ] = $debug;
 
                     return $this->requestInfo([
                         'method' => $method,
                         'url' => $url,
                         'statusCode' => $statusCode,
-                        'duration' => $this->calculateElapsedTime($debug['elapsed']),
+                        'duration' => $this->calculateElapsedTime($elapsed),
                     ]);
                 }
             });


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/octane/issues/448, by fixing the non-displayable HTTP request logs, and fixing the display of some messages such as "worked allocated" or "Server started",  since RoadRunner RoadRunner `v2.6.x`:

<img width="507" alt="Screenshot 2021-12-17 at 17 08 11" src="https://user-images.githubusercontent.com/5457236/146787853-acfffe20-3c35-45db-9ac1-ef8d5b3a2209.png">


The underlying issue relies on the fact that RoadRunner now logs HTTP requests a little bit differently, and this pull request accommodates those changes.

Because this pull request makes Octane require RoadRunner `^2.6.0`, I've also changed the `requiredVersion` constant. No worries, the current code still compatible with older versions, but HTTP logs won't be printed on development. 