### PR TITLE
Fix type declaration error of Swoole table

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Show extension info
+        run: |
+          php --ri ${{ matrix.driver }}
+
       - name: Install dependencies
         run: |
           composer require laravel/framework:"^8.35" --no-update

--- a/src/Tables/SwooleTable.php
+++ b/src/Tables/SwooleTable.php
@@ -4,44 +4,88 @@ namespace Laravel\Octane\Tables;
 
 use Swoole\Table;
 
-class SwooleTable extends Table
-{
-    use Concerns\EnsuresColumnSizes;
-
-    /**
-     * The table columns.
-     *
-     * @var array
-     */
-    protected $columns;
-
-    /**
-     * Set the data type and size of the columns.
-     *
-     * @param  string  $name
-     * @param  int  $type
-     * @param  int  $size
-     * @return void
-     */
-    public function column($name, $type, $size = 0)
+if (SWOOLE_VERSION_ID === 40804 || SWOOLE_VERSION_ID >= 50000) {
+    class SwooleTable extends Table
     {
-        $this->columns[$name] = [$type, $size];
+        use Concerns\EnsuresColumnSizes;
 
-        parent::column($name, $type, $size);
+        /**
+         * The table columns.
+         *
+         * @var array
+         */
+        protected $columns;
+
+        /**
+         * Set the data type and size of the columns.
+         *
+         * @param  string  $name
+         * @param  int  $type
+         * @param  int  $size
+         * @return bool
+         */
+        public function column(string $name, int $type, int $size = 0): bool
+        {
+            $this->columns[$name] = [$type, $size];
+
+            return parent::column($name, $type, $size);
+        }
+
+        /**
+         * Update a row of the table.
+         *
+         * @param  string  $key
+         * @param  array  $values
+         * @return bool
+         */
+        public function set(string $key, array $values): bool
+        {
+            collect($values)
+                ->each($this->ensureColumnsSize());
+
+            return parent::set($key, $values);
+        }
     }
-
-    /**
-     * Update a row of the table.
-     *
-     * @param  string  $key
-     * @param  array  $values
-     * @return void
-     */
-    public function set($key, array $values)
+} else {
+    class SwooleTable extends Table
     {
-        collect($values)
-            ->each($this->ensureColumnsSize());
+        use Concerns\EnsuresColumnSizes;
 
-        parent::set($key, $values);
+        /**
+         * The table columns.
+         *
+         * @var array
+         */
+        protected $columns;
+
+        /**
+         * Set the data type and size of the columns.
+         *
+         * @param  string  $name
+         * @param  int  $type
+         * @param  int  $size
+         * @return void
+         */
+        public function column($name, $type, $size = 0)
+        {
+            $this->columns[$name] = [$type, $size];
+
+            parent::column($name, $type, $size);
+        }
+
+        /**
+         * Update a row of the table.
+         *
+         * @param  string  $key
+         * @param  array  $values
+         * @return void
+         */
+        public function set($key, array $values)
+        {
+            collect($values)
+                ->each($this->ensureColumnsSize());
+
+            parent::set($key, $values);
+        }
     }
 }


### PR DESCRIPTION
Fix #446

Although Swoole has been fixed, a compatibility needs to be done.

Also type declaration will be added in the [v5](https://github.com/swoole/swoole-src/commit/6da32cf3d64f743b87bd2d4c8025876bfa10c9a9) version.