### PR TITLE
[fix] Too many aborted client connections

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -101,7 +101,7 @@ return [
 
         OperationTerminated::class => [
             FlushTemporaryContainerInstances::class,
-            // DisconnectFromDatabases::class,
+            DisconnectFromDatabases::class,
             // CollectGarbage::class,
         ],
 


### PR DESCRIPTION
- Octane Version: 1.1.2
- Laravel Version: 8.77.1
- PHP Version: 8.1.0
- Server & Version: Swoole 4.8.5
- Database Driver & Version: MariaDB 10.4

### Description:
The server status variables in a PHPMyAdmin that is connected to a MariaDB, show there are many aborted client connections. It seems Octane does not close the database connection correctly. 

![chrome_gWdFXoR3Nv](https://user-images.githubusercontent.com/47121888/148285715-a89a3212-4619-4b20-9f1c-66f0ff6752df.png)

Also, this leads to `Too many connections` or `MySQL has gone away` error on machines that have many CPU cores or with databases that have lower max connections config.

There is a `DisconnectFromDatabases::class` listener in `octane.php` that is commented by default. IMO, It should be uncommented to solve these problems.
