### PR TITLE
Give the current App instance to FilesystemManager 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.70",
+        "laravel/framework": "^8.77",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -36,6 +36,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToBroadcastManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToDatabaseManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToDatabaseSessionHandler::class,
+            \Laravel\Octane\Listeners\GiveNewApplicationInstanceToFilesystemManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToHttpKernel::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToMailManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToNotificationChannelManager::class,

--- a/src/Listeners/GiveNewApplicationInstanceToFilesystemManager.php
+++ b/src/Listeners/GiveNewApplicationInstanceToFilesystemManager.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class GiveNewApplicationInstanceToFilesystemManager
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('filesystem')) {
+            return;
+        }
+
+        with($event->sandbox->make('filesystem'), function ($manager) use ($event) {
+            $manager->setApplication($event->sandbox);
+        });
+    }
+}

--- a/tests/FilesystemManagerStateTest.php
+++ b/tests/FilesystemManagerStateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use ReflectionProperty;
+
+class FilesystemManagerStateTest extends TestCase
+{
+    public function test_filesystem_manager_has_fresh_application_instance()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+        ]);
+
+        $filesystemManagerApplication = new ReflectionProperty($app['filesystem'], 'app');
+
+        $app['router']->get('/first', function (Application $app) use ($filesystemManagerApplication) {
+            return spl_object_hash($filesystemManagerApplication->getValue($app['filesystem']));
+        });
+
+        $worker->run();
+
+        $this->assertNotEquals($client->responses[0]->original, $client->responses[1]->original);
+    }
+}


### PR DESCRIPTION
`FilesystemManager` and its custom/extended drivers rely on the `$filesystemManager->app` instance to provide the app config. If the config changes at runtime (e.g. multi-tenancy environment or via a package service provider) the `FilesystemManager` keeps using the old application instance and the wrong config values.

This PR uses https://github.com/laravel/framework/pull/40058 to fix this issue. A test is included and the `laravel/framework` version is bumped to make sure the `FilesystemManager::setApplication()` method from the aforementioned PR is always available.