### PR TITLE
[1.x] Flush monolog state between requests

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -49,6 +49,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\FlushDatabaseQueryLog::class,
             \Laravel\Octane\Listeners\FlushLogContext::class,
             \Laravel\Octane\Listeners\FlushArrayCache::class,
+            \Laravel\Octane\Listeners\FlushMonologState::class,
             \Laravel\Octane\Listeners\FlushTranslatorCache::class,
 
             // First-Party Packages...

--- a/src/Listeners/FlushMonologState.php
+++ b/src/Listeners/FlushMonologState.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Monolog\ResettableInterface;
+
+class FlushMonologState
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('log')) {
+            return;
+        }
+
+        collect($event->sandbox->make('log')->getChannels())
+            ->map->getLogger()
+            ->filter(function ($logger) {
+                return $logger instanceof ResettableInterface;
+            })->each->reset();
+    }
+}

--- a/tests/Listeners/FlushMonologStateTest.php
+++ b/tests/Listeners/FlushMonologStateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Illuminate\Log\Logger;
+use Laravel\Octane\Tests\TestCase;
+use Mockery;
+use Monolog;
+
+class FlushMonologStateTest extends TestCase
+{
+    /** @doesNotPerformAssertions */
+    public function test_logger_are_reset()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+            Request::create('/', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/', function () {
+            // ..
+        });
+
+        $log = $app['log'];
+
+        $app['log'] = tap(Mockery::mock($log), function ($logger) {
+            $logger->shouldReceive('getChannels')->twice()->andReturn([
+                tap(Mockery::mock(Logger::class), function ($logger) {
+                    $logger->shouldReceive('getLogger')->twice()->andReturn(
+                        tap(Mockery::mock(Monolog\Logger::class), function ($logger) {
+                            $logger->shouldReceive('reset')->twice();
+                        }),
+                    );
+                }),
+            ]);
+        });
+
+        $worker->run();
+    }
+}


### PR DESCRIPTION
This pull request ensures the monolog state - handlers and processors - are reset between requests.

An example is on the usage of `FingersCrossedHandler`. Previously, when using the `FingersCrossedHandler`, the following requests printed two logs:

```php
Route::get('/info', fn () => info('info'));
Route::get('/critical', fn () => logger()->critical('critical'));

// 2 requests...
GET /info
GET /critical

// laravel.log (Assuming an `'action_level' => 'critical'`)
line 1: info
line 2: critical
```

Now, because the `FingersCrossedHandler` is flushed between requests, the output is:
```php
// 2 requests...
GET /info
GET /critical

// laravel.log (Assuming an `'action_level' => 'critical'`)
line 1: critical
```
