### PR TITLE
[1.x] Allow users to access $server with in Controller

### DIFF
--- a/bin/WorkerState.php
+++ b/bin/WorkerState.php
@@ -4,6 +4,7 @@ namespace Laravel\Octane\Swoole;
 
 class WorkerState
 {
+    public $server;
     public $workerId;
     public $workerPid;
     public $worker;

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -31,6 +31,7 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
+        $this->workerState->server = $server;
         $this->workerState->workerId = $workerId;
         $this->workerState->workerPid = posix_getpid();
         $this->workerState->worker = $this->bootWorker($server);


### PR DESCRIPTION
Users will be able to access $server status and methods like [app(WorkerState::class)->server->stats()](https://openswoole.com/docs/modules/swoole-server-stats) within the application.
