### PR TITLE
[1.x] Flushes `Str` cache between requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.77|^9.0",
+        "laravel/framework": "^8.81|^9.0",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -50,6 +50,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\FlushLogContext::class,
             \Laravel\Octane\Listeners\FlushArrayCache::class,
             \Laravel\Octane\Listeners\FlushMonologState::class,
+            \Laravel\Octane\Listeners\FlushStrCache::class,
             \Laravel\Octane\Listeners\FlushTranslatorCache::class,
 
             // First-Party Packages...

--- a/src/Listeners/FlushStrCache.php
+++ b/src/Listeners/FlushStrCache.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Support\Str;
+
+class FlushStrCache
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        Str::flushCache();
+    }
+}

--- a/tests/Listeners/FlushStrCacheTest.php
+++ b/tests/Listeners/FlushStrCacheTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Octane\Tests\TestCase;
+use ReflectionClass;
+
+class FlushStrCacheTest extends TestCase
+{
+    public function test_str_is_flushed()
+    {
+        Str::flushCache();
+
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/test-str-cache', 'GET'),
+            Request::create('/', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/', function () {
+            return 'Hello World';
+        });
+
+        $app['router']->middleware('web')->get('/test-str-cache', function () {
+            return Str::snake('Taylor Otwell');
+        });
+
+        $reflection = new ReflectionClass(Str::class);
+        $property = $reflection->getProperty('snakeCache');
+        $property->setAccessible(true);
+
+        $this->assertEmpty($property->getValue());
+
+        $worker->run();
+
+        $this->assertEmpty($property->getValue());
+    }
+}


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/octane/issues/466, by flushing the `Str` between requests.