### PR TITLE
[1.x] Fix passing null to cookie for domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, ${{ matrix.driver }}
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -192,10 +192,10 @@ class SwooleClient implements Client, ServesStaticFiles
                 $cookie->getValue(),
                 $cookie->getExpiresTime(),
                 $cookie->getPath(),
-                $cookie->getDomain(),
+                $cookie->getDomain() ?? '',
                 $cookie->isSecure(),
                 $cookie->isHttpOnly(),
-                $cookie->getSameSite()
+                $cookie->getSameSite(),
             );
         }
     }


### PR DESCRIPTION
This PR enables deprecation throwing and fixes an issue with passing `null` for the `$domain` parameter for a cookie which isn't allowed anymore.

Fixes https://github.com/laravel/telescope/issues/1189