### PR TITLE
Fix Roadrunner 2.8.0 requires version 2.7+ in .rr.yaml file

### DIFF
--- a/src/Commands/stubs/rr.yaml
+++ b/src/Commands/stubs/rr.yaml
@@ -1,0 +1,2 @@
+# RR configuration version
+version: "2.7"


### PR DESCRIPTION
Add the version to the .rr.yaml stub.

so that it can be used if the RoadRunner binary is not found and reinstalled.

Fix #479 