### PR TITLE
[1.x] Fixes missing `version` option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nunomaduro/collision": "^5.10|^6.0",
         "orchestra/testbench": "^6.16|^7.0",
         "phpunit/phpunit": "^9.3",
-        "spiral/roadrunner": "^2.0"
+        "spiral/roadrunner": "^2.8.2"
     },
     "bin": [
         "bin/roadrunner-worker",

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -21,7 +21,7 @@ trait InstallsRoadRunnerDependencies
      *
      * @var string
      */
-    protected $requiredVersion = '2.6.6';
+    protected $requiredVersion = '2.8.2';
 
     /**
      * Determine if RoadRunner is installed.
@@ -44,13 +44,13 @@ trait InstallsRoadRunnerDependencies
             return true;
         }
 
-        if (! $this->confirm('Octane requires "spiral/roadrunner:^2.0". Do you wish to install it as a dependency?')) {
+        if (! $this->confirm('Octane requires "spiral/roadrunner:^2.8.2". Do you wish to install it as a dependency?')) {
             $this->error('Octane requires "spiral/roadrunner".');
 
             return false;
         }
 
-        $command = $this->findComposer().' require spiral/roadrunner:^2.0 --with-all-dependencies';
+        $command = $this->findComposer().' require spiral/roadrunner:^2.8.2 --with-all-dependencies';
 
         $process = Process::fromShellCommandline($command, null, null, null, null);
 

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -25,6 +25,7 @@ trait InteractsWithIO
         'stop signal received, grace timeout is: ',
         'exit forced',
         'worker allocated',
+        'worker is allocated',
         'worker constructed',
         'worker destructed',
         '[INFO] RoadRunner server started; version:',

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -76,6 +76,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         $server = tap(new Process(array_filter([
             $roadRunnerBinary,
             '-c', $this->configPath(),
+            '-o', 'version=2.7',
             '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
             '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path('vendor/bin/roadrunner-worker'),
             '-o', 'http.pool.num_workers='.$this->workerCount(),


### PR DESCRIPTION
Since RoadRunner [v2.8.0](https://github.com/roadrunner-server/roadrunner/releases/tag/v2.8.0), it's necessary to add the `version: 2.7` instruction on the `.rr.yaml` file.

This pull request makes this change easy to Octane developers, by setting `version: 2.7` automatically, and forcing them to use the latest version of the binary.

Waiting for: https://github.com/roadrunner-server/roadrunner/issues/1021.
Fixes: https://github.com/laravel/octane/issues/479.