### PR TITLE
[1.x] Fixes `--watch` files over a network

### DIFF
--- a/bin/file-watcher.js
+++ b/bin/file-watcher.js
@@ -4,6 +4,7 @@ const paths = JSON.parse(process.argv[2]);
 
 const watcher = chokidar.watch(paths, {
     ignoreInitial: true,
+    usePolling: true,
 });
 
 watcher

--- a/bin/file-watcher.js
+++ b/bin/file-watcher.js
@@ -1,7 +1,7 @@
 const chokidar = require('chokidar');
 
 const paths = JSON.parse(process.argv[2]);
-const poll = process.argv[3] ? true : false
+const poll = process.argv[3] ? true : false;
 
 const watcher = chokidar.watch(paths, {
     ignoreInitial: true,

--- a/bin/file-watcher.js
+++ b/bin/file-watcher.js
@@ -1,10 +1,11 @@
 const chokidar = require('chokidar');
 
 const paths = JSON.parse(process.argv[2]);
+const poll = process.argv[3] ? true : false
 
 const watcher = chokidar.watch(paths, {
     ignoreInitial: true,
-    usePolling: true,
+    usePolling: poll,
 });
 
 watcher

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -85,7 +85,7 @@ trait InteractsWithServers
             (new ExecutableFinder)->find('node'),
             'file-watcher.js',
             json_encode(collect(config('octane.watch'))->map(fn ($path) => base_path($path))),
-            $this->option('poll')
+            $this->option('poll'),
         ], realpath(__DIR__.'/../../../bin'), null, null, null))->start();
     }
 

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -85,6 +85,7 @@ trait InteractsWithServers
             (new ExecutableFinder)->find('node'),
             'file-watcher.js',
             json_encode(collect(config('octane.watch'))->map(fn ($path) => base_path($path))),
+            $this->option('poll')
         ], realpath(__DIR__.'/../../../bin'), null, null, null))->start();
     }
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -23,7 +23,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Necessary to successfully watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}';
 
     /**
      * The command's description.

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -22,7 +22,8 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--poll : Necessary to successfully watch files over a network}';
 
     /**
      * The command's description.
@@ -61,6 +62,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
+            '--poll' => $this->option('poll'),
         ]);
     }
 
@@ -79,6 +81,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--rr-config' => $this->option('rr-config'),
             '--watch' => $this->option('watch'),
+            '--poll' => $this->option('poll'),
         ]);
     }
 

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -28,7 +28,8 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--poll : Necessary to successfully watch files over a network}';
 
     /**
      * The command's description.

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -29,7 +29,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Necessary to successfully watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}';
 
     /**
      * The command's description.

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -26,7 +26,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Necessary to successfully watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}';
 
     /**
      * The command's description.

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -25,7 +25,8 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
-                    {--watch : Automatically reload the server when the application is modified}';
+                    {--watch : Automatically reload the server when the application is modified}
+                    {--poll : Necessary to successfully watch files over a network}';
 
     /**
      * The command's description.


### PR DESCRIPTION
This pull request fixes `--watch` files over a network: typically environments such as Laravel Sail, or Windows environments. 

Looking at the documentation, this may increase the CPU usage: https://github.com/paulmillr/chokidar. So, lets stay vigilant to see if someone complains about this change. 

Fixes #487 