### PR TITLE
Optimize PHP8.1 compatibility

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -195,7 +195,7 @@ class SwooleClient implements Client, ServesStaticFiles
                 $cookie->getDomain() ?? '',
                 $cookie->isSecure(),
                 $cookie->isHttpOnly(),
-                $cookie->getSameSite(),
+                $cookie->getSameSite() ?? '',
             );
         }
     }


### PR DESCRIPTION
Fix #498 
```
Swoole\Http\Response::cookie(): Passing null to parameter #8 ($samesite) of type string is deprecated in /var/www/vendor/laravel/octane/src/Swoole/SwooleClient.php on line 198
```