### PR TITLE
[1.x] Update to new forgetScopedInstances method name

### DIFF
--- a/src/Listeners/FlushTemporaryContainerInstances.php
+++ b/src/Listeners/FlushTemporaryContainerInstances.php
@@ -15,6 +15,10 @@ class FlushTemporaryContainerInstances
         if (method_exists($event->app, 'resetScope')) {
             $event->app->resetScope();
         }
+        
+        if (method_exists($event->app, 'forgetScopedInstances')) {
+            $event->app->forgetScopedInstances();
+        }
 
         foreach ($event->sandbox->make('config')->get('octane.flush', []) as $binding) {
             $event->app->forgetInstance($binding);

--- a/src/Listeners/FlushTemporaryContainerInstances.php
+++ b/src/Listeners/FlushTemporaryContainerInstances.php
@@ -15,7 +15,7 @@ class FlushTemporaryContainerInstances
         if (method_exists($event->app, 'resetScope')) {
             $event->app->resetScope();
         }
-        
+
         if (method_exists($event->app, 'forgetScopedInstances')) {
             $event->app->forgetScopedInstances();
         }


### PR DESCRIPTION
This seems to have been left alone after renaming it in Laravel v9.

See https://github.com/laravel/octane/issues/500