### PR TITLE
Make the bin files used by Swoole and Roadrunner config options

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -79,7 +79,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-c', $this->configPath(),
             '-o', 'version=2.7',
             '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
-            '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path('vendor/bin/roadrunner-worker'),
+            '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path(config('octane.roadrunner.server.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
             '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -79,7 +79,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-c', $this->configPath(),
             '-o', 'version=2.7',
             '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
-            '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path(config('octane.roadrunner.server.command', 'vendor/bin/roadrunner-worker')),
+            '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
             '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -78,7 +78,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         $this->forgetEnvironmentVariables();
 
         $server = tap(new Process([
-            (new PhpExecutableFinder)->find(), 'swoole-server', $serverStateFile->path(),
+            (new PhpExecutableFinder)->find(), config('octane.swoole.command', 'swoole-server'), $serverStateFile->path(),
         ], realpath(__DIR__.'/../../bin'), [
             'APP_ENV' => app()->environment(),
             'APP_BASE_PATH' => base_path(),


### PR DESCRIPTION
Hi,

This is a simple but very helpful change, instead of the bin files used to run the servers being hard coded, they are made configurable.

The reason for doing so is without this developers are forced to extend first the server specific command then the octane:start command if they want to change anything about the boot/worker spawn process.

This is particularly useful for roadrunner if you want to support having roadrunner itself act as a queue consumer as that requires a different setup to PSR7Worker.

The config is defaulted to identical values it had before.

I think the escape hatch it provides is powerful and the increase in maintenance burden is negligible. 



