### PR TITLE
Fix max_execution_time config doesn't work

### DIFF
--- a/bin/createSwooleTimerTable.php
+++ b/bin/createSwooleTimerTable.php
@@ -10,6 +10,7 @@ if (($serverState['octaneConfig']['max_execution_time'] ?? 0) > 0) {
 
     $timerTable->column('worker_pid', Table::TYPE_INT);
     $timerTable->column('time', Table::TYPE_INT);
+    $timerTable->column('fd', Table::TYPE_INT);
 
     $timerTable->create();
 

--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -107,6 +107,7 @@ $server->on('request', function ($request, $response) use ($server, $workerState
         $workerState->timerTable->set($workerState->workerId, [
             'worker_pid' => $workerState->workerPid,
             'time' => time(),
+            'fd' => $request->fd,
         ]);
     }
 

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -29,7 +29,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
-                if (extension_loaded('swoole') && $this->server instanceof Server) {
+                if ($this->server instanceof Server) {
                     $response = Response::create($this->server, $row['fd']);
                     $response->status(408);
                     $response->end();

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -29,7 +29,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
-                if ($this->server instanceof Server && isset($row['fd'])) {
+                if (extension_loaded('swoole') && $this->server instanceof Server && isset($row['fd'])) {
                     $response = Response::create($this->server, $row['fd']);
                     $response->status(408);
                     $response->end();

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -29,7 +29,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
-                if (extension_loaded('swoole') && $this->server instanceof Server && isset($row['fd'])) {
+                if (extension_loaded('swoole') && $this->server instanceof Server) {
                     $response = Response::create($this->server, $row['fd']);
                     $response->status(408);
                     $response->end();

--- a/src/Swoole/Handlers/OnServerStart.php
+++ b/src/Swoole/Handlers/OnServerStart.php
@@ -43,9 +43,9 @@ class OnServerStart
         }
 
         if ($this->maxExecutionTime > 0) {
-            $server->tick(1000, function () {
+            $server->tick(1000, function () use ($server) {
                 (new EnsureRequestsDontExceedMaxExecutionTime(
-                    $this->extension, $this->timerTable, $this->maxExecutionTime
+                    $this->extension, $this->timerTable, $this->maxExecutionTime, $server
                 ))();
             });
         }


### PR DESCRIPTION
Fix #470

Re-create the new Swoole response object to use it to send the response.

![image](https://user-images.githubusercontent.com/33931153/163793641-4be30846-c3b4-4141-9797-a4532c229983.png)