### PR TITLE
test flushing logger shared context

### DIFF
--- a/tests/Listeners/FlushLogContextTest.php
+++ b/tests/Listeners/FlushLogContextTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Listeners;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Log\Logger;
 use Laravel\Octane\Tests\TestCase;
@@ -12,6 +13,10 @@ class FlushLogContextTest extends TestCase
 {
     public function test_shared_context_is_flushed()
     {
+        if (version_compare(Application::VERSION, '9.0.0', '<')) {
+            $this->markTestSkipped('Shared context is only supported in Laravel 9+');
+        }
+
         [$app, $worker, $client] = $this->createOctaneContext([
             Request::create('/', 'GET'),
         ]);

--- a/tests/Listeners/FlushLogContextTest.php
+++ b/tests/Listeners/FlushLogContextTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Illuminate\Log\Logger;
+use Laravel\Octane\Tests\TestCase;
+use Mockery;
+use Monolog;
+
+class FlushLogContextTest extends TestCase
+{
+    public function test_shared_context_is_flushed()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+        ]);
+        $app['router']->middleware('web')->get('/', function () {
+            // ..
+        });
+        $log = $app['log'];
+        $log->shareContext(['shared' => 'context']);
+
+        $this->assertSame(['shared' => 'context'], $log->sharedContext());
+
+        $worker->run();
+
+        $this->assertSame([], $log->sharedContext());
+    }
+}

--- a/tests/Listeners/FlushLogContextTest.php
+++ b/tests/Listeners/FlushLogContextTest.php
@@ -4,10 +4,7 @@ namespace Laravel\Octane\Listeners;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
-use Illuminate\Log\Logger;
 use Laravel\Octane\Tests\TestCase;
-use Mockery;
-use Monolog;
 
 class FlushLogContextTest extends TestCase
 {


### PR DESCRIPTION
Introduces a test for #513. This is in a separate PR so that #513 can be merged without a failing build and this PR can be merged once the two PRs from `laravel/framework` and `laravel/octane` have both been merged and tagged - otherwise we'll have failing CI.