### PR TITLE
Support custom setting swoole event handle

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -2,6 +2,7 @@
 <?php
 
 use Laravel\Octane\RequestContext;
+use Laravel\Octane\Swoole\Handlers\ExtendEvent;
 use Laravel\Octane\Swoole\Handlers\OnManagerStart;
 use Laravel\Octane\Swoole\Handlers\OnServerStart;
 use Laravel\Octane\Swoole\Handlers\OnWorkerStart;
@@ -160,5 +161,20 @@ $server->on('workerstop', function () use ($workerState) {
 
     $workerState->worker->terminate();
 });
+
+/*
+|--------------------------------------------------------------------------
+| Extended Swoole Event.
+|--------------------------------------------------------------------------
+|
+| Extended swoole event function. This will overwrite the previously
+| registered swoole event.
+|
+*/
+
+(fn (Server $server) => $bootstrap($serverState) && (new ExtendEvent(
+        $bootstrap($serverState), $serverState, $workerState
+    ))($server)
+)($server);
 
 $server->start();

--- a/config/octane.php
+++ b/config/octane.php
@@ -218,4 +218,17 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Swoole Event Callbacks.
+    |--------------------------------------------------------------------------
+    |
+    | The following settings are custom swoole event callback processing.
+    | Note that this will override registered event callback.
+    |
+    */
+
+    'callbacks' => [
+        //
+    ],
 ];

--- a/src/Events/MainServerStarting.php
+++ b/src/Events/MainServerStarting.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Laravel\Octane\Events;
+
+use Swoole\Http\Server;
+
+class MainServerStarting
+{
+    public function __construct(public Server $server)
+    {
+    }
+}

--- a/src/Swoole/Event.php
+++ b/src/Swoole/Event.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Octane\Swoole;
+
+class Event
+{
+    /**
+     * Swoole onStart event.
+     */
+    public const ON_START = 'start';
+
+    /**
+     * Swoole onWorkerStart event.
+     */
+    public const ON_WORKER_START = 'workerStart';
+
+    /**
+     * Swoole onWorkerStop event.
+     */
+    public const ON_WORKER_STOP = 'workerStop';
+
+    /**
+     * Swoole onWorkerExit event.
+     */
+    public const ON_WORKER_EXIT = 'workerExit';
+
+    /**
+     * Swoole onWorkerError event.
+     */
+    public const ON_WORKER_ERROR = 'workerError';
+
+    /**
+     * Swoole onPipeMessage event.
+     */
+    public const ON_PIPE_MESSAGE = 'pipeMessage';
+
+    /**
+     * Swoole onRequest event.
+     */
+    public const ON_REQUEST = 'request';
+
+    /**
+     * Swoole onReceive event.
+     */
+    public const ON_RECEIVE = 'receive';
+
+    /**
+     * Swoole onConnect event.
+     */
+    public const ON_CONNECT = 'connect';
+
+    /**
+     * Swoole onHandShake event.
+     */
+    public const ON_HAND_SHAKE = 'handshake';
+
+    /**
+     * Swoole onOpen event.
+     */
+    public const ON_OPEN = 'open';
+
+    /**
+     * Swoole onMessage event.
+     */
+    public const ON_MESSAGE = 'message';
+
+    /**
+     * Swoole onClose event.
+     */
+    public const ON_CLOSE = 'close';
+
+    /**
+     * Swoole onTask event.
+     */
+    public const ON_TASK = 'task';
+
+    /**
+     * Swoole onFinish event.
+     */
+    public const ON_FINISH = 'finish';
+
+    /**
+     * Swoole onShutdown event.
+     */
+    public const ON_SHUTDOWN = 'shutdown';
+
+    /**
+     * Swoole onPacket event.
+     */
+    public const ON_PACKET = 'packet';
+
+    /**
+     * Swoole onManagerStart event.
+     */
+    public const ON_MANAGER_START = 'managerStart';
+
+    /**
+     * Swoole onManagerStop event.
+     */
+    public const ON_MANAGER_STOP = 'managerStop';
+
+    /**
+     * Before server start, it's not a swoole event.
+     */
+    public const ON_BEFORE_START = 'beforeStart';
+
+    public static function isSwooleEvent($event): bool
+    {
+        return !in_array($event, [self::ON_BEFORE_START]);
+    }
+}

--- a/src/Swoole/Handlers/ExtendEvent.php
+++ b/src/Swoole/Handlers/ExtendEvent.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Laravel\Octane\Swoole\Handlers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Laravel\Octane\ApplicationFactory;
+use Laravel\Octane\DispatchesEvents;
+use Laravel\Octane\Events\MainServerStarting;
+use Laravel\Octane\Swoole\Event;
+use Laravel\Octane\Swoole\WorkerState;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Swoole\Http\Server;
+
+class ExtendEvent
+{
+    use DispatchesEvents;
+
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    public function __construct(
+        protected string $basePath,
+        protected array $serverState,
+        protected WorkerState $workerState,
+    ) {
+    }
+
+    /**
+     * Extended Swoole Event.
+     *
+     * @param Server $server
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(Server $server): void
+    {
+        $this->app = $app = $this->getApplication($server);
+
+        $config = $this->serverState['octaneConfig'];
+        $callbacks = $config['callbacks'] ?? [];
+
+        $this->registerSwooleEvents($server, $callbacks);
+
+        $this->dispatchEvent($app, new MainServerStarting($server));
+    }
+
+    /**
+     * Get a new Laravel application instance.
+     *
+     * @param Server $server
+     * @return Application
+     */
+    protected function getApplication(Server $server): Application
+    {
+        $initialInstances = [
+            'octane.cacheTable' => $this->workerState->cacheTable,
+            Server::class       => $server,
+            WorkerState::class  => $this->workerState,
+        ];
+        $appFactory = new ApplicationFactory($this->basePath);
+        return $appFactory->createApplication($initialInstances);
+    }
+
+    /**
+     * Register for swoole events.
+     * This will overwrite the previously registered swoole event.
+     *
+     * @param Server $server
+     * @param array  $events
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function registerSwooleEvents(Server $server, array $events): void
+    {
+        foreach ($events as $event => $callback) {
+            if (!Event::isSwooleEvent($event)) {
+                continue;
+            }
+
+            if (is_array($callback)) {
+                [$className, $method] = $callback;
+                $class = $this->app->get($className);
+                $callback = [$class, $method];
+            }
+            $server->on($event, $callback);
+        }
+    }
+}


### PR DESCRIPTION
## Update content

Support custom setting swoole event handle, add "MainServerStarting" event.

## Reason

Add "MainServerStarting" event.

Some things need to be done before the swoole server starts. For example, adding a user-defined worker process for monitoring, reporting or other special tasks.

Swoole event callbacks can be defined in the configuration.

Extend swoole event to meet the event callback needs of different scenarios. For example add "onPipeMessage" event for `unixsocket` communication.

## Example

Create a process and send messages to the process periodically.

**config/octane.php**

```php
<?php

use Laravel\Octane\Events\MainServerStarting;
use Laravel\Octane\Swoole\Event;

return [
    //...
    //Ignore other configurations.
    
    /*
    |--------------------------------------------------------------------------
    | Octane Listeners
    |--------------------------------------------------------------------------
    |
    | All of the event listeners for Octane's events are defined below. These
    | listeners are responsible for resetting your application's state for
    | the next request. You may even add your own listeners to the list.
    |
    */

    'listeners' => [
        MainServerStarting::class => [
            App\Listeners\BootProcessListener::class,
        ],
    ],

    /*
    |--------------------------------------------------------------------------
    | Swoole Event Callbacks.
    |--------------------------------------------------------------------------
    |
    | The following settings are custom swoole event callback processing.
    | Note that this will override registered event callback.
    |
    */

    'callbacks' => [
        Event::ON_PIPE_MESSAGE => [App\Bootstrap\PipeMessageCallback::class, 'onPipeMessage'],
    ],
];
```

**app/Listeners/BootProcessListener.php**

```php
<?php

namespace App\Listeners;

use Laravel\Octane\Events\MainServerStarting;
use Swoole\Process as SwooleProcess;

class BootProcessListener
{
    public function handle(object $event): void
    {
        if ($event instanceof MainServerStarting) {
            $server = $event->server;
            $workerCount = $server->setting['worker_num'] + ($server->setting['task_worker_num'] ?? 0) - 1;
            $process = new SwooleProcess(function () use ($server, $workerCount) {
                // Simple example, send messages to the process regularly.
                while (true) {
                    for ($workerId = 0; $workerId <= $workerCount; ++$workerId) {
                        $server->sendMessage('Hello world.', $workerId);
                    }

                    sleep(1);
                }
            }, false, SOCK_DGRAM, true);
            $server->addProcess($process);
        }
    }
}

```

**app/Bootstrap/PipeMessageCallback.php**

```php
<?php

declare(strict_types=1);

namespace App\Bootstrap;

use Swoole\Server;

class PipeMessageCallback
{
    public function onPipeMessage(Server $server, int $fromWorkerId, $data): void
    {
        echo $data . PHP_EOL;
    }
}
```


Run command.

```bash
php artisan octane:start
```

Got the answer:

> Regularly output "Hello world." on the command line.
