### PR TITLE
Revert PaginationState to resolve using new instance of the app

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -19,7 +19,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\EnforceRequestScheme::class,
             \Laravel\Octane\Listeners\EnsureRequestServerPortMatchesScheme::class,
             \Laravel\Octane\Listeners\GiveNewRequestInstanceToApplication::class,
-            // \Laravel\Octane\Listeners\GiveNewRequestInstanceToPaginator::class,
+            \Laravel\Octane\Listeners\GiveNewRequestInstanceToPaginator::class,
         ];
     }
 

--- a/src/Listeners/GiveNewRequestInstanceToPaginator.php
+++ b/src/Listeners/GiveNewRequestInstanceToPaginator.php
@@ -14,6 +14,6 @@ class GiveNewRequestInstanceToPaginator
      */
     public function handle($event): void
     {
-        // PaginationState::resolveUsing($event->sandbox);
+        PaginationState::resolveUsing($event->app);
     }
 }

--- a/src/Listeners/GiveNewRequestInstanceToPaginator.php
+++ b/src/Listeners/GiveNewRequestInstanceToPaginator.php
@@ -14,6 +14,6 @@ class GiveNewRequestInstanceToPaginator
      */
     public function handle($event): void
     {
-        PaginationState::resolveUsing($event->app);
+        PaginationState::resolveUsing($event->sandbox);
     }
 }


### PR DESCRIPTION
based on our experience PaginationState will use different instance (old instance) of the app and cannot recognize new parameter has been set in the route it seems this was implemented before but commented out.

this PR revert them back but in Listener class it was using `sandbox` not sure what was the reason I change it to `app`
