### PR TITLE
Add Concurrent

### DIFF
--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -2,13 +2,13 @@
 
 namespace Laravel\Octane\Concerns;
 
-use Swoole\Http\Server;
+use Laravel\Octane\Contracts\DispatchesTasks;
 use Laravel\Octane\Swoole\Concurrent;
 use Laravel\Octane\Swoole\ServerStateFile;
 use Laravel\Octane\SequentialTaskDispatcher;
-use Laravel\Octane\Contracts\DispatchesTasks;
-use Laravel\Octane\Swoole\SwooleTaskDispatcher;
 use Laravel\Octane\Swoole\SwooleHttpTaskDispatcher;
+use Laravel\Octane\Swoole\SwooleTaskDispatcher;
+use Swoole\Http\Server;
 
 trait ProvidesConcurrencySupport
 {

--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -53,7 +53,7 @@ trait ProvidesConcurrencySupport
      *
      * @return \Laravel\Octane\Swoole\Concurrent
      */
-    public function concurrent(int $limit = 0)
+    public function concurrent(int $limit = null)
     {
         return new Concurrent($limit);
     }

--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -2,12 +2,13 @@
 
 namespace Laravel\Octane\Concerns;
 
-use Laravel\Octane\Contracts\DispatchesTasks;
-use Laravel\Octane\SequentialTaskDispatcher;
-use Laravel\Octane\Swoole\ServerStateFile;
-use Laravel\Octane\Swoole\SwooleHttpTaskDispatcher;
-use Laravel\Octane\Swoole\SwooleTaskDispatcher;
 use Swoole\Http\Server;
+use Laravel\Octane\Swoole\Concurrent;
+use Laravel\Octane\Swoole\ServerStateFile;
+use Laravel\Octane\SequentialTaskDispatcher;
+use Laravel\Octane\Contracts\DispatchesTasks;
+use Laravel\Octane\Swoole\SwooleTaskDispatcher;
+use Laravel\Octane\Swoole\SwooleHttpTaskDispatcher;
 
 trait ProvidesConcurrencySupport
 {
@@ -45,5 +46,15 @@ trait ProvidesConcurrencySupport
             ))(app(ServerStateFile::class)->read()),
             default => new SequentialTaskDispatcher,
         };
+    }
+
+    /**
+     * Get the concurrent dispatcher.
+     *
+     * @return \Laravel\Octane\Swoole\Concurrent
+     */
+    public function concurrent(int $limit = 0)
+    {
+        return new Concurrent($limit);
     }
 }

--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -3,9 +3,9 @@
 namespace Laravel\Octane\Concerns;
 
 use Laravel\Octane\Contracts\DispatchesTasks;
+use Laravel\Octane\SequentialTaskDispatcher;
 use Laravel\Octane\Swoole\Concurrent;
 use Laravel\Octane\Swoole\ServerStateFile;
-use Laravel\Octane\SequentialTaskDispatcher;
 use Laravel\Octane\Swoole\SwooleHttpTaskDispatcher;
 use Laravel\Octane\Swoole\SwooleTaskDispatcher;
 use Swoole\Http\Server;

--- a/src/Swoole/Concurrent.php
+++ b/src/Swoole/Concurrent.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Laravel\Octane\Swoole;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+/**
+ * @method bool isFull()
+ * @method bool isEmpty()
+ */
+class Concurrent
+{
+    /**
+     * @var Channel
+     */
+    protected $channel;
+
+    /**
+     * @var int
+     */
+    protected $limit;
+
+    public function __construct(int $limit)
+    {
+        $this->limit = $limit;
+        $this->channel = new Channel($limit);
+    }
+
+    public function __call($name, $arguments)
+    {
+        if (in_array($name, ['isFull', 'isEmpty'])) {
+            return $this->channel->{$name}(...$arguments);
+        }
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function length(): int
+    {
+        return $this->channel->getLength();
+    }
+
+    public function getLength(): int
+    {
+        return $this->channel->getLength();
+    }
+
+    public function getRunningCoroutineCount(): int
+    {
+        return $this->getLength();
+    }
+
+    public function getChannel(): Channel
+    {
+        return $this->channel;
+    }
+
+    public function create(callable $callable): void
+    {
+        $this->channel->push(true);
+
+        Coroutine::create(function () use ($callable) {
+            try {
+                $callable();
+            } catch (\Throwable $exception) {
+                app(ExceptionHandler::class)->report($exception);
+            } finally {
+                $this->channel->pop();
+            }
+        });
+    }
+}

--- a/src/Swoole/Concurrent.php
+++ b/src/Swoole/Concurrent.php
@@ -22,7 +22,7 @@ class Concurrent
      */
     protected $limit;
 
-    public function __construct(int $limit)
+    public function __construct(int $limit = null)
     {
         $this->limit = $limit;
         $this->channel = new Channel($limit);

--- a/src/Swoole/Concurrent.php
+++ b/src/Swoole/Concurrent.php
@@ -42,12 +42,12 @@ class Concurrent
 
     public function length(): int
     {
-        return $this->channel->getLength();
+        return $this->channel->length();
     }
 
     public function getLength(): int
     {
-        return $this->channel->getLength();
+        return $this->length();
     }
 
     public function getRunningCoroutineCount(): int

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -11,7 +11,7 @@ class ConcurrentTest extends TestCase
     public function test_concurrent()
     {
         run(function() {
-            $concurrent = new Concurrent($limit = 10, 1);
+            $concurrent = new Concurrent($limit = 10);
             $this->assertSame($limit, $concurrent->getLimit());
             $this->assertTrue($concurrent->isEmpty());
             $this->assertFalse($concurrent->isFull());
@@ -41,7 +41,7 @@ class ConcurrentTest extends TestCase
     public function test_exception()
     {
         run(function() {
-            $concurrent = new Concurrent(10, 1);
+            $concurrent = new Concurrent(10);
             $count = 0;
 
             for ($i = 0; $i < 15; ++$i) {

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -9,17 +9,17 @@ class ConcurrentTest extends TestCase
 {
     public function test_concurrent()
     {
-        Coroutine::create(function() {
+        Coroutine::create(function () {
             $concurrent = new Concurrent($limit = 10);
             $this->assertSame($limit, $concurrent->getLimit());
             $this->assertTrue($concurrent->isEmpty());
             $this->assertFalse($concurrent->isFull());
 
             $count = 0;
-            for ($i = 0; $i < 15; ++$i) {
+            for ($i = 0; $i < 15; $i++) {
                 $concurrent->create(function () use (&$count) {
                     Coroutine::sleep(0.1);
-                    ++$count;
+                    $count++;
                 });
             }
 
@@ -39,14 +39,14 @@ class ConcurrentTest extends TestCase
 
     public function test_exception()
     {
-        Coroutine::create(function() {
+        Coroutine::create(function () {
             $concurrent = new Concurrent(10);
             $count = 0;
 
-            for ($i = 0; $i < 15; ++$i) {
+            for ($i = 0; $i < 15; $i++) {
                 $concurrent->create(function () use (&$count) {
                     Coroutine::sleep(0.1);
-                    ++$count;
+                    $count++;
                     throw new \Exception('ddd');
                 });
             }

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Laravel\Octane\Swoole\Concurrent;
+use Swoole\Coroutine;
+
+class ConcurrentTest extends TestCase
+{
+    public function test_concurrent()
+    {
+        $concurrent = new Concurrent($limit = 10, 1);
+        $this->assertSame($limit, $concurrent->getLimit());
+        $this->assertTrue($concurrent->isEmpty());
+        $this->assertFalse($concurrent->isFull());
+
+        $count = 0;
+        for ($i = 0; $i < 15; ++$i) {
+            $concurrent->create(function () use (&$count) {
+                Coroutine::sleep(0.1);
+                ++$count;
+            });
+        }
+
+        $this->assertTrue($concurrent->isFull());
+        $this->assertSame(5, $count);
+        $this->assertSame($limit, $concurrent->getRunningCoroutineCount());
+        $this->assertSame($limit, $concurrent->getLength());
+        $this->assertSame($limit, $concurrent->length());
+
+        while (! $concurrent->isEmpty()) {
+            Coroutine::sleep(0.1);
+        }
+
+        $this->assertSame(15, $count);
+    }
+
+    public function test_exception()
+    {
+        $concurrent = new Concurrent(10, 1);
+        $count = 0;
+
+        for ($i = 0; $i < 15; ++$i) {
+            $concurrent->create(function () use (&$count) {
+                Coroutine::sleep(0.1);
+                ++$count;
+                throw new \Exception('ddd');
+            });
+        }
+
+        $this->assertSame(5, $count);
+        $this->assertSame(10, $concurrent->getRunningCoroutineCount());
+
+        while (! $concurrent->isEmpty()) {
+            Coroutine::sleep(0.1);
+        }
+
+        $this->assertSame(15, $count);
+    }
+}

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -4,7 +4,7 @@ namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\Swoole\Concurrent;
 use Swoole\Coroutine;
-use function Coroutine\run;
+use function Swoole\Coroutine\run;
 
 class ConcurrentTest extends TestCase
 {

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -4,57 +4,62 @@ namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\Swoole\Concurrent;
 use Swoole\Coroutine;
+use function Coroutine\run;
 
 class ConcurrentTest extends TestCase
 {
     public function test_concurrent()
     {
-        $concurrent = new Concurrent($limit = 10, 1);
-        $this->assertSame($limit, $concurrent->getLimit());
-        $this->assertTrue($concurrent->isEmpty());
-        $this->assertFalse($concurrent->isFull());
+        run(function() {
+            $concurrent = new Concurrent($limit = 10, 1);
+            $this->assertSame($limit, $concurrent->getLimit());
+            $this->assertTrue($concurrent->isEmpty());
+            $this->assertFalse($concurrent->isFull());
 
-        $count = 0;
-        for ($i = 0; $i < 15; ++$i) {
-            $concurrent->create(function () use (&$count) {
+            $count = 0;
+            for ($i = 0; $i < 15; ++$i) {
+                $concurrent->create(function () use (&$count) {
+                    Coroutine::sleep(0.1);
+                    ++$count;
+                });
+            }
+
+            $this->assertTrue($concurrent->isFull());
+            $this->assertSame(5, $count);
+            $this->assertSame($limit, $concurrent->getRunningCoroutineCount());
+            $this->assertSame($limit, $concurrent->getLength());
+            $this->assertSame($limit, $concurrent->length());
+
+            while (! $concurrent->isEmpty()) {
                 Coroutine::sleep(0.1);
-                ++$count;
-            });
-        }
+            }
 
-        $this->assertTrue($concurrent->isFull());
-        $this->assertSame(5, $count);
-        $this->assertSame($limit, $concurrent->getRunningCoroutineCount());
-        $this->assertSame($limit, $concurrent->getLength());
-        $this->assertSame($limit, $concurrent->length());
-
-        while (! $concurrent->isEmpty()) {
-            Coroutine::sleep(0.1);
-        }
-
-        $this->assertSame(15, $count);
+            $this->assertSame(15, $count);
+        });
     }
 
     public function test_exception()
     {
-        $concurrent = new Concurrent(10, 1);
-        $count = 0;
+        run(function() {
+            $concurrent = new Concurrent(10, 1);
+            $count = 0;
 
-        for ($i = 0; $i < 15; ++$i) {
-            $concurrent->create(function () use (&$count) {
+            for ($i = 0; $i < 15; ++$i) {
+                $concurrent->create(function () use (&$count) {
+                    Coroutine::sleep(0.1);
+                    ++$count;
+                    throw new \Exception('ddd');
+                });
+            }
+
+            $this->assertSame(5, $count);
+            $this->assertSame(10, $concurrent->getRunningCoroutineCount());
+
+            while (! $concurrent->isEmpty()) {
                 Coroutine::sleep(0.1);
-                ++$count;
-                throw new \Exception('ddd');
-            });
-        }
+            }
 
-        $this->assertSame(5, $count);
-        $this->assertSame(10, $concurrent->getRunningCoroutineCount());
-
-        while (! $concurrent->isEmpty()) {
-            Coroutine::sleep(0.1);
-        }
-
-        $this->assertSame(15, $count);
+            $this->assertSame(15, $count);
+        });
     }
 }

--- a/tests/ConcurrentTest.php
+++ b/tests/ConcurrentTest.php
@@ -4,13 +4,12 @@ namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\Swoole\Concurrent;
 use Swoole\Coroutine;
-use function Swoole\Coroutine\run;
 
 class ConcurrentTest extends TestCase
 {
     public function test_concurrent()
     {
-        run(function() {
+        Coroutine::create(function() {
             $concurrent = new Concurrent($limit = 10);
             $this->assertSame($limit, $concurrent->getLimit());
             $this->assertTrue($concurrent->isEmpty());
@@ -40,7 +39,7 @@ class ConcurrentTest extends TestCase
 
     public function test_exception()
     {
-        run(function() {
+        Coroutine::create(function() {
             $concurrent = new Concurrent(10);
             $count = 0;
 


### PR DESCRIPTION
Based on `Swoole\Coroutine\Channel` implementation, it is used to control the maximum number of concurrent coroutines in a code block. In the following example, when 10 coroutines are executed at the same time, they will block in the loop, but only the current coroutine will be blocked until a position is released, and the loop will continue to execute the next coroutine.

```php
use Laravel\Octane\Facades\Octane;

$concurrent = Octane::concurrent(10);

for ($i = 0; $i < 15; ++$i) {
    $concurrent->create(function () {
        // Do something...
    });
}
```

or

```php
use App\Models\User;

$concurrent = Octane::concurrent(100);
User::cursor()->each(function($user) use ($concurrent) {
    $concurrent->create(function() use ($user) {  /* do something*/ });
});
```