### PR TITLE
add silent option to RoadRunner reset to remove info output which leads to non error

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -51,6 +51,7 @@ class ServerProcessInspector
             $this->findRoadRunnerBinary(),
             'reset',
             '-o', "rpc.listen=tcp://$host:$rpcPort",
+            '-s',
         ], base_path()))->start()->waitUntil(function ($type, $buffer) {
             if ($type === Process::ERR) {
                 throw new RuntimeException('Cannot reload RoadRunner: '.$buffer);

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -62,7 +62,7 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
         ]);
 
         $processFactory->shouldReceive('createProcess')->with(
-            [$this->findRoadRunnerBinary(), 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002'],
+            [$this->findRoadRunnerBinary(), 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002', '-s'],
             base_path(),
         )->andReturn($process = Mockery::mock('stdClass'));
 


### PR DESCRIPTION
RoadRunner changed there info output to be send to stderr which leads to an error as Symfony Process threads stderr messages as an error in there callback. With this we remove info output as we should be able to see and error message when it fails in RoadRunner logs and the command it self should fail with and error code.

Here how it would look like when the command could not connect to the RoadRunner server.

```sh
php artisan octane:start --watch  

   INFO  Server running…

  Local: http://127.0.0.1:8000 

  Press Ctrl+C to stop the server


   INFO  Application change detected. Restarting workers…

   RuntimeException 

  Cannot reload RoadRunner: dial tcp 127.0.0.1:10000: connect: connection refused

  at vendor/laravel/octane/src/RoadRunner/ServerProcessInspector.php:57
     53▕             '-o', "rpc.listen=tcp://$host:10000",
     54▕             '-s'
     55▕         ], base_path()))->start()->waitUntil(function ($type, $buffer) {
     56▕             if ($type === Process::ERR) {
  ➜  57▕                 throw new RuntimeException('Cannot reload RoadRunner: '.$buffer);
     58▕             }
     59▕ 
     60▕             return true;
     61▕         });

      +30 vendor frames 
  31  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))


```

#524 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
