### PR TITLE
Auto generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - octocat
+  categories:
+    - title: Added
+      labels:
+        - feature
+    - title: Changed
+      labels:
+        - enhancement
+    - title: Deprecated
+      labels:
+        - deprecated
+    - title: Removed
+      labels:
+        - removed
+    - title: Fixed
+      labels:
+        - bug
+    - title: Security
+      labels:
+        - security


### PR DESCRIPTION
This PR adds a `release.yml` file to the repo that automatically will generate release notes based on the keep a changelog standard we maintain at Laravel.

These new labels will need to be added to the repo for this to work (I'll add them once this PR gets merged):

- feature
- deprecated
- removed
- security

And all PR's will need to be labeled in the future in order to make this work properly.

In general, this will save much more time when generating release notes. Let's try this out as a test case on Octane before rolling it out on other repos.