### PR TITLE
[1.x] Removes non-needed message

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -28,6 +28,7 @@ trait InteractsWithIO
         'worker is allocated',
         'worker constructed',
         'worker destructed',
+        'worker destroyed',
         '[INFO] RoadRunner server started; version:',
     ];
 


### PR DESCRIPTION
This pull request avoids the message "worker destroyed" to appear while we reload octane.