### PR TITLE
Moved opcache clearing to before bootWorker

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -31,6 +31,8 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
+        $this->clearOpcodeCache();
+
         $this->workerState->server = $server;
         $this->workerState->workerId = $workerId;
         $this->workerState->workerPid = posix_getpid();
@@ -38,7 +40,6 @@ class OnWorkerStart
 
         $this->dispatchServerTickTaskEverySecond($server);
         $this->streamRequestsToConsole($server);
-        $this->clearOpcodeCache();
 
         if ($this->shouldSetProcessName) {
             $isTaskWorker = $workerId >= $server->setting['worker_num'];


### PR DESCRIPTION
Moved opcached clearing to before bootWorker method to enable hot reloading for Swoole and OpenSwoole when Opcache is enabled.

More information about the issue this solves can be seen in #546 .

Closes #546 
