### PR TITLE
[1.x] Fixes sharing "Carbon" state shared between requests 

### DIFF
--- a/src/Listeners/FlushLocaleState.php
+++ b/src/Listeners/FlushLocaleState.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Octane\Listeners;
 
+use Carbon\Laravel\ServiceProvider as CarbonServiceProvider;
+
 class FlushLocaleState
 {
     /**
@@ -18,5 +20,7 @@ class FlushLocaleState
             $translator->setLocale($config->get('app.locale'));
             $translator->setFallback($config->get('app.fallback_locale'));
         });
+
+        (new CarbonServiceProvider($event->app))->updateLocale();
     }
 }

--- a/tests/LocaleStateTest.php
+++ b/tests/LocaleStateTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Octane\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class LocaleStateTest extends TestCase
 {
@@ -28,5 +29,28 @@ class LocaleStateTest extends TestCase
         $this->assertEquals('nl', $client->responses[0]->getContent());
         $this->assertEquals('en', $client->responses[1]->getContent());
         $this->assertEquals('ms', $client->responses[2]->getContent());
+    }
+
+    public function test_carbon_state_is_reset_across_subsequent_requests()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/test-locale', 'GET'), // should be "en"
+            Request::create('/test-locale?locale=nl', 'GET'),
+            Request::create('/test-locale', 'GET'), // should be "en", and not "nl"...
+        ]);
+
+        $app['router']->get('/test-locale', function (Application $app, Request $request) {
+            if ($request->has('locale')) {
+                Carbon::setLocale($request->query('locale'));
+            }
+
+            return now()->getLocale();
+        });
+
+        $worker->run();
+
+        $this->assertEquals('en', $client->responses[0]->getContent());
+        $this->assertEquals('nl', $client->responses[1]->getContent());
+        $this->assertEquals('en', $client->responses[2]->getContent());
     }
 }

--- a/tests/LocaleStateTest.php
+++ b/tests/LocaleStateTest.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Octane\Tests;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
-use Carbon\Carbon;
 
 class LocaleStateTest extends TestCase
 {


### PR DESCRIPTION
At the time of this writing, when a "Carbon::setLocale()" call is made within an Octane request, the "locale" state persist to the next request. This pull request fixes that, by reset the Carbon "locale" to the original of the application. 

Fixes #551, and once this pull request is merged and tagged, and we put https://github.com/briannesbitt/Carbon/pull/2640 "Ready to Review".