### PR TITLE
Boot providers on app clone

### DIFF
--- a/src/Listeners/FlushLocaleState.php
+++ b/src/Listeners/FlushLocaleState.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Octane\Listeners;
 
-use Carbon\Laravel\ServiceProvider as CarbonServiceProvider;
-
 class FlushLocaleState
 {
     /**
@@ -20,7 +18,5 @@ class FlushLocaleState
             $translator->setLocale($config->get('app.locale'));
             $translator->setFallback($config->get('app.fallback_locale'));
         });
-
-        (new CarbonServiceProvider($event->app))->updateLocale();
     }
 }


### PR DESCRIPTION
Replace `(new CarbonServiceProvider($event->app))->updateLocale();` with a re-boot of all providers after the new app has been re-attached to them.

The point of this change is to have a generic handling of providers that would work the same as in typical installas (expect 1 boot() for each request) instead of handling specifically each provider.

It would be safer that providers that don't need to be re-booted would expose some interface/flag so Octane would skip them (so it can still be optimized as much as possible) + a manual exception list that Octane can have for the basic stuff, than the other way round where booting is skipped by default (which might fall unexpected for most providers) and each provider having to adapt their code to support Octane.

Suggestion for interface can be:
```php
interface OctaneServiceProvider
{
  public function bootWithOctaneApp(Illuminate\Foundation\Application $application);
}
```

If present Octane would call `$provider->bootWithOctaneApp($app)` instead of `$app->bootProvider($provider)` and it would be up to the provider implementing the interface to decide which callbacks/events/etc. to do or keep the method void to do nothing.

The annoying part is the `Closure` used to manipulate protected properties of `Application` and `ServiceProvider` but if we agree on the principle first, we might add methods to `Illuminate\Foundation\Application` and `Illuminate\Support\ServiceProvider` to allow this without entering the protected scope.