### PR TITLE
[1.x] Fix carbon locale when setting it via app locale setter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "laravel/framework": "^8.81|^9.0",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
-        "nesbot/carbon": "dev-master as 2.53.1",
+        "nesbot/carbon": "^2.60",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
         "nesbot/carbon": "^2.60",
         "symfony/psr-http-message-bridge": "^2.0"
     },
-    "repositories": [
-        {
-            "type": "github",
-            "url": "https://github.com/briannesbitt/Carbon"
-        }
-    ],
     "require-dev": {
         "guzzlehttp/guzzle": "^7.2",
         "mockery/mockery": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,15 @@
         "laravel/framework": "^8.81|^9.0",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
+        "nesbot/carbon": "dev-master as 2.53.1",
         "symfony/psr-http-message-bridge": "^2.0"
     },
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/briannesbitt/Carbon"
+        }
+    ],
     "require-dev": {
         "guzzlehttp/guzzle": "^7.2",
         "mockery/mockery": "^1.4",

--- a/src/Listeners/FlushLocaleState.php
+++ b/src/Listeners/FlushLocaleState.php
@@ -21,6 +21,10 @@ class FlushLocaleState
             $translator->setFallback($config->get('app.fallback_locale'));
         });
 
-        (new CarbonServiceProvider($event->app))->updateLocale();
+        $provider = tap(new CarbonServiceProvider($event->app))->updateLocale();
+
+        collect($event->sandbox->getProviders($provider))
+            ->values()
+            ->whenNotEmpty(fn ($providers) => $providers->first()->setAppGetter(fn () => $event->sandbox));
     }
 }

--- a/tests/LocaleStateTest.php
+++ b/tests/LocaleStateTest.php
@@ -53,4 +53,29 @@ class LocaleStateTest extends TestCase
         $this->assertEquals('nl', $client->responses[1]->getContent());
         $this->assertEquals('en', $client->responses[2]->getContent());
     }
+
+    public function test_carbon_and_app_locale_gets_updated_when_changing_app_locale()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/test-locale', 'GET'), // should be "en"
+            Request::create('/test-locale?locale=nl', 'GET'), // should be "nl"
+            Request::create('/test-locale', 'GET'), // should be "en", and not "nl"
+            Request::create('/test-locale?locale=pt', 'GET'), // should be "pt"
+        ]);
+
+        $app['router']->get('/test-locale', function (Application $app, Request $request) {
+            if ($request->has('locale')) {
+                app()->setLocale($request->query('locale'));
+            }
+
+            return [app()->getLocale(), now()->getLocale()];
+        });
+
+        $worker->run();
+
+        $this->assertEquals(['en', 'en'], json_decode($client->responses[0]->getContent(), true));
+        $this->assertEquals(['nl', 'nl'], json_decode($client->responses[1]->getContent(), true));
+        $this->assertEquals(['en', 'en'], json_decode($client->responses[2]->getContent(), true));
+        $this->assertEquals(['pt', 'pt'], json_decode($client->responses[3]->getContent(), true));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Tests;
 
+use Carbon\Laravel\ServiceProvider as CarbonServiceProvider;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
@@ -21,6 +22,7 @@ class TestCase extends BaseTestCase
 
         $appFactory->shouldReceive('createApplication')->andReturn($app = $this->createApplication());
 
+        $app->register(new CarbonServiceProvider($app));
         $app->register(new OctaneServiceProvider($app));
 
         $worker = new FakeWorker($appFactory, $roadRunnerClient = new FakeClient($requests));


### PR DESCRIPTION
This pull request fixes the last issue regarding the "locale" update on Vapor apps.

So, the first, got fixed here: https://github.com/laravel/octane/pull/552. And it was regarding the any call to "Carbon::setLocale()" actually changing the local for subsequent requests.

The second, is this one, and concerns the fact that "app->setLocale()" is actually setting the locale of the "app" running the server, and not the app handling the request.

As discussed with Carbon's maintainer, we need the releasing of Carbon, before merging and tagging this pull request: https://github.com/briannesbitt/Carbon/pull/2640.

Fixes https://github.com/laravel/octane/issues/551.

PS: Ignore the tests for now, and I will update this, once the Carbon release is ready.
