### PR TITLE
[1.x] Adds support for Swoole 5

### DIFF
--- a/src/Swoole/Handlers/OnServerStart.php
+++ b/src/Swoole/Handlers/OnServerStart.php
@@ -5,6 +5,7 @@ namespace Laravel\Octane\Swoole\Handlers;
 use Laravel\Octane\Swoole\Actions\EnsureRequestsDontExceedMaxExecutionTime;
 use Laravel\Octane\Swoole\ServerStateFile;
 use Laravel\Octane\Swoole\SwooleExtension;
+use Swoole\Timer;
 
 class OnServerStart
 {
@@ -37,13 +38,13 @@ class OnServerStart
         }
 
         if ($this->shouldTick) {
-            $server->tick(1000, function () use ($server) {
+            Timer::tick(1000, function () use ($server) {
                 $server->task('octane-tick');
             });
         }
 
         if ($this->maxExecutionTime > 0) {
-            $server->tick(1000, function () use ($server) {
+            Timer::tick(1000, function () use ($server) {
                 (new EnsureRequestsDontExceedMaxExecutionTime(
                     $this->extension, $this->timerTable, $this->maxExecutionTime, $server
                 ))();

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -83,7 +83,7 @@ class OnWorkerStart
      */
     protected function dispatchServerTickTaskEverySecond($server)
     {
-        // ..
+        // ...
     }
 
     /**

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -83,12 +83,7 @@ class OnWorkerStart
      */
     protected function dispatchServerTickTaskEverySecond($server)
     {
-        // if ($this->workerState->workerId === 0 &&
-        //     ($this->serverState['octaneConfig']['tick'] ?? true)) {
-        //     $this->workerState->tickTimerId = $server->tick(1000, function () use ($server) {
-        //         $server->task('octane-tick');
-        //     });
-        // }
+        // ..
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for Swoole 5.

Here is the list of breaking changes, between Swoole 4 and 5: https://github.com/swoole/swoole-src/blob/master/CHANGELOG.md#2022-07-22-v500. Yet, the only change affecting Octane is the removal of `Server::tick`. 

Fixes #559.