### PR TITLE
This PR fixes #562 by defining "non-standard HTTP status codes reasons" in the octane config file.

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -231,8 +231,6 @@ return [
 
     'status_code_reasons' => [
         419 => 'Page Expired',
-        431 => 'Request Header Fields Too Large',                // RFC6585
-        451 => 'Unavailable For Legal Reasons',                  // RFC7725
     ],
 
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -224,7 +224,7 @@ return [
     |--------------------------------------------------------------------------
     | The following setting allows you to set non-standard HTTP status codes
     | for Octane. Octane gonna return "200 OK" in responded status if you
-    | use a "non-standard HTTP status codes" in your response header. 
+    | use a "non-standard HTTP status codes" in your response header.
     |
     */
 

--- a/config/octane.php
+++ b/config/octane.php
@@ -218,18 +218,4 @@ return [
 
     'max_execution_time' => 30,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Status Code Reasons for Octane Swoole
-    |--------------------------------------------------------------------------
-    | The following setting allows you to set non-standard HTTP status codes
-    | for Octane. Octane gonna return "200 OK" in responded status if you
-    | use a "non-standard HTTP status codes" in your response header.
-    |
-    */
-
-    'status_code_reasons' => [
-        419 => 'Page Expired',
-    ],
-
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -218,4 +218,21 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Status Code Reasons for Octane Swoole
+    |--------------------------------------------------------------------------
+    |
+    | If you use non-standard HTTP status codes in your response, Octane gonna 
+    | return "200 OK" in responded status code. The following setting allows you
+    | to set non-standard HTTP status codes.
+    |
+    */
+
+    'status_code_reasons' => [
+        419 => 'Page Expired',
+        431 => 'Request Header Fields Too Large',                // RFC6585
+        451 => 'Unavailable For Legal Reasons',                  // RFC7725
+    ],
+
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -223,7 +223,7 @@ return [
     | Status Code Reasons for Octane Swoole
     |--------------------------------------------------------------------------
     |
-    | If you use non-standard HTTP status codes in your response, Octane gonna 
+    | If you use non-standard HTTP status codes in your response, Octane gonna
     | return "200 OK" in responded status code. The following setting allows you
     | to set non-standard HTTP status codes.
     |

--- a/config/octane.php
+++ b/config/octane.php
@@ -222,10 +222,9 @@ return [
     |--------------------------------------------------------------------------
     | Status Code Reasons for Octane Swoole
     |--------------------------------------------------------------------------
-    |
-    | If you use non-standard HTTP status codes in your response, Octane gonna
-    | return "200 OK" in responded status code. The following setting allows you
-    | to set non-standard HTTP status codes.
+    | The following setting allows you to set non-standard HTTP status codes
+    | for Octane. Octane gonna return "200 OK" in responded status if you
+    | use a "non-standard HTTP status codes" in your response header. 
     |
     */
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,11 +19,6 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
-    const STATUS_CODE_REASONS = [
-        419 => 'Page Expired',
-        431 => 'Request Header Fields Too Large',                             // RFC6585
-        451 => 'Unavailable For Legal Reasons',                               // RFC7725
-    ];
 
     public function __construct(protected int $chunkSize = 1048576)
     {
@@ -285,8 +280,8 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     protected function getReasonFromStatusCode(int $code): ?string
     {
-        if (array_key_exists($code, self::STATUS_CODE_REASONS)) {
-            return self::STATUS_CODE_REASONS[$code];
+        if (array_key_exists($code, config('octane.status_code_reasons'))) {
+            return config('octane.status_code_reasons')[$code];
         }
 
         return null;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,6 +19,11 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
+    const STATUS_CODE_REASONS = [
+        431 => 'Request Header Fields Too Large',                             // RFC6585
+        451 => 'Unavailable For Legal Reasons',                               // RFC7725
+    ];
+
     public function __construct(protected int $chunkSize = 1048576)
     {
     }
@@ -279,8 +284,9 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     protected function getReasonFromStatusCode(int $code): ?string
     {
-        if (array_key_exists($code, config('octane.status_code_reasons'))) {
-            return config('octane.status_code_reasons')[$code];
+        $statusCodeReasons = array_replace_recursive(self::STATUS_CODE_REASONS, config('octane.status_code_reasons'));
+        if (array_key_exists($code, $statusCodeReasons)) {
+            return $statusCodeReasons[$code];
         }
 
         return null;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -20,6 +20,7 @@ use Throwable;
 class SwooleClient implements Client, ServesStaticFiles
 {
     const STATUS_CODE_REASONS = [
+        419 => 'Page Expired',
         431 => 'Request Header Fields Too Large',                             // RFC6585
         451 => 'Unavailable For Legal Reasons',                               // RFC7725
     ];
@@ -284,9 +285,13 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     protected function getReasonFromStatusCode(int $code): ?string
     {
-        $statusCodeReasons = array_replace_recursive(self::STATUS_CODE_REASONS, config('octane.status_code_reasons'));
-        if (array_key_exists($code, $statusCodeReasons)) {
-            return $statusCodeReasons[$code];
+        $statusCodes = array_replace_recursive(
+            self::STATUS_CODE_REASONS,
+            config('octane.status_codes', [])
+        );
+
+        if (array_key_exists($code, $statusCodes)) {
+            return $statusCodes[$code];
         }
 
         return null;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,7 +19,6 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
-
     public function __construct(protected int $chunkSize = 1048576)
     {
     }


### PR DESCRIPTION
This PR fixes #562 by defining "non-standard HTTP status codes reasons" in the octane config file.

This PR allows users to define other status code reasons in `octane.php` config file