### PR TITLE
Output Swoole request information based on swoole log_level

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -95,7 +95,7 @@ class OnWorkerStart
     protected function streamRequestsToConsole($server)
     {
         $this->workerState->worker->onRequestHandled(function ($request, $response, $sandbox) {
-            if (! $sandbox->environment('local', 'testing')) {
+            if ($server->setting['log_level'] > SWOOLE_LOG_INFO) {
                 return;
             }
 


### PR DESCRIPTION
Before this PR Swoole request logs are only display if app is in local or testing environment. 

With this PR it display request logs based on the Swoole log_level. There is no change for the user with default configuration. 
