### PR TITLE
feat: add custom dispatch mode for swoole server

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -18,6 +18,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port=8000 : The port the server should be available on}
                     {--rpc-port= : The RPC port the server should be available on}
+                    {--dispatch-mode=auto : The mode of dispatching connections to the worker processes [1-9]}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -58,6 +59,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:swoole', [
             '--host' => $this->option('host'),
             '--port' => $this->option('port'),
+            '--dispatch-mode' => $this->option('dispatch-mode'),
             '--workers' => $this->option('workers'),
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -131,7 +131,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'max_request' => $this->option('max-requests'),
             'package_max_length' => 10 * 1024 * 1024,
             'reactor_num' => $this->workerCount($extension),
-            'send_yield' => $this->sendYeild(),
+            'send_yield' => $this->sendYield(),
             'socket_buffer_size' => 10 * 1024 * 1024,
             'task_max_request' => $this->option('max-requests'),
             'task_worker_num' => $this->taskWorkerCount($extension),
@@ -152,11 +152,11 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     }
 
     /**
-     * Get the mode of dispatching connections to the worker processes.
+     * Yield the current task and wait for I/O if the send buffer is full.
      *
      * @return bool
      */
-    protected function sendYeild()
+    protected function sendYield()
     {
         return $this->option('dispatch-mode') === 'auto'
                     ? true


### PR DESCRIPTION
Add feature custom dispatch_mode

Reference : https://openswoole.com/docs/modules/swoole-server/configuration#dispatch_mode

The mode of dispatching connections to the worker processes.

This parameter only works for the SWOOLE_PROCESS mode is set when running your server.

List of the different dispatch modes (default is 2):
