### PR TITLE
add possibility to launch swoole server with additional php options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 /vendor
 composer.lock
 /phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /vendor
 composer.lock
 /phpunit.xml

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -79,7 +79,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
 
         $server = tap(new Process([
             (new PhpExecutableFinder)->find(),
-            config('octane.swoole.php_options', []),
+            ...config('octane.swoole.php_options', []),
             config('octane.swoole.command', 'swoole-server'),
             $serverStateFile->path(),
         ], realpath(__DIR__.'/../../bin'), [

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -78,7 +78,10 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         $this->forgetEnvironmentVariables();
 
         $server = tap(new Process([
-            (new PhpExecutableFinder)->find(), config('octane.swoole.command', 'swoole-server'), $serverStateFile->path(),
+            (new PhpExecutableFinder)->find(),
+            config('octane.swoole.php_options', []),
+            config('octane.swoole.command', 'swoole-server'),
+            $serverStateFile->path(),
         ], realpath(__DIR__.'/../../bin'), [
             'APP_ENV' => app()->environment(),
             'APP_BASE_PATH' => base_path(),


### PR DESCRIPTION
## Context

In the `StartSwooleCommand`, When [launching the swoole server](https://github.com/laravel/octane/blob/d6c928ba623fa5ea2cf73d43ea02e37a74b7bfff/src/Commands/StartSwooleCommand.php#L80-L86), the command takes only the php executable ignoring any custom options that may be necessary on ones environnement.

##  What did i do

Add optional config to specify any custom options to pass to the php executable

## Config Example

```
'swoole' => [
    'php_options' => [
        '-c',
        '/Library/Application Support/appsolute/MAMP PRO/conf/php8.1.1.ini',
    ],
],
```