### PR TITLE
make STATUS_CODE_REASONS public static

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -19,7 +19,7 @@ use Throwable;
 
 class SwooleClient implements Client, ServesStaticFiles
 {
-    const STATUS_CODE_REASONS = [
+    public static $STATUS_CODE_REASONS = [
         419 => 'Page Expired',
         431 => 'Request Header Fields Too Large',                             // RFC6585
         451 => 'Unavailable For Legal Reasons',                               // RFC7725


### PR DESCRIPTION
Based on the [swoole documentation](https://openswoole.com/docs/modules/swoole-http-response-status#description), swoole will ignore `custom status code` without `reason`. 

> If an invalid status code is set, Swoole will reset the value to 200. However, if a HTTP status code $reason is given, you may set any status code such as 499 or 856.

I changed STATUS_CODE_REASON to public static so other projects also register their custom status code.