### PR TITLE
added $CUSTOM_STATUS_CODE for registering custom status code

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -25,8 +25,15 @@ class SwooleClient implements Client, ServesStaticFiles
         451 => 'Unavailable For Legal Reasons',                               // RFC7725
     ];
 
+    private static array $CUSTOM_STATUS_CODE = [];
+
     public function __construct(protected int $chunkSize = 1048576)
     {
+    }
+
+    public static function addCustomStatusCode(int $status, string $reason)
+    {
+        self::$CUSTOM_STATUS_CODE[$status] = $reason;
     }
 
     /**
@@ -287,6 +294,10 @@ class SwooleClient implements Client, ServesStaticFiles
     {
         if (array_key_exists($code, self::STATUS_CODE_REASONS)) {
             return self::STATUS_CODE_REASONS[$code];
+        }
+
+        if (array_key_exists($code, self::$CUSTOM_STATUS_CODE)) {
+            return self::$CUSTOM_STATUS_CODE[$code];
         }
 
         return null;

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -213,6 +213,31 @@ class SwooleClientTest extends TestCase
     }
 
     /** @doesNotPerformAssertions @test */
+    public function test_respond_method_with_custom_status_code_sends_response_to_swoole()
+    {
+        $client = new SwooleClient;
+
+        if (extension_loaded('openswoole')) {
+            $this->markTestSkipped('This test is not compatible with Open Swoole');
+        }
+
+        $swooleResponse = Mockery::mock('Swoole\Http\Response');
+
+        SwooleClient::addCustomStatusCode($customStatusCode = 471, $reason = 'Custom Status Code');
+
+        $swooleResponse->shouldReceive('status')->once()->with(471, $reason);
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('write')->with('Hello World');
+        $swooleResponse->shouldReceive('end')->once();
+
+        $client->respond(new RequestContext([
+            'swooleResponse' => $swooleResponse,
+        ]), new OctaneResponse(new Response('Hello World', $customStatusCode, ['Content-Type' => 'text/html'])));
+    }
+
+    /** @doesNotPerformAssertions @test */
     public function test_error_method_sends_error_response_to_swoole()
     {
         $client = new SwooleClient;


### PR DESCRIPTION
Based on the [swoole documentation](https://openswoole.com/docs/modules/swoole-http-response-status#description), swoole will ignore `custom status code` without `reason`. 

> If an invalid status code is set, Swoole will reset the value to 200. However, if a HTTP status code $reason is given, you may set any status code such as 499 or 856.

I added `$CUSTOM_STATUS_CODE` to SwooleClient so other projects can register their custom code to swoole.