### PR TITLE
Handle worker startup errors for development purposes

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -114,7 +114,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'storagePath' => storage_path(),
             'defaultServerOptions' => $this->defaultServerOptions($extension),
             'octaneConfig' => config('octane'),
-            'dontShutdownOnError' => $this->option('dont-shutdown-on-error')
+            'dontShutdownOnError' => $this->option('dont-shutdown-on-error'),
         ]);
     }
 

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -26,7 +26,8 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Use file system polling while watching in order to watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}
+                    {--dont-shutdown-on-error : Don\'t shutdown the server when the worker throws exception}';
 
     /**
      * The command's description.
@@ -113,6 +114,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'storagePath' => storage_path(),
             'defaultServerOptions' => $this->defaultServerOptions($extension),
             'octaneConfig' => config('octane'),
+            'dontShutdownOnError' => $this->option('dont-shutdown-on-error')
         ]);
     }
 

--- a/src/EmergencyWorker.php
+++ b/src/EmergencyWorker.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Octane;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Octane\Contracts\Client;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use Whoops\Handler\PlainTextHandler;
+use Whoops\Run;
+
+class EmergencyWorker implements \Laravel\Octane\Contracts\Worker
+{
+    protected Run $whoops;
+
+    public function __construct(
+        protected Client $client,
+        protected Throwable $exception,
+    ) {
+        $this->whoops = new Run();
+        $this->whoops->allowQuit(false);
+        $this->whoops->writeToOutput(false);
+        $this->whoops->pushHandler(new PlainTextHandler());
+    }
+
+    public function handle(Request $request, RequestContext $context): void
+    {
+        $response = new Response();
+        $response->setStatusCode(500);
+        $response->headers->add(['Content-Type' => 'text/plain']);
+        $response->setContent($this->whoops->handleException($this->exception));
+
+        $this->client->respond($context, new OctaneResponse($response));
+    }
+
+    public function boot(): void
+    {
+    }
+
+    public function handleTask($data)
+    {
+    }
+
+    public function terminate(): void
+    {
+    }
+
+    public function handleTick(): void
+    {
+    }
+
+    public function onRequestHandled(Closure $callback)
+    {
+        return $this;
+    }
+}

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -72,6 +72,7 @@ class OnWorkerStart
         } catch (Throwable $e) {
             if ($this->serverState['dontShutdownOnError']) {
                 Stream::throwable($e);
+
                 return new EmergencyWorker(new SwooleClient(), $e);
             } else {
                 Stream::shutdown($e);


### PR DESCRIPTION
## Context
When swoole server running with --watch option, saving of broken code causes shutdown of master process.
It is may be reasonable for production environment, but in development I want to see the changes right after error is fixed, without manual restart of the server process.

## What did i do
Add option `--dont-shutdown-on-error` for the `octane:swoole` command. With this option `OnWorkerStart` event listener doesn't stops the server, but returns an instance of special dummy worker, which aimed for exception rendering.