### PR TITLE
[1.x] Gracefully stop Swoole when running octane:stop

### DIFF
--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -61,6 +61,7 @@ class OctaneServiceProvider extends ServiceProvider
                 $app->make(SignalDispatcher::class),
                 $app->make(SwooleServerStateFile::class),
                 $app->make(Exec::class),
+                $app['config']->get('octane.max_execution_time', 30)
             );
         });
 

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -10,6 +10,7 @@ class ServerProcessInspector
         protected SignalDispatcher $dispatcher,
         protected ServerStateFile $serverStateFile,
         protected Exec $exec,
+        protected int $terminateWait,
     ) {
     }
 
@@ -58,8 +59,12 @@ class ServerProcessInspector
 
         $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
 
-        foreach ([$masterProcessId, $managerProcessId, ...$workerProcessIds] as $processId) {
-            $this->dispatcher->signal((int) $processId, SIGKILL);
+        foreach ($workerProcessIds as $processId) {
+            $this->dispatcher->signal((int)$processId, SIGTERM);
+        }
+
+        foreach ([$managerProcessId, $masterProcessId] as $processId) {
+            $this->dispatcher->terminate((int)$processId, $this->terminateWait);
         }
 
         return true;

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -59,13 +59,8 @@ class ServerProcessInspector
 
         $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
 
-        foreach ($workerProcessIds as $processId) {
-            $this->dispatcher->signal((int)$processId, SIGTERM);
-        }
-
-        foreach ([$managerProcessId, $masterProcessId] as $processId) {
-            $this->dispatcher->terminate((int)$processId, $this->terminateWait);
-        }
+        $this->dispatcher->terminate($workerProcessIds, $this->terminateWait - 5);
+        $this->dispatcher->terminate([$managerProcessId, $masterProcessId], 5);
 
         return true;
     }

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -59,8 +59,8 @@ class ServerProcessInspector
 
         $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
 
-        $this->dispatcher->terminate($workerProcessIds, $this->terminateWait - 5);
-        $this->dispatcher->terminate([$managerProcessId, $masterProcessId], 5);
+        $this->dispatcher->terminate($workerProcessIds, $this->terminateWait);
+        $this->dispatcher->terminate([$managerProcessId, $masterProcessId]);
 
         return true;
     }

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -59,8 +59,8 @@ class ServerProcessInspector
 
         $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
 
-        $this->dispatcher->terminate($workerProcessIds, $this->terminateWait);
-        $this->dispatcher->terminate([$managerProcessId, $masterProcessId]);
+        $this->dispatcher->terminate(array_map('intval', $workerProcessIds), $this->terminateWait);
+        $this->dispatcher->terminate([(int) $managerProcessId, (int) $masterProcessId]);
 
         return true;
     }

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -30,18 +30,18 @@ class SignalDispatcher
      */
     public function terminate(int|array $processId, int $wait = 0): bool
     {
-        $processId = Arr::wrap($processId);
+        $processIds = Arr::wrap($processId);
 
-        foreach ($processId as $processId) {
+        foreach ($processIds as $processId) {
             $this->extension->dispatchProcessSignal($processId, SIGTERM);
         }
 
         if ($wait) {
             $start = time();
-            $runningProcesses = $processId;
+            $runningProcesses = $processIds;
 
             do {
-                foreach ($processId as $processId) {
+                foreach ($processIds as $processId) {
                     if (! $this->canCommunicateWith($processId)) {
                         $runningProcesses = array_diff($runningProcesses, [$processId]);
                     } else {

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Octane\Swoole;
 
+use Illuminate\Support\Arr;
+
 class SignalDispatcher
 {
     public function __construct(protected SwooleExtension $extension)
@@ -22,23 +24,24 @@ class SignalDispatcher
     /**
      * Send a SIGTERM signal to the given process.
      *
-     * @param array $processIds
+     * @param  int|array  $processId
      * @param  int  $wait
-     *
      * @return bool
      */
-    public function terminate(array $processIds, int $wait = 0): bool
+    public function terminate(int|array $processId, int $wait = 0): bool
     {
-        foreach($processIds as $processId) {
+        $processId = Arr::wrap($processId);
+
+        foreach ($processId as $processId) {
             $this->extension->dispatchProcessSignal($processId, SIGTERM);
         }
 
         if ($wait) {
             $start = time();
-            $runningProcesses = $processIds;
+            $runningProcesses = $processId;
 
             do {
-                foreach ($processIds as $processId) {
+                foreach ($processId as $processId) {
                     if (! $this->canCommunicateWith($processId)) {
                         $runningProcesses = array_diff($runningProcesses, [$processId]);
                     } else {

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -35,24 +35,23 @@ class SignalDispatcher
 
         if ($wait) {
             $start = time();
+            $runningProcesses = $processIds;
 
             do {
-                $allTerminated = true;
-
                 foreach ($processIds as $processId) {
-                    if ($this->canCommunicateWith($processId)) {
-                        $allTerminated = false;
-
+                    if (! $this->canCommunicateWith($processId)) {
+                        $runningProcesses = array_diff($runningProcesses, [$processId]);
+                    } else {
                         $this->extension->dispatchProcessSignal($processId, SIGTERM);
                     }
                 }
 
-                if ($allTerminated) {
+                if (! $runningProcesses) {
                     return true;
                 }
 
                 sleep(1);
-            } while (time() < $start + $wait);
+            } while (time() < $start + $wait && $runningProcesses);
         }
 
         return false;

--- a/tests/SwooleServerProcessInspectorTest.php
+++ b/tests/SwooleServerProcessInspectorTest.php
@@ -16,6 +16,7 @@ class SwooleServerProcessInspectorTest extends TestCase
             $dispatcher = Mockery::mock(SignalDispatcher::class),
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             Mockery::mock(Exec::class),
+            30
         );
 
         $dispatcher->shouldReceive('canCommunicateWith')->with(2)->andReturn(true);
@@ -33,6 +34,7 @@ class SwooleServerProcessInspectorTest extends TestCase
             $dispatcher = Mockery::mock(SignalDispatcher::class),
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             Mockery::mock(Exec::class),
+            30
         );
 
         $dispatcher->shouldReceive('canCommunicateWith')->with(2)->andReturn(false);
@@ -50,6 +52,7 @@ class SwooleServerProcessInspectorTest extends TestCase
             $dispatcher = Mockery::mock(SignalDispatcher::class),
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             Mockery::mock(Exec::class),
+            30
         );
 
         $dispatcher->shouldReceive('canCommunicateWith')->with(1)->andReturn(true);
@@ -67,6 +70,7 @@ class SwooleServerProcessInspectorTest extends TestCase
             $dispatcher = Mockery::mock(SignalDispatcher::class),
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             Mockery::mock(Exec::class),
+            30
         );
 
         $dispatcher->shouldReceive('canCommunicateWith')->with(1)->andReturn(false);
@@ -84,6 +88,7 @@ class SwooleServerProcessInspectorTest extends TestCase
             $dispatcher = Mockery::mock(SignalDispatcher::class),
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             $exec = Mockery::mock(Exec::class),
+            30
         );
 
         $processIdFile->writeProcessIds(3, 2);
@@ -91,8 +96,8 @@ class SwooleServerProcessInspectorTest extends TestCase
 
         collect([2, 3, 4, 5])->each(
             fn ($processId) => $dispatcher
-                ->shouldReceive('signal')
-                ->with($processId, SIGKILL)
+                ->shouldReceive('terminate')
+                ->with($processId, 30)
                 ->once(),
         );
 

--- a/tests/SwooleServerProcessInspectorTest.php
+++ b/tests/SwooleServerProcessInspectorTest.php
@@ -97,12 +97,14 @@ class SwooleServerProcessInspectorTest extends TestCase
         // Workers
         $dispatcher
             ->shouldReceive('terminate')
-            ->with([4, 5], 30);
+            ->with([4, 5], 30)
+            ->once();
 
         // Master/Manager
         $dispatcher
             ->shouldReceive('terminate')
-            ->with([2, 3]);
+            ->with([2, 3])
+            ->once();
 
         $this->assertTrue($inspector->stopServer());
 

--- a/tests/SwooleServerProcessInspectorTest.php
+++ b/tests/SwooleServerProcessInspectorTest.php
@@ -94,12 +94,15 @@ class SwooleServerProcessInspectorTest extends TestCase
         $processIdFile->writeProcessIds(3, 2);
         $exec->shouldReceive('run')->once()->with('pgrep -P 2')->andReturn([4, 5]);
 
-        collect([2, 3, 4, 5])->each(
-            fn ($processId) => $dispatcher
-                ->shouldReceive('terminate')
-                ->with($processId, 30)
-                ->once(),
-        );
+        // Workers
+        $dispatcher
+            ->shouldReceive('terminate')
+            ->with([4, 5], 30);
+
+        // Master/Manager
+        $dispatcher
+            ->shouldReceive('terminate')
+            ->with([2, 3]);
 
         $this->assertTrue($inspector->stopServer());
 


### PR DESCRIPTION
Fixes #469

The existing behavior when running `octane:stop` is to send a `SIGKILL` signal to the Swoole master process, manager process, and all of the worker processes. This causes in-flight requests to immediately be terminated instead of waiting for them to complete.

This PR changes the behavior of `ServerProcessInspector::stopServer()` and `SignalDispatcher::terminate()` to support gracefully shutting down the workers and master/manager process so that all existing requests can complete (with a timeout) before terminating.

The revised flow in this PR:
- `octane:stop` is called (either via artisan or when a SIGTERM/SIGINT is signaled)
- Send `SIGTERM` to all workers
- Wait for all workers to terminate (With a max of the `octane.max_execution_time` config value)
- Send `SIGTERM` to the master and manager process.

Although not used in the octane package as far as I can tell, backwards compatibility of the `SignalDispatcher::terminate()` is maintained.