### PR TITLE
prevent ob_end_clean(): Failed to delete buffer. No buffer to delete error - Worker.PHP

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -93,7 +93,10 @@ class Worker implements WorkerContract
 
             $output = ob_get_contents();
 
-            ob_end_clean();
+           if($output) {
+               ob_end_clean();
+           }
+          
 
             // Here we will actually hand the incoming request to the Laravel application so
             // it can generate a response. We'll send this response back to the client so

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -93,9 +93,9 @@ class Worker implements WorkerContract
 
             $output = ob_get_contents();
 
-           if($output) {
-               ob_end_clean();
-           }
+            if($output) {
+                ob_end_clean();
+            }
           
 
             // Here we will actually hand the incoming request to the Laravel application so


### PR DESCRIPTION
added a condition to prevent "ob_end_clean(): Failed to delete buffer. No buffer to delete" error in some situation (in my case ckfinder) 