### PR TITLE
prevent ob_end_clean(): Failed to delete buffer. No buffer to delete error - Worker.PHP

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -92,8 +92,10 @@ class Worker implements WorkerContract
             $response = $gateway->handle($request);
 
             $output = ob_get_contents();
-
-            ob_end_clean();
+            
+            if ($output) {
+                ob_end_clean();
+            }
 
             // Here we will actually hand the incoming request to the Laravel application so
             // it can generate a response. We'll send this response back to the client so


### PR DESCRIPTION
added a condition to prevent "ob_end_clean(): Failed to delete buffer. No buffer to delete" error in some situation (in my case ckfinder) 