### PR TITLE
[1.x] Ignore `Response::create` failed

### DIFF
--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -31,6 +31,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 if ($this->server instanceof Server) {
                     $response = Response::create($this->server, $row['fd']);
+
                     if ($response) {
                         $response->status(408);
                         $response->end();

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -29,7 +29,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
-                if ($this->server instanceof Server && extension_loaded('swoole')) {
+                if ($this->server instanceof Server) {
                     $response = Response::create($this->server, $row['fd']);
                     if ($response) {
                         $response->status(408);

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -29,10 +29,12 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
-                if ($this->server instanceof Server) {
+                if ($this->server instanceof Server && extension_loaded('swoole')) {
                     $response = Response::create($this->server, $row['fd']);
-                    $response->status(408);
-                    $response->end();
+                    if ($response) {
+                        $response->status(408);
+                        $response->end();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #588

This feature should only be available for Swoole.

OpenSwoole recommends using the [max_request_execution_time](https://openswoole.com/docs/modules/swoole-server/configuration#max_request_execution_time) configuration.

If a new response cannot be created, we can ignore it.

This will fall back to a page hold instead of an exception.
