### PR TITLE
Handle static files by Swoole HTTP server

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -137,6 +137,8 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'task_max_request' => $this->option('max-requests'),
             'task_worker_num' => $this->taskWorkerCount($extension),
             'worker_num' => $this->workerCount($extension),
+            'document_root' => public_path(),
+            'enable_static_handler' => true,
         ];
     }
 


### PR DESCRIPTION
This PR follows #592 and configures static files to be handled by the Swoole HTTP server, not Laravel.

This will:
- Fix serving static files with non-ASCII characters naming issues
- Increase the app's throughput
- Reduce resource consumption
