### PR TITLE
[1.x] Adds tests regarding flushing controller is computed middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.83.25|^9.33",
+        "laravel/framework": "^8.83.26|^9.38.0",
         "laminas/laminas-diactoros": "^2.5",
         "laravel/serializable-closure": "^1.0",
         "nesbot/carbon": "^2.60",

--- a/tests/RequestStateTest.php
+++ b/tests/RequestStateTest.php
@@ -63,16 +63,16 @@ class RequestStateTest extends TestCase
         $worker->run();
 
         $this->assertEquals(1, $client->responses[0]->original['invokedCount']);
-        $this->assertEquals(1, $client->responses[0]->original['controllerMiddlewareInvokedCount']);
+        $this->assertEquals(1, $client->responses[0]->original['middlewareInvokedCount']);
         $this->assertEquals(1, $client->responses[1]->original['invokedCount']);
-        $this->assertEquals(1, $client->responses[1]->original['controllerMiddlewareInvokedCount']);
+        $this->assertEquals(1, $client->responses[1]->original['middlewareInvokedCount']);
 
         $worker->run();
 
         $this->assertEquals(1, $client->responses[0]->original['invokedCount']);
-        $this->assertEquals(1, $client->responses[0]->original['controllerMiddlewareInvokedCount']);
+        $this->assertEquals(1, $client->responses[0]->original['middlewareInvokedCount']);
         $this->assertEquals(1, $client->responses[1]->original['invokedCount']);
-        $this->assertEquals(1, $client->responses[1]->original['controllerMiddlewareInvokedCount']);
+        $this->assertEquals(1, $client->responses[1]->original['middlewareInvokedCount']);
     }
 
     public function test_request_routes_controller_does_not_leak()
@@ -101,7 +101,7 @@ class RequestStateTest extends TestCase
 
 class UserControllerStub extends Controller
 {
-    protected $controllerMiddlewareInvokedCount = 0;
+    protected $middlewareInvokedCount = 0;
 
     protected $invokedCount = 0;
 
@@ -110,7 +110,7 @@ class UserControllerStub extends Controller
     public function __construct()
     {
         $this->middleware(function ($request, $next) {
-            $this->controllerMiddlewareInvokedCount++;
+            $this->middlewareInvokedCount++;
 
             return $next($request);
         });
@@ -121,7 +121,7 @@ class UserControllerStub extends Controller
         $this->invokedCount++;
 
         return [
-            'controllerMiddlewareInvokedCount' => $this->controllerMiddlewareInvokedCount,
+            'middlewareInvokedCount' => $this->middlewareInvokedCount,
             'invokedCount' => $this->invokedCount,
         ];
     }


### PR DESCRIPTION
This pull request adds tests for https://github.com/laravel/octane/issues/594, and it it's waiting for a framework release before being "ready for review".

- [x] Bump `composer.json` versions on framework releases are done.