### PR TITLE
RoadRunner Relay Overrides

### DIFF
--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -27,8 +27,9 @@ $basePath = require __DIR__.'/bootstrap.php';
 |
 */
 
+$relay = getenv('LARAVEL_OCTANE_ROADRUNNER_RELAY') ?: 'pipes';
 $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
-    new RoadRunnerWorker(Relay::create('pipes')),
+    new RoadRunnerWorker(Relay::create($relay)),
     new ServerRequestFactory,
     new StreamFactory,
     new UploadedFileFactory,

--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -27,10 +27,8 @@ $basePath = require __DIR__.'/bootstrap.php';
 |
 */
 
-$relay = $_ENV['LARAVEL_OCTANE_ROADRUNNER_RELAY'] ?? 'pipes';
-
 $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
-    new RoadRunnerWorker(Relay::create($relay)),
+    new RoadRunnerWorker(Relay::create($_ENV['LARAVEL_OCTANE_ROADRUNNER_RELAY'] ?? 'pipes')),
     new ServerRequestFactory,
     new StreamFactory,
     new UploadedFileFactory,

--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -28,6 +28,7 @@ $basePath = require __DIR__.'/bootstrap.php';
 */
 
 $relay = getenv('LARAVEL_OCTANE_ROADRUNNER_RELAY') ?: 'pipes';
+
 $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
     new RoadRunnerWorker(Relay::create($relay)),
     new ServerRequestFactory,

--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -27,7 +27,7 @@ $basePath = require __DIR__.'/bootstrap.php';
 |
 */
 
-$relay = getenv('LARAVEL_OCTANE_ROADRUNNER_RELAY') ?: 'pipes';
+$relay = $_ENV['LARAVEL_OCTANE_ROADRUNNER_RELAY'] ?? 'pipes';
 
 $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
     new RoadRunnerWorker(Relay::create($relay)),


### PR DESCRIPTION
This PR implements RoadRunner Relay Overrides (#598), and has no effect unless an environment variable is presented.

In advanced Octane use cases, it may be necessary to override which RoadRunner Relay mechanism is used. This is accomplished by adding the following to your `rr.yaml` file:

```yaml
server:
  # define the relay to use
  relay: "unix://rr.sock"

  env:
    # configure roadrunner-worker to use relay
    - LARAVEL_OCTANE_ROADRUNNER_RELAY: "unix://rr.sock"
```

As an aside, I'd love to get documentation added for this, but not sure where to go. If you can point me in the right direction, that would be appreciated!