### PR TITLE
Re-do: Configurable Roadrunner log level

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -30,7 +30,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
-                    {--log-level= : Suppress messages under this log level}';
+                    {--log-level= : Log messages at or above the specified log level}';
 
     /**
      * The command's description.
@@ -88,7 +88,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.static.dir='.base_path('public'),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
             '-o', 'logs.mode=production',
-            '-o', 'logs.level='.$this->logLevel(),
+            '-o', 'logs.level='.$this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn'),
             '-o', 'logs.output=stdout',
             '-o', 'logs.encoding=json',
             'serve',
@@ -175,17 +175,6 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function rpcPort()
     {
         return $this->option('rpc-port') ?: $this->option('port') - 1999;
-    }
-
-    /**
-     * Suppress messages under this log level.
-     *
-     * @return string
-     */
-    protected function logLevel()
-    {
-        return $this->option('log-level') ?:
-            (app()->environment('local') ? 'debug' : 'warn');
     }
 
     /**

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -88,7 +88,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.static.dir='.base_path('public'),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
             '-o', 'logs.mode=production',
-            '-o', 'logs.level='.$this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn'),
+            '-o', 'logs.level='.($this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn')),
             '-o', 'logs.output=stdout',
             '-o', 'logs.encoding=json',
             'serve',

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -29,7 +29,8 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Use file system polling while watching in order to watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}
+                    {--log-level= : Suppress messages under this log level}';
 
     /**
      * The command's description.
@@ -87,7 +88,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.static.dir='.base_path('public'),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
             '-o', 'logs.mode=production',
-            '-o', app()->environment('local') ? 'logs.level=debug' : 'logs.level=warn',
+            '-o', 'logs.level='.$this->logLevel(),
             '-o', 'logs.output=stdout',
             '-o', 'logs.encoding=json',
             'serve',
@@ -174,6 +175,17 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function rpcPort()
     {
         return $this->option('rpc-port') ?: $this->option('port') - 1999;
+    }
+
+    /**
+     * Suppress messages under this log level.
+     *
+     * @return string
+     */
+    protected function logLevel()
+    {
+        return $this->option('log-level') ?:
+            (app()->environment('local') ? 'debug' : 'warn');
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

See https://github.com/laravel/octane/pull/601. This adds a new flag, `--log-level`, to the `octane:roadrunner` command.

Was asked to provide an explanation as to why this broke; it was, simply put, due to an operator precedence issue added in the second commit.

```php
'logs.level='.$this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn')
```
Will result in `logs.level=` (no actual level) if no `--log-level` option is given instead of falling back to the old behaviour, due to `.` having higher precedence than `?:`.

Adding parentheses fixes this:
```php
'logs.level='.($this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn'))
```

It's perhaps easiest to see with a simpler example:
```php
'foo' . null ?: 'bar'
```
Results in `foo`, while
```php
'foo' . (null ?: 'bar')
```
Results in `foobar`.