### PR TITLE
[1.x] Read port for http server from environment if no port is passed 

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -127,7 +127,7 @@ trait InteractsWithServers
      */
     protected function getPort()
     {
-        return $this->option('port') ?? config('octane.port') ?? '8000';
+        return $this->option('port') ?? config('octane.port') ?? $_ENV['OCTANE_PORT'] ?? '8000';
     }
 
     /**

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -142,7 +142,7 @@ trait InteractsWithServers
     }
 
     /**
-     * Get the HTTP server port
+     * Get the HTTP server port.
      *
      * @return int
      */

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -100,7 +100,7 @@ trait InteractsWithServers
 
         $this->output->writeln([
             '',
-            '  Local: <fg=white;options=bold>http://'.$this->option('host').':'.$this->option('port').' </>',
+            '  Local: <fg=white;options=bold>http://'.$this->option('host').':'.$this->getPort().' </>',
             '',
             '  <fg=yellow>Press Ctrl+C to stop the server</>',
             '',
@@ -139,5 +139,15 @@ trait InteractsWithServers
     public function handleSignal(int $signal): void
     {
         $this->stopServer();
+    }
+
+    /**
+     * Get the HTTP server port
+     *
+     * @return int
+     */
+    protected function getPort()
+    {
+        return $this->option('port') ?? env('SERVER_PORT') ?? '8000';
     }
 }

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -121,6 +121,16 @@ trait InteractsWithServers
     }
 
     /**
+     * Get the Octane HTTP server port.
+     *
+     * @return string
+     */
+    protected function getPort()
+    {
+        return $this->option('port') ?? config('octane.port') ?? '8000';
+    }
+
+    /**
      * Returns the list of signals to subscribe.
      *
      * @return array
@@ -139,15 +149,5 @@ trait InteractsWithServers
     public function handleSignal(int $signal): void
     {
         $this->stopServer();
-    }
-
-    /**
-     * Get the HTTP server port.
-     *
-     * @return int
-     */
-    protected function getPort()
-    {
-        return $this->option('port') ?? env('SERVER_PORT') ?? '8000';
     }
 }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -16,7 +16,7 @@ class StartCommand extends Command implements SignalableCommandInterface
     public $signature = 'octane:start
                     {--server= : The server that should be used to serve the application}
                     {--host=127.0.0.1 : The IP address the server should bind to}
-                    {--port=8000 : The port the server should be available on}
+                    {--port= : The port the server should be available on}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
@@ -57,7 +57,7 @@ class StartCommand extends Command implements SignalableCommandInterface
     {
         return $this->call('octane:swoole', [
             '--host' => $this->option('host'),
-            '--port' => $this->option('port'),
+            '--port' => $this->getPort(),
             '--workers' => $this->option('workers'),
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
@@ -75,7 +75,7 @@ class StartCommand extends Command implements SignalableCommandInterface
     {
         return $this->call('octane:roadrunner', [
             '--host' => $this->option('host'),
-            '--port' => $this->option('port'),
+            '--port' => $this->getPort(),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -23,7 +23,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     public $signature = 'octane:roadrunner
                     {--host=127.0.0.1 : The IP address the server should bind to}
-                    {--port=8000 : The port the server should be available on}
+                    {--port= : The port the server should be available on}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -79,7 +79,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             $roadRunnerBinary,
             '-c', $this->configPath(),
             '-o', 'version=2.7',
-            '-o', 'http.address='.$this->option('host').':'.$this->option('port'),
+            '-o', 'http.address='.$this->option('host').':'.$this->getPort(),
             '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
@@ -115,7 +115,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         $serverStateFile->writeState([
             'appName' => config('app.name', 'Laravel'),
             'host' => $this->option('host'),
-            'port' => $this->option('port'),
+            'port' => $this->getPort(),
             'rpcPort' => $this->rpcPort(),
             'workers' => $this->workerCount(),
             'maxRequests' => $this->option('max-requests'),
@@ -174,7 +174,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      */
     protected function rpcPort()
     {
-        return $this->option('rpc-port') ?: $this->option('port') - 1999;
+        return $this->option('rpc-port') ?: $this->getPort() - 1999;
     }
 
     /**

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -21,7 +21,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
      */
     public $signature = 'octane:swoole
                     {--host=127.0.0.1 : The IP address the server should bind to}
-                    {--port=8000 : The port the server should be available on}
+                    {--port= : The port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -105,7 +105,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         $serverStateFile->writeState([
             'appName' => config('app.name', 'Laravel'),
             'host' => $this->option('host'),
-            'port' => $this->option('port'),
+            'port' => $this->getPort(),
             'workers' => $this->workerCount($extension),
             'taskWorkers' => $this->taskWorkerCount($extension),
             'maxRequests' => $this->option('max-requests'),


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request aims to add support for defining the HTTP server port through environment variables. The implementation shouldn't break any existing behavior.
This feature should be helpful for anyone that needs to run octane with a randomly generated port.