### PR TITLE
[1.x] Make IP to bind the server to configurable via env

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -121,6 +121,16 @@ trait InteractsWithServers
     }
 
     /**
+     * Get the Octane HTTP server host IP to bind on.
+     *
+     * @return string
+     */
+    protected function getHost()
+    {
+        return $this->option('host') ?? config('octane.host') ?? $_ENV['OCTANE_HOST'] ?? '127.0.0.1';
+    }
+
+    /**
      * Get the Octane HTTP server port.
      *
      * @return string

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -56,7 +56,7 @@ class StartCommand extends Command implements SignalableCommandInterface
     protected function startSwooleServer()
     {
         return $this->call('octane:swoole', [
-            '--host' => $this->option('host'),
+            '--host' => $this->getHost(),
             '--port' => $this->getPort(),
             '--workers' => $this->option('workers'),
             '--task-workers' => $this->option('task-workers'),
@@ -74,7 +74,7 @@ class StartCommand extends Command implements SignalableCommandInterface
     protected function startRoadRunnerServer()
     {
         return $this->call('octane:roadrunner', [
-            '--host' => $this->option('host'),
+            '--host' => $this->getHost(),
             '--port' => $this->getPort(),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -114,7 +114,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     ) {
         $serverStateFile->writeState([
             'appName' => config('app.name', 'Laravel'),
-            'host' => $this->option('host'),
+            'host' => $this->getHost(),
             'port' => $this->getPort(),
             'rpcPort' => $this->rpcPort(),
             'workers' => $this->workerCount(),

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -104,7 +104,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     ) {
         $serverStateFile->writeState([
             'appName' => config('app.name', 'Laravel'),
-            'host' => $this->option('host'),
+            'host' => $this->getHost(),
             'port' => $this->getPort(),
             'workers' => $this->workerCount($extension),
             'taskWorkers' => $this->taskWorkerCount($extension),


### PR DESCRIPTION
Building further on #605 this also makes the IP that the server listens on configurable using environment variables when no commandline argument for `--host` is provided.

The implementation should not break any existing deployments.