### PR TITLE
Prefix rr binary permissions with 0 to specify it as an octal value

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -171,7 +171,7 @@ trait InstallsRoadRunnerDependencies
             fn ($type, $buffer) => $this->output->write($buffer)
         );
 
-        chmod(base_path('rr'), 755);
+        chmod(base_path('rr'), 0755);
 
         $this->line('');
     }


### PR DESCRIPTION
This resolves the issue described [here](https://github.com/laravel/octane/issues/610).

On php 8.1 octane errors out because it's unable to start the rr binary that gets downloaded. It's unable to because it doesn't have permission, because the `chmod()` that gets run after the binary is installed, doesn't have the right value for permissions. It's trying to set them to `755` but per the [chmod documentation](https://www.php.net/manual/en/function.chmod.php), you need to use a `0` prefix to specify it as an octal value. 

This PR adds the `0` prefix to the permissions, setting them to `0755` which runs successfully on php 8.1.