### PR TITLE
Revert "Prefix rr binary permissions with 0 to specify it as an octal value"

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -171,7 +171,7 @@ trait InstallsRoadRunnerDependencies
             fn ($type, $buffer) => $this->output->write($buffer)
         );
 
-        chmod(base_path('rr'), 0755);
+        chmod(base_path('rr'), 755);
 
         $this->line('');
     }


### PR DESCRIPTION
Reverts laravel/octane#611