### PR TITLE
[1.x] Fixes `test_error_method_sends_error_response_to_roadrunner` test

### DIFF
--- a/tests/RoadRunnerClientTest.php
+++ b/tests/RoadRunnerClientTest.php
@@ -72,6 +72,7 @@ class RoadRunnerClientTest extends TestCase
         $client = new RoadRunnerClient($psr7Client);
 
         $app = $this->createApplication();
+        $app['config']['app.debug'] = false;
         $request = Request::create('/', 'GET');
         $context = new RequestContext;
 

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -224,6 +224,8 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::spy('Swoole\Http\Response');
 
         $app = $this->createApplication();
+        $app['config']['app.debug'] = false;
+
         $request = Request::create('/', 'GET');
         $context = new RequestContext(['swooleResponse' => $swooleResponse]);
 


### PR DESCRIPTION
This pull request fixes the test suite due a change in the `testbench` package.