### PR TITLE
fix: resolve typo resulting in deprecation notice

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -234,7 +234,7 @@ trait InteractsWithIO
             'request' => $this->requestInfo($stream, $verbosity),
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),
-            default => $this->info(json_encode($stream, $verbosity))
+            default => $this->info(json_encode($stream), $verbosity)
         };
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

We noticed that on PHP 8.1, we are receiving the following deprecation notice in Sentry.
```txt
json_encode(): Passing null to parameter #2 ($flags) of type int is deprecated in /var/www/vendor/laravel/octane/src/Commands/Concerns/InteractsWithIO.php on line 237
```

It looks like this is just a typo, and the verbosity should be passed to `info()` not to `json_encode()`. 👍🏻