### PR TITLE
fix: ensure Testbench `vendor` symlink exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,11 @@
             "Laravel\\Octane\\Tests\\": "tests"
         }
     },
+    "scripts": {
+        "post-autoload-dump": [
+            "@php vendor/bin/testbench package:discover --ansi"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This should fix the issues with the Testbench `vendor` directory not existing. When any `testbench` command is run, it creates the symlink if it does not exist.