### PR TITLE
Add --rpc-host option for Roadrunner

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -77,7 +77,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
-            '--rpc-host' => $this->option('rpc-host') ?: $this->getHost(),
+            '--rpc-host' => $this->option('rpc-host'),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,6 +17,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
+                    {--rpc-host= : The RPC IP address the server should bind to [default: "--host value"]}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
@@ -76,6 +77,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
+            '--rpc-host' => $this->option('rpc-host') ?: $this->getHost(),
             '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -24,6 +24,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     public $signature = 'octane:roadrunner
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
+                    {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -83,7 +84,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'server.command='.(new PhpExecutableFinder)->find().' '.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
-            '-o', 'rpc.listen=tcp://'.$this->option('host').':'.$this->rpcPort(),
+            '-o', 'rpc.listen=tcp://'.$this->rpcHost().':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir='.base_path('public'),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
@@ -165,6 +166,16 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     protected function maxExecutionTime()
     {
         return config('octane.max_execution_time', '30').'s';
+    }
+
+    /**
+     * Get the RPC IP address the server should be available on.
+     *
+     * @return int
+     */
+    protected function rpcHost()
+    {
+        return $this->option('rpc-host') ?: $this->getHost();
     }
 
     /**


### PR DESCRIPTION
## What

This PR adds the `--rpc-host` option to be used for the Roadrunner server. Its values default to the `--host` option in order to preserve backward compatibility.

## Why

When deploying to AWS ECS as a Docker container and Nginx sidecar, the `--host` option must be set to `0.0.0.0` in order to listen to any host.

However, the RPC host needs to be set to the loopback interface `127.0.0.1`. The current logic sets both hosts to the same, making this impossible to configure.

We've already implemented this as a custom command on our own codebase which has been deployed to a production environment and is successfully working as we expect.