### PR TITLE
feat: compatibility with openswoole v22.x

### DIFF
--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -53,6 +53,10 @@ class SwooleExtension
      */
     public function cpuCount(): int
     {
-        return swoole_cpu_num();
+        try {
+            return swoole_cpu_num();
+        } catch (\Throwable $th) {
+            return extension_loaded('openswoole') ? \OpenSwoole\Util::getCPUNum() : 1;
+        }
     }
 }


### PR DESCRIPTION
Openswoole v22.x change `swoole_cpu_num()` to `OpenSwoole\Util::getCPUNum()`

https://openswoole.com/docs/modules/swoole-server/configuration#reactor_num
