### PR TITLE
[1.x] Reset prevent queries state

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -48,6 +48,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\FlushDatabaseRecordModificationState::class,
             \Laravel\Octane\Listeners\FlushDatabaseQueryLog::class,
             \Laravel\Octane\Listeners\RefreshQueryDurationHandling::class,
+            \Laravel\Octane\Listeners\ResetPreventQueriesState::class,
             \Laravel\Octane\Listeners\FlushLogContext::class,
             \Laravel\Octane\Listeners\FlushArrayCache::class,
             \Laravel\Octane\Listeners\FlushMonologState::class,

--- a/src/Listeners/ResetPreventQueriesState.php
+++ b/src/Listeners/ResetPreventQueriesState.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class ResetPreventQueriesState
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('db')) {
+            return;
+        }
+
+        foreach ($event->sandbox['db']->getConnections() as $connection) {
+            $connection->allowQueries();
+        }
+    }
+}

--- a/tests/Listeners/ResetPreventQueriesStateTest.php
+++ b/tests/Listeners/ResetPreventQueriesStateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Laravel\Octane\Tests\TestCase;
+
+class ResetPreventQueriesStateTest extends TestCase
+{
+    public function test_it_resets_prevents_queries_state()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+        ]);
+        $app['router']->middleware('web')->get('/', function () {
+            //
+        });
+        $connection = $app['db']->connection();
+
+        $connection->preventQueries();
+        $this->assertTrue($connection->preventingQueries());
+
+        $worker->run();
+        $this->assertSame(false, $connection->preventingQueries());
+    }
+}
+
+
+


### PR DESCRIPTION
Dependent on https://github.com/laravel/framework/pull/45603 being accepted, merged, and tagged.

This PR will always reset the "preventQueries" state to `false`. This does mean, unfortunately, that setting `DB::preventQueries()` in a service provider is not supported. Considering this would probably make your app unusable anyway, I don't think we need to be concerned with this.

In the rare case that functionality was wanted, it would be possible via event listeners instead.

I've deviated from the naming convention as I didn't feel it was "flushing" anything.