### PR TITLE
[1.x] Removes internal messages from output

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -23,6 +23,7 @@ trait InteractsWithIO
     protected $ignoreMessages = [
         'destroy signal received',
         'scan command',
+        'sending stop request to the worker',
         'stop signal received, grace timeout is: ',
         'exit forced',
         'worker allocated',

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -21,6 +21,7 @@ trait InteractsWithIO
      * @var array
      */
     protected $ignoreMessages = [
+        'destroy signal received',
         'scan command',
         'stop signal received, grace timeout is: ',
         'exit forced',


### PR DESCRIPTION
This pull request makes Octane ignore some internal messages on the Octane output:

<img width="478" alt="Screenshot 2023-02-01 at 17 23 54" src="https://user-images.githubusercontent.com/5457236/216116951-d271b5a7-a0ea-4b22-99c2-b9cb0ec3edbf.png">
