### PR TITLE
[1.x] Only displays source when there is source

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -185,9 +185,11 @@ trait InteractsWithIO
             $outputTrace = function ($trace, $number) {
                 $number++;
 
-                ['line' => $line, 'file' => $file] = $trace;
+                if (isset($trace['line'])) {
+                    ['line' => $line, 'file' => $file] = $trace;
 
-                $this->line("  <fg=yellow>$number</>   $file:$line");
+                    $this->line("  <fg=yellow>$number</>   $file:$line");
+                }
             };
 
             $outputTrace($throwable, -1);


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/octane/issues/637, by only displaying the source file and line, when those all available.