### PR TITLE
Fix unsetting a cookie value when using Swoole

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -193,7 +193,7 @@ class SwooleClient implements Client, ServesStaticFiles
 
             $swooleResponse->{$cookie->isRaw() ? 'rawcookie' : 'cookie'}(
                 $cookie->getName(),
-                !$shouldDelete ? $cookie->getValue() : 'deleted',
+                $shouldDelete ? 'deleted' : $cookie->getValue(),
                 $cookie->getExpiresTime(),
                 $cookie->getPath(),
                 $cookie->getDomain() ?? '',

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -189,9 +189,11 @@ class SwooleClient implements Client, ServesStaticFiles
         }
 
         foreach ($response->headers->getCookies() as $cookie) {
+            $shouldDelete = (string) $cookie->getValue() === '';
+
             $swooleResponse->{$cookie->isRaw() ? 'rawcookie' : 'cookie'}(
                 $cookie->getName(),
-                $cookie->getValue(),
+                !$shouldDelete ? $cookie->getValue() : 'deleted',
                 $cookie->getExpiresTime(),
                 $cookie->getPath(),
                 $cookie->getDomain() ?? '',

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -156,12 +156,18 @@ class SwooleClientTest extends TestCase
         $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
         $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('cookie')->once()->with('new', 'value', 0, '/', '', false, true, 'lax');
+        $swooleResponse->shouldReceive('cookie')->once()->with('cleared', 'deleted', Mockery::type('int'), '/', '', false, true, 'lax');
         $swooleResponse->shouldReceive('write')->with('Hello World');
         $swooleResponse->shouldReceive('end')->once();
 
+        $response = new Response('Hello World', 200, ['Content-Type' => 'text/html']);
+        $response->cookie('new', 'value');
+        $response->withoutCookie('cleared');
+
         $client->respond(new RequestContext([
             'swooleResponse' => $swooleResponse,
-        ]), new OctaneResponse(new Response('Hello World', 200, ['Content-Type' => 'text/html'])));
+        ]), new OctaneResponse($response));
     }
 
     /** @doesNotPerformAssertions @test */


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #641 

Following the Symfony's implementation, any empty string or `null` value will instead use string `deleted`. To avoid issues with strings like `0` (which are valid cookie values) I'm not using the `?:` op.