### PR TITLE
Add support for custom HTTP headers on static files

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -137,6 +137,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Static file headers
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may serve static files from the public directory.
+    | You may set the HTTP headers that should be returned along with those
+    | files here.
+    |
+    */
+
+    'static_file_headers' => [
+        // 'Cache-Control' => 'max-age=604800, must-revalidate, immutable, public',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Cache Table
     |--------------------------------------------------------------------------
     |

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -138,6 +138,11 @@ class SwooleClient implements Client, ServesStaticFiles
         $swooleResponse = $context->swooleResponse;
 
         $publicPath = $context->publicPath;
+        $staticHeaders = $context->octaneConfig['static_file_headers'] ?: [];
+
+        foreach ($staticHeaders as $name => $value) {
+            $swooleResponse->header($name, $value);
+        }
 
         $swooleResponse->status(200);
         $swooleResponse->header('Content-Type', MimeType::get(pathinfo($request->path(), PATHINFO_EXTENSION)));

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -138,10 +138,13 @@ class SwooleClient implements Client, ServesStaticFiles
         $swooleResponse = $context->swooleResponse;
 
         $publicPath = $context->publicPath;
-        $staticHeaders = $context->octaneConfig['static_file_headers'] ?: [];
 
-        foreach ($staticHeaders as $name => $value) {
-            $swooleResponse->header($name, $value);
+        if (isset($context->octaneConfig) && ! empty($context->octaneConfig['static_file_headers'])) {
+            $staticHeaders = $context->octaneConfig['static_file_headers'];
+
+            foreach ($staticHeaders as $name => $value) {
+                $swooleResponse->header($name, $value);
+            }
         }
 
         $swooleResponse->status(200);

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -115,6 +115,30 @@ class SwooleClientTest extends TestCase
         $client->serveStaticFile($request, $context);
     }
 
+    public function test_static_file_headers_can_be_sent()
+    {
+        $client = new SwooleClient;
+
+        $request = Request::create('/foo.txt', 'GET');
+
+        $context = new RequestContext([
+            'swooleResponse' => $swooleResponse = Mockery::mock('stdClass'),
+            'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [
+                'static_file_headers' => [
+                    'X-Test-Header' => 'Valid',
+                ],
+            ],
+        ]);
+
+        $swooleResponse->shouldReceive('header')->once()->with('X-Test-Header', 'Valid');
+        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/plain');
+        $swooleResponse->shouldReceive('sendfile')->once()->with(realpath(__DIR__.'/public/foo.txt'));
+
+        $client->serveStaticFile($request, $context);
+    }
+
     public function test_can_serve_static_files_through_symlink()
     {
         $client = new SwooleClient;


### PR DESCRIPTION
This PR will enable users to add custom HTTP headers on files served from the public directory. This is important for production applications that could benefit from configuring a `Cache-Control` policy for their web assets. I have included an example policy to show how the new configuration option can be used.

This change should be backwards compatible as it checks if the new configuration option is present in `config/octane.php`.