### PR TITLE
Add support for custom HTTP headers on static files

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -142,12 +142,14 @@ return [
     |
     | While using Swoole, you may serve static files from the public directory.
     | You may set the HTTP headers that should be returned along with those
-    | files here.
+    | files here. Headers can be applied according to the request path pattern.
     |
     */
 
     'static_file_headers' => [
-        // 'Cache-Control' => 'max-age=604800, must-revalidate, immutable, public',
+        // 'css/dist*' => [
+        //     'Cache-Control' => 'max-age=604800, must-revalidate, immutable, public',
+        // ],
     ],
 
     /*

--- a/config/octane.php
+++ b/config/octane.php
@@ -137,23 +137,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Static file headers
-    |--------------------------------------------------------------------------
-    |
-    | While using Swoole, you may serve static files from the public directory.
-    | You may set the HTTP headers that should be returned along with those
-    | files here. Headers can be applied according to the request path pattern.
-    |
-    */
-
-    'static_file_headers' => [
-        // 'css/dist*' => [
-        //     'Cache-Control' => 'max-age=604800, must-revalidate, immutable, public',
-        // ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Octane Cache Table
     |--------------------------------------------------------------------------
     |

--- a/config/octane.php
+++ b/config/octane.php
@@ -137,6 +137,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Static file headers
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may serve static files from the public directory.
+    | You may set the HTTP headers that should be returned along with those
+    | files here.
+    |
+    */
+
+    'static_file_headers' => [
+        // 'Cache-Control' => 'max-age=604800, must-revalidate, immutable, public',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Cache Table
     |--------------------------------------------------------------------------
     |

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -140,10 +140,8 @@ class SwooleClient implements Client, ServesStaticFiles
         $publicPath = $context->publicPath;
         $octaneConfig = $context->octaneConfig ?? [];
 
-        if (! empty($octaneConfig['static_file_headers'])) {
-            $staticHeaders = $octaneConfig['static_file_headers'];
-
-            foreach ($staticHeaders as $pattern => $headers) {
+        if (! empty($octaneConfig['static_file_headers'] ?? [])) {
+            foreach ($octaneConfig['static_file_headers'] as $pattern => $headers) {
                 if ($request->is($pattern)) {
                     foreach ($headers as $name => $value) {
                         $swooleResponse->header($name, $value);

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -139,6 +139,14 @@ class SwooleClient implements Client, ServesStaticFiles
 
         $publicPath = $context->publicPath;
 
+        if (! empty($context->octaneConfig['static_file_headers'])) {
+            $staticHeaders = $context->octaneConfig['static_file_headers'];
+
+            foreach ($staticHeaders as $name => $value) {
+                $swooleResponse->header($name, $value);
+            }
+        }
+
         $swooleResponse->status(200);
         $swooleResponse->header('Content-Type', MimeType::get(pathinfo($request->path(), PATHINFO_EXTENSION)));
         $swooleResponse->sendfile(realpath($publicPath.'/'.$request->path()));

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -138,12 +138,17 @@ class SwooleClient implements Client, ServesStaticFiles
         $swooleResponse = $context->swooleResponse;
 
         $publicPath = $context->publicPath;
+        $octaneConfig = $context->octaneConfig ?? [];
 
-        if (! empty($context->octaneConfig['static_file_headers'])) {
-            $staticHeaders = $context->octaneConfig['static_file_headers'];
+        if (! empty($octaneConfig['static_file_headers'])) {
+            $staticHeaders = $octaneConfig['static_file_headers'];
 
-            foreach ($staticHeaders as $name => $value) {
-                $swooleResponse->header($name, $value);
+            foreach ($staticHeaders as $pattern => $headers) {
+                if ($request->is($pattern)) {
+                    foreach ($headers as $name => $value) {
+                        $swooleResponse->header($name, $value);
+                    }
+                }
             }
         }
 

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -65,6 +65,7 @@ class SwooleClientTest extends TestCase
 
         $context = new RequestContext([
             'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [],
         ]);
 
         $this->assertTrue($client->canServeRequestAsStaticFile($request, $context));
@@ -78,6 +79,7 @@ class SwooleClientTest extends TestCase
 
         $context = new RequestContext([
             'publicPath' => __DIR__.'/public/files',
+            'octaneConfig' => [],
         ]);
 
         $this->assertFalse($client->canServeRequestAsStaticFile($request, $context));
@@ -91,6 +93,7 @@ class SwooleClientTest extends TestCase
 
         $context = new RequestContext([
             'publicPath' => __DIR__.'/public/files',
+            'octaneConfig' => [],
         ]);
 
         $this->assertFalse($client->canServeRequestAsStaticFile($request, $context));
@@ -106,9 +109,34 @@ class SwooleClientTest extends TestCase
         $context = new RequestContext([
             'swooleResponse' => $swooleResponse = Mockery::mock('stdClass'),
             'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [],
         ]);
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/plain');
+        $swooleResponse->shouldReceive('sendfile')->once()->with(realpath(__DIR__.'/public/foo.txt'));
+
+        $client->serveStaticFile($request, $context);
+    }
+
+    public function test_static_file_headers_can_be_sent()
+    {
+        $client = new SwooleClient;
+
+        $request = Request::create('/foo.txt', 'GET');
+
+        $context = new RequestContext([
+            'swooleResponse' => $swooleResponse = Mockery::mock('stdClass'),
+            'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [
+                'static_file_headers' => [
+                    'X-Test-Header' => 'Valid',
+                ],
+            ],
+        ]);
+
+        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('header')->once()->with('X-Test-Header', 'Valid');
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/plain');
         $swooleResponse->shouldReceive('sendfile')->once()->with(realpath(__DIR__.'/public/foo.txt'));
 
@@ -123,6 +151,7 @@ class SwooleClientTest extends TestCase
 
         $context = new RequestContext([
             'publicPath' => __DIR__.'/public/files',
+            'octaneConfig' => [],
         ]);
 
         $this->assertTrue($client->canServeRequestAsStaticFile($request, $context));
@@ -136,6 +165,7 @@ class SwooleClientTest extends TestCase
 
         $context = new RequestContext([
             'publicPath' => __DIR__.'/public/files',
+            'octaneConfig' => [],
         ]);
 
         $this->assertFalse($client->canServeRequestAsStaticFile($request, $context));

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -130,7 +130,9 @@ class SwooleClientTest extends TestCase
             'publicPath' => __DIR__.'/public',
             'octaneConfig' => [
                 'static_file_headers' => [
-                    'X-Test-Header' => 'Valid',
+                    'foo.txt' => [
+                        'X-Test-Header' => 'Valid',
+                    ],
                 ],
             ],
         ]);


### PR DESCRIPTION
This PR will enable users to add custom HTTP headers on files served from the public directory. This is important for production applications that could benefit from configuring a `Cache-Control` policy for their web assets. I have included an example policy to show how the new configuration option can be used.

This change should be backwards compatible as it checks if the new configuration option is present in `config/octane.php`.