### PR TITLE
Fix return value error and Remove useless code

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -171,7 +171,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     /**
      * Get the RPC IP address the server should be available on.
      *
-     * @return int
+     * @return string
      */
     protected function rpcHost()
     {

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -140,7 +140,7 @@ class SwooleClient implements Client, ServesStaticFiles
         $publicPath = $context->publicPath;
         $octaneConfig = $context->octaneConfig ?? [];
 
-        if (! empty($octaneConfig['static_file_headers'] ?? [])) {
+        if (! empty($octaneConfig['static_file_headers'])) {
             foreach ($octaneConfig['static_file_headers'] as $pattern => $headers) {
                 if ($request->is($pattern)) {
                     foreach ($headers as $name => $value) {


### PR DESCRIPTION
The return value of rpcHost should be string.

`empty()` is essentially the concise equivalent to `!isset($var) || $var == false`, so it doesn't need to be processed`?? []`