### PR TITLE
[1.x] Add method to fix octane route caching. 

### DIFF
--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -41,6 +41,14 @@ trait ProvidesRouting
     }
 
     /**
+     * @return array
+     */
+    public function getRoutes(): array
+    {
+        return $this->routes;
+    }
+
+    /**
      * Invoke the route for the given method and URI.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Concerns/ProvidesRouting.php
+++ b/src/Concerns/ProvidesRouting.php
@@ -41,14 +41,6 @@ trait ProvidesRouting
     }
 
     /**
-     * @return array
-     */
-    public function getRoutes(): array
-    {
-        return $this->routes;
-    }
-
-    /**
      * Invoke the route for the given method and URI.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -59,5 +51,15 @@ trait ProvidesRouting
     public function invokeRoute(Request $request, string $method, string $uri): Response
     {
         return call_user_func($this->routes[$method.$uri], $request);
+    }
+
+    /**
+     * Get the registered Octane routes.
+     *
+     * @return array
+     */
+    public function getRoutes(): array
+    {
+        return $this->routes;
     }
 }


### PR DESCRIPTION
This PR is a required dep to this pr in the main repo.

this method is required to get octane specific routes for caching. 

https://github.com/laravel/framework/pull/46448