### PR TITLE
[1.x] Reverts #669

### DIFF
--- a/src/Listeners/GiveNewApplicationInstanceToSessionManager.php
+++ b/src/Listeners/GiveNewApplicationInstanceToSessionManager.php
@@ -12,14 +12,6 @@ class GiveNewApplicationInstanceToSessionManager
      */
     public function handle($event): void
     {
-        if (! $event->sandbox->resolved('session')) {
-            return;
-        }
-
-        with($event->sandbox->make('session'), function ($manager) use ($event) {
-            if (method_exists($manager, 'setContainer')) {
-                $manager->setContainer($event->sandbox);
-            }
-        });
+        //
     }
 }


### PR DESCRIPTION
This pull request reverts #669, fixing https://github.com/laravel/octane/issues/674, and https://github.com/laravel/octane/issues/673, and the reports of users not being able to see run Octane and see logs.