### PR TITLE
Use Laravel ResponseHeaderBag to send Set-Cookie Header instead of Swoole function

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -171,8 +171,9 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  \Swoole\Http\Response  $response
+     * @param   \Symfony\Component\HttpFoundation\Response  $response
+     * @param   \Swoole\Http\Response                       $swooleResponse
+     *
      * @return void
      */
     public function sendResponseHeaders(Response $response, SwooleResponse $swooleResponse): void
@@ -182,10 +183,6 @@ class SwooleClient implements Client, ServesStaticFiles
         }
 
         $headers = $response->headers->allPreserveCase();
-
-        if (isset($headers['Set-Cookie'])) {
-            unset($headers['Set-Cookie']);
-        }
 
         foreach ($headers as $name => $values) {
             foreach ($values as $value) {
@@ -197,21 +194,6 @@ class SwooleClient implements Client, ServesStaticFiles
             $swooleResponse->status($response->getStatusCode(), $reason);
         } else {
             $swooleResponse->status($response->getStatusCode());
-        }
-
-        foreach ($response->headers->getCookies() as $cookie) {
-            $shouldDelete = (string) $cookie->getValue() === '';
-
-            $swooleResponse->{$cookie->isRaw() ? 'rawcookie' : 'cookie'}(
-                $cookie->getName(),
-                $shouldDelete ? 'deleted' : $cookie->getValue(),
-                $cookie->getExpiresTime(),
-                $cookie->getPath(),
-                $cookie->getDomain() ?? '',
-                $cookie->isSecure(),
-                $cookie->isHttpOnly(),
-                $cookie->getSameSite() ?? '',
-            );
         }
     }
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -171,8 +171,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param \Symfony\Component\HttpFoundation\Response $response
--    * @param \Swoole\Http\Response $response
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Swoole\Http\Response  $response
      * @return void
      */
     public function sendResponseHeaders(Response $response, SwooleResponse $swooleResponse): void

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -158,8 +158,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the response to the server.
      *
-     * @param \Symfony\Component\HttpFoundation\Response $response
-     * @param \Swoole\Http\Response $response
+     * @param  \Laravel\Octane\RequestContext  $context
+     * @param  \Laravel\Octane\OctaneResponse  $octaneResponse
      * @return void
      */
     public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
@@ -171,8 +171,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param \Symfony\Component\HttpFoundation\Response $response
--    * @param \Swoole\Http\Response $response
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Swoole\Http\Response  $response
      * @return void
      */
     public function sendResponseHeaders(Response $response, SwooleResponse $swooleResponse): void

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -171,9 +171,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param \Symfony\Component\HttpFoundation\Response $response
-     * @param \Swoole\Http\Response $response
-     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Swoole\Http\Response  $response
      * @return void
      */
     public function sendResponseHeaders(Response $response, SwooleResponse $swooleResponse): void

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -171,8 +171,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param   \Symfony\Component\HttpFoundation\Response  $response
-     * @param   \Swoole\Http\Response                       $swooleResponse
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param \Swoole\Http\Response $response
      *
      * @return void
      */

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -158,8 +158,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the response to the server.
      *
-     * @param  \Laravel\Octane\RequestContext  $context
-     * @param  \Laravel\Octane\OctaneResponse  $octaneResponse
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param \Swoole\Http\Response $response
      * @return void
      */
     public function respond(RequestContext $context, OctaneResponse $octaneResponse): void

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -171,8 +171,8 @@ class SwooleClient implements Client, ServesStaticFiles
     /**
      * Send the headers from the Illuminate response to the Swoole response.
      *
-     * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  \Swoole\Http\Response  $response
+     * @param \Symfony\Component\HttpFoundation\Response $response
+-    * @param \Swoole\Http\Response $response
      * @return void
      */
     public function sendResponseHeaders(Response $response, SwooleResponse $swooleResponse): void

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -188,13 +188,16 @@ class SwooleClientTest extends TestCase
         $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
         $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
-        $swooleResponse->shouldReceive('cookie')->once()->with('new', 'value', 0, '/', '', false, true, 'lax');
-        $swooleResponse->shouldReceive('cookie')->once()->with('cleared', 'deleted', Mockery::type('int'), '/', '', false, true, 'lax');
         $swooleResponse->shouldReceive('write')->with('Hello World');
         $swooleResponse->shouldReceive('end')->once();
 
+        $swooleResponse->shouldReceive('header')->once()
+            ->with('Set-Cookie', Mockery::pattern('/new=value; expires=.*; Max-Age=3600; path=\/; httponly; samesite=lax/'));
+        $swooleResponse->shouldReceive('header')->once()
+            ->with('Set-Cookie', Mockery::pattern('/cleared=deleted; expires=.*; Max-Age=0; path=\/; httponly; samesite=lax/'));
+
         $response = new Response('Hello World', 200, ['Content-Type' => 'text/html']);
-        $response->cookie('new', 'value');
+        $response->cookie('new', 'value', 60);
         $response->withoutCookie('cleared');
 
         $client->respond(new RequestContext([


### PR DESCRIPTION
At the moment the SwooleClient uses the cookie or rawCookie function of the SwooleResponse to send cookies.
With these functions it is not possible to send the Max-Age cookie parameter, only an absolute expires time is sent.
Which leads to the problem that clients without a valid time do not save the cookie correctly.

To fix this and simplify the code, this pull request removes the swoole cookie function and reuses the cookie header function from the Laravel ResponseHeaderBag class.

This has the further advantage that the responses between a normal Laravel PHP-FPM server and Laravel Octane do not differ.

on-behalf-of: @e-solutions-GmbH <info@esolutions.de>