### PR TITLE
fix: os specific roadrunner binary file ext

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -171,7 +171,9 @@ trait InstallsRoadRunnerDependencies
             fn ($type, $buffer) => $this->output->write($buffer)
         );
 
-        chmod(base_path('rr'), 0755);
+        $binaryName = preg_match('/windows/i', php_uname('s')) ? 'rr.exe' : 'rr';
+
+        chmod(base_path($binaryName), 0755);
 
         $this->line('');
     }


### PR DESCRIPTION
This PR fixes laravel octane roadrunner installation error on Windows.

Roadrunner executable binary has a `.exe` extension which causes `chmod(base_path($binaryName), 0755);` error:

![Roadrunner installation error on Windows](https://i.imgur.com/XCYp0DI.png)