### PR TITLE
Support roadrunner http v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "orchestra/testbench": "^6.16|^7.0|^8.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.3",
-        "spiral/roadrunner": "^2.8.2"
+        "spiral/roadrunner-http": "^2.0 || ^3.0",
+        "spiral/roadrunner-cli": "^2.0 || ^3.0"
     },
     "bin": [
         "bin/roadrunner-worker",

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -19,7 +19,7 @@ trait InstallsRoadRunnerDependencies
     /**
      * The minimum required version of the RoadRunner binary.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $requiredVersions = ['2023.1.0', '2.8.2'];
 

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -17,7 +17,7 @@ trait InstallsRoadRunnerDependencies
     use FindsRoadRunnerBinary;
 
     /**
-     * The minimum required version of the RoadRunner binary.
+     * The minimum required versions of the RoadRunner binary.
      *
      * @var array<int, string>
      */


### PR DESCRIPTION
This PR adds support for `spiral/roadrunner-http` v3

The [`spiral/roadrunner`](https://packagist.org/packages/spiral/roadrunner) now is a meta package and does not require `spiral/roadrunner-http` anymore, so I've changed the requirements to `spiral/roadrunner-http` (and `spiral/roadrunner-cli` which is required to download the roadrunner binary) instead of `spiral/roadrunner`.

The other required change is the configuration `version`, that must be set to `3` for the new version,  and is set dynamically based on roadrunner binary version