### PR TITLE
feat: enable http compression by sending data not with chunked encodi…

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -260,12 +260,15 @@ class SwooleClient implements Client, ServesStaticFiles
             return;
         }
 
+        // if the content fits into one chunk -> perform no chunked encoding
         if ($length <= $this->chunkSize) {
-            $swooleResponse->write($content);
-        } else {
-            for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
-                $swooleResponse->write(substr($content, $offset, $this->chunkSize));
-            }
+            $swooleResponse->end($content);
+
+            return;
+        }
+
+        for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
+            $swooleResponse->write(substr($content, $offset, $this->chunkSize));
         }
 
         $swooleResponse->end();

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -260,7 +260,6 @@ class SwooleClient implements Client, ServesStaticFiles
             return;
         }
 
-        // if the content fits into one chunk -> perform no chunked encoding
         if ($length <= $this->chunkSize) {
             $swooleResponse->end($content);
 


### PR DESCRIPTION
…ng - if possible

http compression can only be used if chunked encoding is not used.
Therefore if the response body "fits into one chunk" `end()` is called instead of `write()` followed by `end()`


refs: https://openswoole.com/docs/modules/swoole-http-server/configuration#http_compression

Applies to swoole as well