### PR TITLE
[2.x] Adds support for PSR-7 v2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1.0",
         "laravel/framework": "^10.9.0",
-        "laminas/laminas-diactoros": "^2.25.2",
+        "laminas/laminas-diactoros": "^3.0.0",
         "laravel/serializable-closure": "^1.3.0",
         "nesbot/carbon": "^2.66.0",
         "symfony/psr-http-message-bridge": "^2.2.0"


### PR DESCRIPTION
By updating the dependency to version v3 of laminas/laminas-diactoros, this pull request introduces compatibility with PSR-7 v2.x.