### PR TITLE
[2.x] Restores original Eloquent Global Scopes [WIP]

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -19,6 +19,7 @@ use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
 use Laravel\Octane\Listeners\FlushUploadedFiles;
 use Laravel\Octane\Listeners\ReportException;
 use Laravel\Octane\Listeners\StopWorkerIfNecessary;
+use Laravel\Octane\Listeners\StoreOriginalEloquentGlobalScopes;
 use Laravel\Octane\Octane;
 
 return [
@@ -66,6 +67,7 @@ return [
         WorkerStarting::class => [
             EnsureUploadedFilesAreValid::class,
             EnsureUploadedFilesCanBeMoved::class,
+            StoreOriginalEloquentGlobalScopes::class,
         ],
 
         RequestReceived::class => [

--- a/src/Listeners/RestoreOriginalEloquentGlobalScopes.php
+++ b/src/Listeners/RestoreOriginalEloquentGlobalScopes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RestoreOriginalEloquentGlobalScopes
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Laravel\Octane\Events\RequestTerminated  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        if ($event->app->bound('eloquent.scopes')) {
+            Model::setAllGlobalScopes($event->app->make('eloquent.scopes'));
+        }
+    }
+}

--- a/src/Listeners/StoreOriginalEloquentGlobalScopes.php
+++ b/src/Listeners/StoreOriginalEloquentGlobalScopes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StoreOriginalEloquentGlobalScopes
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Laravel\Octane\Events\RequestReceived  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $event->app->instance('eloquent.scopes', Model::getAllGlobalScopes());
+    }
+}

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -133,8 +133,10 @@ class OctaneServiceProvider extends ServiceProvider
         $this->app->singleton(Listeners\PrepareLivewireForNextOperation::class);
         $this->app->singleton(Listeners\PrepareScoutForNextOperation::class);
         $this->app->singleton(Listeners\PrepareSocialiteForNextOperation::class);
+        $this->app->singleton(Listeners\RestoreOriginalEloquentGlobalScopes::class);
         $this->app->singleton(Listeners\ReportException::class);
         $this->app->singleton(Listeners\StopWorkerIfNecessary::class);
+        $this->app->singleton(Listeners\StoreOriginalEloquentGlobalScopes::class);
     }
 
     /**

--- a/tests/EloquentScopeTest.php
+++ b/tests/EloquentScopeTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+class EloquentScopeTest extends TestCase
+{
+    public function test_request_receives_fresh_scopes(): void
+    {
+        // TODO: Figure out how to test this.
+    }
+}


### PR DESCRIPTION
It's purpose is to _reset_ the global scope list back to its original state after the application boots.

This is because #255. Laravel Octane doesn't restores the Global Scope list, since it's a static array. That means there is potential to memory leaks and unwanted state bleeding into other requests.

The way it fixes it is hearing when the worker starts, were the list is saved as `eloquent.scopes`, and when the request is handled, were the list is restored.

> This small fix is a work in progress because I don't know how to test this at first glance. By the powers GitHub grants me, I shall invoke @nunomaduro and @taylorotwell.