### PR TITLE
RoadRunner bridge for laravel cache and config improvements

### DIFF
--- a/.github/workflows/tests-rr.yml
+++ b/.github/workflows/tests-rr.yml
@@ -1,0 +1,59 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+
+jobs:
+  tests-rr:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.1, 8.2]
+        laravel: [10]
+        rr: [2023.1.4]
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - RR ${{ matrix.rr }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Install laravel
+        run: |
+          composer create-project laravel/laravel laravel
+
+      - name: Setup laravel with local octane repository
+        working-directory: ./laravel
+        run: |
+          composer config repositories.octane path ../.
+          composer config minimum-stability dev
+          composer require laravel/octane spiral/roadrunner-cli spiral/roadrunner-http spiral/roadrunner-kv
+
+      - name: Install RoadRunner Binary
+        working-directory: ./laravel
+        run: |
+          docker run --rm -v ${PWD}:/rootfs:rw --entrypoint "" spiralscout/roadrunner:${{ matrix.rr }} cp /usr/bin/rr /rootfs/rr
+
+      - name: Install basic Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress --ansi
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Feature
+        env:
+          FEATURE_TEST: rr
+          LARAVEL_PATH: laravel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
 
     strategy:
       fail-fast: true

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan": "^1.10.15",
         "phpunit/phpunit": "^10.1.3",
         "spiral/roadrunner-http": "^3.0.1",
-        "spiral/roadrunner-cli": "^2.5.0"
+        "spiral/roadrunner-cli": "^2.5.0",
+        "spiral/roadrunner-kv": "^4.0.0"
     },
     "bin": [
         "bin/roadrunner-worker",

--- a/config/octane.php
+++ b/config/octane.php
@@ -171,6 +171,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | RoadRunner Options
+    |--------------------------------------------------------------------------
+    |
+    | While using RoadRunner, you may define additional options to set up RPC (host and port),
+    | HTTP middlewares and Cache key.
+    */
+
+    'roadrunner' => [
+        'rpc' => [
+            'host' => env('OCTANE_RPC_HOST', '127.0.0.1'),
+            'port' => env('OCTANE_RPC_PORT', 6001),
+        ],
+        'http_middleware' => 'gzip,static,http_metrics',
+        'cache' => [
+            'key' => 'local',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | File Watching
     |--------------------------------------------------------------------------
     |

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true">
     <testsuites>
-        <testsuite name="Feature">
+        <testsuite name="Tests">
             <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -44,13 +44,13 @@ trait InstallsRoadRunnerDependencies
             return true;
         }
 
-        if (! $this->confirm('Octane requires "spiral/roadrunner-http:^3.0.1" and "spiral/roadrunner-cli:^2.5.0". Do you wish to install them as a dependencies?')) {
-            $this->error('Octane requires "spiral/roadrunner-http" and "spiral/roadrunner-cli".');
+        if (! $this->confirm('Octane requires "spiral/roadrunner-http:^3.0.1", "spiral/roadrunner-cli:^2.5.0" and "spiral/roadrunner-kv:^4.0.0". Do you wish to install them as a dependencies?')) {
+            $this->error('Octane requires "spiral/roadrunner-http", "spiral/roadrunner-cli" and "spiral/roadrunner-kv".');
 
             return false;
         }
 
-        $command = $this->findComposer().' require spiral/roadrunner-http:^3.0.1 spiral/roadrunner-cli:^2.5.0 --with-all-dependencies';
+        $command = $this->findComposer().' require spiral/roadrunner-http:^3.0.1 spiral/roadrunner-cli:^2.5.0 spiral/roadrunner-kv:^4.0.0 --with-all-dependencies';
 
         $process = Process::fromShellCommandline($command, null, null, null, null);
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,8 +17,6 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
-                    {--rpc-host= : The RPC IP address the server should bind to}
-                    {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -78,9 +76,8 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:roadrunner', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
-            '--rpc-host' => $this->option('rpc-host'),
-            '--rpc-port' => $this->option('rpc-port'),
             '--workers' => $this->option('workers'),
+            '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),
             '--rr-config' => $this->option('rr-config'),
             '--watch' => $this->option('watch'),

--- a/src/RoadRunner/Cache.php
+++ b/src/RoadRunner/Cache.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Laravel\Octane\RoadRunner;
+
+use Illuminate\Contracts\Cache\Store;
+use Psr\SimpleCache\InvalidArgumentException;
+use Spiral\RoadRunner\KeyValue\StorageInterface;
+
+final class Cache implements Store
+{
+    private readonly string $prefix;
+
+    public function __construct(private readonly StorageInterface $storage, string $prefix)
+    {
+        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($key)
+    {
+        try {
+            return $this->storage->get($this->prefix.$key);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function many(array $keys): array
+    {
+        $results = [];
+
+        $keysPrefixes = array_map(fn (string $key) => $this->prefix.$key, $keys);
+
+        foreach ($this->storage->getMultiple($keysPrefixes) as $index => $value) {
+            $results[$keys[$index]] = $value;
+        }
+
+        return $results;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function put($key, $value, $seconds): bool
+    {
+        return $this->storage->set($this->prefix.$key, $value, $seconds);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function putMany(array $values, $seconds): bool
+    {
+        $keys = array_keys($values);
+        $keys = array_map(fn (string $key) => $this->prefix.$key, $keys);
+        $values = array_combine($keys, $values);
+
+        return $this->storage->setMultiple($values, $seconds);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function increment($key, $value = 1): int
+    {
+        $record = $this->get($this->prefix.$key);
+
+        if ($record === null) {
+            $this->storage->set($this->prefix.$key, $value);
+
+            return $value;
+        }
+
+        $value = (int) $record + $value;
+        $this->storage->set($this->prefix.$key, $value);
+
+        return $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function decrement($key, $value = 1): int
+    {
+        return $this->increment($key, $value * -1);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function forever($key, $value): bool
+    {
+        return $this->storage->set($this->prefix.$key, $value);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function forget($key): bool
+    {
+        return $this->storage->delete($this->prefix.$key);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function flush(): bool
+    {
+        return $this->storage->clear();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+}

--- a/src/RoadRunner/RoadRunnerFactory.php
+++ b/src/RoadRunner/RoadRunnerFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Octane\RoadRunner;
+
+use Illuminate\Contracts\Cache\Store;
+use Spiral\Goridge\RPC\RPC;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\KeyValue\Factory;
+use Spiral\RoadRunner\KeyValue\StorageInterface;
+
+final class RoadRunnerFactory
+{
+    public static function ensureCacheSetup(): bool
+    {
+        return class_exists(Factory::class);
+    }
+
+    public static function createRPC(): RPCInterface
+    {
+        return RPC::create(sprintf('tcp://%s:%s', config('octane.roadrunner.rpc.host'), config('octane.roadrunner.rpc.port')));
+    }
+
+    public static function createCacheStorage(RPCInterface $rpc): StorageInterface
+    {
+        return (new Factory($rpc))->select(config('octane.roadrunner.cache.key'));
+    }
+
+    public static function createCacheStore(RPCInterface $rpc): Store
+    {
+        return new Cache(self::createCacheStorage($rpc), config('cache.prefix', ''));
+    }
+}

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -39,7 +39,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
     {
         [
             'state' => [
-                'host' => $host,
+                'rpcHost' => $rpcHost,
                 'rpcPort' => $rpcPort,
             ],
         ] = $this->serverStateFile->read();
@@ -47,7 +47,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
         tap($this->processFactory->createProcess([
             $this->findRoadRunnerBinary(),
             'reset',
-            '-o', "rpc.listen=tcp://$host:$rpcPort",
+            '-o', "rpc.listen=tcp://$rpcHost:$rpcPort",
             '-s',
         ], base_path()))->start()->waitUntil(function ($type, $buffer) {
             if ($type === Process::ERR) {

--- a/tests/Feature/RoadRunnerServerTest.php
+++ b/tests/Feature/RoadRunnerServerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Laravel\Octane\Tests\Feature;
+
+use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Cache\Repository;
+use Laravel\Octane\OctaneServiceProvider;
+use Laravel\Octane\PosixExtension;
+use Laravel\Octane\RoadRunner\RoadRunnerFactory;
+use Laravel\Octane\RoadRunner\ServerProcessInspector as RoadRunnerServerProcessInspector;
+use Laravel\Octane\RoadRunner\ServerStateFile as RoadRunnerServerStateFile;
+use Laravel\Octane\SymfonyProcessFactory;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class RoadRunnerServerTest extends TestCase
+{
+    /**
+     * Path to the RoadRunner binary file.
+     */
+    private const RR_BIN_PATH = 'rr';
+
+    private string $path;
+
+    public function setUp(): void
+    {
+        $this->path = sprintf('%s/../../%s', __DIR__, rtrim(env('LARAVEL_PATH', ''), '/'));
+
+        parent::setUp();
+    }
+
+    public function testServerStart(): void
+    {
+        if (env('FEATURE_TEST') !== 'rr') {
+            $this->markTestSkipped('Only for RoadRunner Server');
+        }
+
+        $this->assertRoadRunnerBinaryExists();
+
+        $rrProc = new Process([
+            (new PhpExecutableFinder)->find(),
+            $this->path.'/artisan',
+            'octane:start',
+            '--server=roadrunner',
+            '--host=127.0.0.1',
+            '--port=22622',
+            '--workers=1',
+            '--task-workers=1',
+            '--log-level=debug',
+        ]);
+
+        $httpClient = new Guzzle(['base_uri' => 'http://127.0.0.1:22622']);
+
+        // to preventing child process blocking <https://www.php.net/manual/ru/function.proc-open.php#38870>
+        $rrProc->disableOutput();
+
+        try {
+            // https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
+            $rrProc->start();
+
+            $this->waitUntilServerIsStarted($httpClient);
+            $this->checkServerHttp($httpClient);
+            $this->checkServerProcessFile();
+            $this->checkCache();
+        } finally {
+            $this->assertSame(0, $rrProc->stop());
+        }
+    }
+
+    protected function checkServerHttp(Guzzle $httpClient): void
+    {
+        $response = $httpClient->send(new Request('GET', '/'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Laravel', $body = (string) $response->getBody());
+        $this->assertStringContainsString('https://laravel.com/', $body);
+
+        $response = $httpClient->send(new Request('GET', '/robots.txt'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('User-agent', (string) $response->getBody());
+    }
+
+    protected function checkServerProcessFile(): void
+    {
+        $processInspector = new RoadRunnerServerProcessInspector(
+            new RoadRunnerServerStateFile($this->path.'/storage/logs/octane-server-state.json'),
+            new SymfonyProcessFactory(),
+            new PosixExtension(),
+        );
+
+        $this->assertTrue($processInspector->serverIsRunning());
+    }
+
+    protected function checkCache(): void
+    {
+        $rpc = RoadRunnerFactory::createRPC();
+        $driver = RoadRunnerFactory::createCacheStorage($rpc);
+        $store = RoadRunnerFactory::createCacheStore($rpc);
+
+        $repository = new Repository($store);
+        $this->assertTrue($repository->add('k', 'v', 3600));
+        $this->assertFalse($repository->add('k', 'v', 3600));
+        $this->assertGreaterThan(3500, $driver->getTtl('k'));
+    }
+
+    protected function assertRoadRunnerBinaryExists(): void
+    {
+        $process = new Process([sprintf('%s/%s', $this->path, self::RR_BIN_PATH), '--help']);
+
+        $this->assertSame(0, $process->run(), 'RoadRunner binary file was not found: '.$process->getOutput());
+
+        $this->assertStringContainsString('serve', $process->getOutput());
+        $this->assertStringContainsString('RoadRunner', $process->getOutput());
+    }
+
+    protected function waitUntilServerIsStarted(Guzzle $guzzle, int $limit = 100): void
+    {
+        for ($i = 0; $i < $limit; $i++) {
+            try {
+                $guzzle->send(new Request('HEAD', '/'));
+
+                return;
+            } catch (GuzzleException) {
+                \usleep(30_000);
+            }
+        }
+
+        $this->fail('Server was not started');
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            OctaneServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
I offer to add the RoadRunner bridge for Laravel Cache. It will work by RPC.

Also, I prepare some config improvements to correctly set up rr server.
I am ready to update related docs and add more tests if you say I am on the right path.

Changes:
To install RoadRunner we require package "spiral/roadrunner-kv". 