### PR TITLE
[Bug][Swoole] Disable unintentional swoole header formatting by config value

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -119,12 +119,12 @@ class SwooleClient implements Client, ServesStaticFiles
         $octaneConfig = $context->octaneConfig ?? [];
 
         if (! empty($octaneConfig['static_file_headers'])) {
-            $headerNameFormatting = config('octane.swoole.header_name_formatting', true);
+            $formatHeaders = config('octane.swoole.format_headers', true);
 
             foreach ($octaneConfig['static_file_headers'] as $pattern => $headers) {
                 if ($request->is($pattern)) {
                     foreach ($headers as $name => $value) {
-                        $swooleResponse->header($name, $value, $headerNameFormatting);
+                        $swooleResponse->header($name, $value, $formatHeaders);
                     }
                 }
             }

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -161,10 +161,11 @@ class SwooleClient implements Client, ServesStaticFiles
             unset($headers['Set-Cookie']);
         }
 
-        $headerNameFormatting = config('octane.swoole.header_name_formatting', true);
+        $formatHeaders = config('octane.swoole.format_headers', true);
+
         foreach ($headers as $name => $values) {
             foreach ($values as $value) {
-                $swooleResponse->header($name, $value, $headerNameFormatting);
+                $swooleResponse->header($name, $value, $formatHeaders);
             }
         }
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -119,10 +119,12 @@ class SwooleClient implements Client, ServesStaticFiles
         $octaneConfig = $context->octaneConfig ?? [];
 
         if (! empty($octaneConfig['static_file_headers'])) {
+            $headerNameFormatting = config('octane.swoole.header_name_formatting', true);
+
             foreach ($octaneConfig['static_file_headers'] as $pattern => $headers) {
                 if ($request->is($pattern)) {
                     foreach ($headers as $name => $value) {
-                        $swooleResponse->header($name, $value);
+                        $swooleResponse->header($name, $value, $headerNameFormatting);
                     }
                 }
             }
@@ -159,9 +161,10 @@ class SwooleClient implements Client, ServesStaticFiles
             unset($headers['Set-Cookie']);
         }
 
+        $headerNameFormatting = config('octane.swoole.header_name_formatting', true);
         foreach ($headers as $name => $values) {
             foreach ($values as $value) {
-                $swooleResponse->header($name, $value);
+                $swooleResponse->header($name, $value, $headerNameFormatting);
             }
         }
 

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Tests;
 
+use Config;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -140,7 +141,7 @@ class SwooleClientTest extends TestCase
         ]);
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
-        $swooleResponse->shouldReceive('header')->once()->with('X-Test-Header', 'Valid');
+        $swooleResponse->shouldReceive('header')->once()->with('X-Test-Header', 'Valid', true);
         $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/plain');
         $swooleResponse->shouldReceive('sendfile')->once()->with(realpath(__DIR__.'/public/foo.txt'));
 
@@ -185,9 +186,9 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
-        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
-        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
-        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), true);
         $swooleResponse->shouldReceive('cookie')->once()->with('new', 'value', 0, '/', '', false, true, 'lax');
         $swooleResponse->shouldReceive('cookie')->once()->with('cleared', 'deleted', Mockery::type('int'), '/', '', false, true, 'lax');
         $swooleResponse->shouldReceive('write')->with('Hello World');
@@ -210,9 +211,9 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
-        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
-        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
-        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), true);
         $swooleResponse->shouldReceive('write')->once()->with('Hello World');
         $swooleResponse->shouldReceive('end')->once();
 
@@ -231,9 +232,9 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(419, 'Page Expired');
-        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
-        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
-        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), true);
         $swooleResponse->shouldReceive('write')->with('Hello World');
         $swooleResponse->shouldReceive('end')->once();
 
@@ -290,9 +291,9 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::mock(SwooleResponse::class);
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
-        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
-        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
-        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), true);
         $swooleResponse->shouldReceive('write')->never();
         $swooleResponse->shouldReceive('end')->once()->with('Hello World');
 
@@ -311,14 +312,38 @@ class SwooleClientTest extends TestCase
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 
         $swooleResponse->shouldReceive('status')->once()->with(200);
-        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private');
-        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html');
-        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'));
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', true);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), true);
         $swooleResponse->shouldReceive('write')->once()->with('Hello ');
         $swooleResponse->shouldReceive('write')->once()->with('World');
         $swooleResponse->shouldReceive('end')->once();
 
         $response = new Response('Hello World', 200, ['Content-Type' => 'text/html']);
+
+        $client->respond(new RequestContext([
+            'swooleResponse' => $swooleResponse,
+        ]), new OctaneResponse($response));
+    }
+
+    /** @doesNotPerformAssertions @test */
+    public function test_respond_method_preserves_header_formatting_if_configured(): void
+    {
+        $this->createApplication();
+
+        $client = new SwooleClient;
+
+        Config::set('octane.swoole.header_name_formatting', false);
+
+        $swooleResponse = Mockery::mock('Swoole\Http\Response');
+
+        $swooleResponse->shouldReceive('status')->once()->with(200);
+        $swooleResponse->shouldReceive('header')->once()->with('Cache-Control', 'no-cache, private', false);
+        $swooleResponse->shouldReceive('header')->once()->with('Content-Type', 'text/html', false);
+        $swooleResponse->shouldReceive('header')->once()->with('Date', Mockery::type('string'), false);
+        $swooleResponse->shouldReceive('end')->once();
+
+        $response = new Response(null, 200, ['Content-Type' => 'text/html']);
 
         $client->respond(new RequestContext([
             'swooleResponse' => $swooleResponse,

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -333,7 +333,7 @@ class SwooleClientTest extends TestCase
 
         $client = new SwooleClient;
 
-        Config::set('octane.swoole.header_name_formatting', false);
+        Config::set('octane.swoole.format_headers', false);
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
 


### PR DESCRIPTION
With this Pull Request i want to fix a bug where Swoole is formatting headers names unintentionally.

Swoole and Open Swoole are formatting headers by default.
https://openswoole.com/docs/modules/swoole-http-response-header

It seems odd that octane calles ResponseHeaderBag's allPreserveCase presumably to preserve the casing.
https://github.com/laravel/octane/blob/d962806a79c5ac97ddd1e371bd232d00c855c0d9/src/Swoole/SwooleClient.php#L156

But few lines later swoole will format it.
https://github.com/laravel/octane/blob/d962806a79c5ac97ddd1e371bd232d00c855c0d9/src/Swoole/SwooleClient.php#L164

The swoole formatting should be adjustable by config, so it could be behave like Laravel and Symfony by default.
This change is backwards compatible, because the default is still "true".

on-behalf-of: @e-solutions-GmbH info@esolutions.de