### PR TITLE
[2.x] Fixes "Incorrect header size"

### DIFF
--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -10,6 +10,7 @@ use Laravel\Octane\RoadRunner\RoadRunnerClient;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Worker;
 use Psr\Http\Message\ServerRequestInterface;
+use Spiral\Goridge\Exception\RelayException;
 use Spiral\Goridge\Relay;
 use Spiral\RoadRunner\Http\PSR7Worker;
 use Spiral\RoadRunner\Worker as RoadRunnerWorker;
@@ -36,28 +37,30 @@ $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
 
 $worker = null;
 
-while ($psr7Request = $psr7Client->waitRequest()) {
-    try {
+try {
+    while ($psr7Request = $psr7Client->waitRequest()) {
         $worker = $worker ?: tap((new Worker(
             new ApplicationFactory($basePath), $roadRunnerClient
         )))->boot();
-    } catch (Throwable $e) {
-        Stream::shutdown($e);
 
-        exit(1);
+        if (! $psr7Request instanceof ServerRequestInterface) {
+            break;
+        }
+
+        [$request, $context] = $roadRunnerClient->marshalRequest(new RequestContext([
+            'psr7Request' => $psr7Request,
+        ]));
+
+        $worker->handle($request, $context);
+    }
+} catch (Throwable $e) {
+    if (! $e instanceof RelayException) {
+        $worker ? report($e) : Stream::shutdown($e);
     }
 
-    if (! $psr7Request instanceof ServerRequestInterface) {
-        break;
+    exit(1);
+} finally {
+    if (! is_null($worker)) {
+        $worker->terminate();
     }
-
-    [$request, $context] = $roadRunnerClient->marshalRequest(new RequestContext([
-        'psr7Request' => $psr7Request
-    ]));
-
-    $worker->handle($request, $context);
-}
-
-if (! is_null($worker)) {
-    $worker->terminate();
 }


### PR DESCRIPTION
As of the time of writing, we have documented that customers should stop their Octane servers using the "octane:stop" command. However, it appears that some customers are sending a SIGTERM signal to the "octane:start" command, as reported in this GitHub issue: https://github.com/laravel/octane/issues/713. Specifically, during local development, people often use the `Control + C` shortcut in their terminals.

Although behind the scenes, we do invoke the "octane:stop" command when a `SIGTERM` signal is sent to the `StartRoadRunnerCommand`, there is an issue with the fact that "octane:stop" does not wait for the underlying worker to stop completely. As a result, there is a possibility that the worker may attempt to communicate with the master process (like a regular Laravel response with sleep(5)) after the master process has been stopped by the `StartRoadRunnerCommand`.

When this situation occurs, a `RelayException` exception is thrown from a RoadRunner worker, indicating its failure to communicate with the master process. So, there are two approaches to address this issue:

1. The first option is presented in this pull request. It provides a quick fix that simply "ignores" this specific exception when it occurs, without making any other changes. We document that the "octane:stop" command should be used anyway.
2. The second option involves implementing a more extensive fix. This would require modifying the "octane:stop" command to block and wait for each underlying worker to stop before proceeding with further actions, among other necessary adjustments.