### PR TITLE
Fix handleSignal deprecation warning

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -154,5 +154,7 @@ trait InteractsWithServers
     public function handleSignal(int $signal): void
     {
         $this->stopServer();
+
+        exit(0);
     }
 }


### PR DESCRIPTION
Fix not returning an exit code from "Laravel\Octane\Commands\StartCommand::handleSignal()" is deprecated

Fix #718 