### PR TITLE
[2.x] Fixes installation when using Herd

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -90,7 +90,7 @@ trait InstallsRoadRunnerDependencies
             $composerPath = (new ExecutableFinder())->find('composer');
         }
 
-        return '"'.$phpPath.'" '.$composerPath;
+        return '"'.$phpPath.'" "'.$composerPath.'"';
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the installation of Octane (RoadRunner) when using something like Herd.

Before:
```
 Octane requires "spiral/roadrunner-http:^3.0.1" and "spiral/roadrunner-cli:^2.5.0". Do you wish to install them as a dependencies? (yes/no) [no]:
 > yes

Could not open input file: /Users/nunomaduro/Library/Application
```

After:
```
 Octane requires "spiral/roadrunner-http:^3.0.1" and "spiral/roadrunner-cli:^2.5.0". Do you wish to install them as a dependencies? (yes/no) [no]:
 > yes

./composer.json has been updated
Running composer update spiral/roadrunner-http spiral/roadrunner-cli --with-all-dependencies
Loading composer repositories with package information
...
```