### PR TITLE
Add IPv6 support for Swoole

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -4,7 +4,9 @@ $config = $serverState['octaneConfig'];
 
 try {
     $host = $serverState['host'] ?? '127.0.0.1';
+
     $sock = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? SWOOLE_SOCK_TCP : SWOOLE_SOCK_TCP6;
+
     $server = new Swoole\Http\Server(
         $host,
         $serverState['port'] ?? 8080,

--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -3,13 +3,15 @@
 $config = $serverState['octaneConfig'];
 
 try {
+    $host = $serverState['host'] ?? '127.0.0.1';
+    $sock = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? SWOOLE_SOCK_TCP : SWOOLE_SOCK_TCP6;
     $server = new Swoole\Http\Server(
-        $serverState['host'] ?? '127.0.0.1',
+        $host,
         $serverState['port'] ?? 8080,
         $serverState['mode'] ?? SWOOLE_PROCESS,
         ($config['swoole']['ssl'] ?? false)
-            ? SWOOLE_SOCK_TCP | SWOOLE_SSL
-            : SWOOLE_SOCK_TCP,
+            ? $sock | SWOOLE_SSL
+            : $sock,
     );
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);


### PR DESCRIPTION
Currently creating a swoole server will result in it always listening on an IPv4 socket regardless of the host address configured.
This change will use the listen host address to determine whether Swoole should listen on an IPv4 or IPv6 socket.

Previously a swoole server configured to listen on `::` would show up in `netstat` as listening on a `0.0.0.0` address, 

![image](https://github.com/laravel/octane/assets/4212335/42f2048b-5cfc-4992-9a6b-4efe5d3f6c44)

whereas now it will correctly show it as listening on the `::` address.

![image](https://github.com/laravel/octane/assets/4212335/716b857b-aded-4b46-b5fe-a9ff27019351)
