### PR TITLE
Fix passing invalid connection session id to `Swoole\Http\Response::create()`

### DIFF
--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -27,6 +27,10 @@ class EnsureRequestsDontExceedMaxExecutionTime
             if ((time() - $row['time']) > $this->maxExecutionTime) {
                 $this->timerTable->del($workerId);
 
+                if ($this->server instanceof Server && ! $this->server->exists($row['fd'])) {
+                    continue;
+                }
+
                 $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
 
                 if ($this->server instanceof Server) {


### PR DESCRIPTION
Fixes laravel/octane#545 and potential fix for laravel/octane#712 