### PR TITLE
Fix setting Swoole server mode 

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,6 +17,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
+                    {--mode= : The mode the Swoole server should run}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
@@ -60,6 +61,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:swoole', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
+            '--mode' => $this->option('mode'),
             '--workers' => $this->option('workers'),
             '--task-workers' => $this->option('task-workers'),
             '--max-requests' => $this->option('max-requests'),

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -142,7 +142,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
      */
     protected function getMode()
     {
-        return $this->option('mode') ?? config('octane.swoole.mode') ?? $_ENV['SWOOLE_SERVER_MODE'] ?? SWOOLE_PROCESS;
+        return (int) ($this->option('mode') ?? config('octane.swoole.mode') ?? $_ENV['SWOOLE_SERVER_MODE'] ?? SWOOLE_PROCESS);
     }
 
     /**

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -22,6 +22,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     public $signature = 'octane:swoole
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
+                    {--mode= : The mode the server should run}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -101,6 +101,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'appName' => config('app.name', 'Laravel'),
             'host' => $this->getHost(),
             'port' => $this->getPort(),
+            'mode' => $this->getMode(),
             'workers' => $this->workerCount($extension),
             'taskWorkers' => $this->taskWorkerCount($extension),
             'maxRequests' => $this->option('max-requests'),
@@ -132,6 +133,16 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'task_worker_num' => $this->taskWorkerCount($extension),
             'worker_num' => $this->workerCount($extension),
         ];
+    }
+
+    /**
+     * Get the HTTP server mode.
+     *
+     * @return int
+     */
+    protected function getMode()
+    {
+        return $this->option('mode') ?? config('octane.swoole.mode') ?? $_ENV['SWOOLE_SERVER_MODE'] ?? SWOOLE_PROCESS;
     }
 
     /**


### PR DESCRIPTION
Follows laravel/octane#666

Currently, running the `php artisan octane:start --server=swoole --host=0.0.0.0 --port=80 --mode=1` will throw the following error:
```php
"exception": "[object] (Symfony\\Component\\Console\\Exception\\RuntimeException(code: 0): The \"--mode\" option does not exist. at /var/www/html/vendor/symfony/console/Input/ArgvInput.php:223)
[stacktrace]
#0 /var/www/html/vendor/symfony/console/Input/ArgvInput.php(150): Symfony\\Component\\Console\\Input\\ArgvInput->addLongOption('mode', '1')
#1 /var/www/html/vendor/symfony/console/Input/ArgvInput.php(85): Symfony\\Component\\Console\\Input\\ArgvInput->parseLongOption('--mode=1')
#2 /var/www/html/vendor/symfony/console/Input/ArgvInput.php(74): Symfony\\Component\\Console\\Input\\ArgvInput->parseToken('--mode=1', true)
#3 /var/www/html/vendor/symfony/console/Input/Input.php(55): Symfony\\Component\\Console\\Input\\ArgvInput->parse()
#4 /var/www/html/vendor/symfony/console/Command/Command.php(285): Symfony\\Component\\Console\\Input\\Input->bind(Object(Symfony\\Component\\Console\\Input\\InputDefinition))
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\\Component\\Console\\Command\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Illuminate\\Console\\OutputStyle))
#6 /var/www/html/vendor/symfony/console/Application.php(1081): Illuminate\\Console\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#7 /var/www/html/vendor/symfony/console/Application.php(320): Symfony\\Component\\Console\\Application->doRunCommand(Object(Laravel\\Octane\\Commands\\StartCommand), Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#8 /var/www/html/vendor/symfony/console/Application.php(174): Symfony\\Component\\Console\\Application->doRun(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\\Component\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#10 /var/www/html/artisan(35): Illuminate\\Foundation\\Console\\Kernel->handle(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#11 {main}
```