### PR TITLE
Add “raw” type in handleStream method for custom json in stdout

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -238,6 +238,7 @@ trait InteractsWithIO
             'request' => $this->requestInfo($stream, $verbosity),
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),
+            'raw' => $this->raw(json_encode($stream)),
             default => $this->info(json_encode($stream), $verbosity)
         };
     }


### PR DESCRIPTION
To implement the filebeat logs in stdout during the execution of the project with octane, all outputs are displayed with the info method in the output, which causes a change in the output of stdout and makes it difficult to implement filebeat using stdout.
My suggestion is to create a new type in the handleStream method and use it whenever we need to send a specific json in the output.