### PR TITLE
Add ability to run the file watcher using Bun

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -82,11 +82,25 @@ trait InteractsWithServers
         }
 
         return tap(new Process([
-            (new ExecutableFinder)->find('node'),
+            (new ExecutableFinder)->find($this->determineJavaScriptRuntime()),
             'file-watcher.cjs',
             json_encode(collect(config('octane.watch'))->map(fn ($path) => base_path($path))),
             $this->option('poll'),
         ], realpath(__DIR__.'/../../../bin'), null, null, null))->start();
+    }
+
+    /**
+     * Determine which JavaScript runtime to use.
+     *
+     * @return string
+     */
+    protected function determineJavaScriptRuntime()
+    {
+        if ($this->option('bun')) {
+            return 'bun';
+        }
+
+        return 'node';
     }
 
     /**

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -25,6 +25,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
+                    {--bun : Use Bun instead of Node to watch for changes}
                     {--log-level= : Log messages at or above the specified log level}';
 
     /**
@@ -65,6 +66,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--watch' => $this->option('watch'),
             '--poll' => $this->option('poll'),
+            '--bun' => $this->option('bun'),
         ]);
     }
 
@@ -85,6 +87,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--rr-config' => $this->option('rr-config'),
             '--watch' => $this->option('watch'),
             '--poll' => $this->option('poll'),
+            '--bun' => $this->option('bun'),
             '--log-level' => $this->option('log-level'),
         ]);
     }

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -31,6 +31,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
+                    {--bun : Use Bun instead of Node to watch for changes}
                     {--log-level= : Log messages at or above the specified log level}';
 
     /**

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -26,7 +26,8 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--watch : Automatically reload the server when the application is modified}
-                    {--poll : Use file system polling while watching in order to watch files over a network}';
+                    {--poll : Use file system polling while watching in order to watch files over a network}
+                    {--bun : Use Bun instead of Node to watch for changes}';
 
     /**
      * The command's description.


### PR DESCRIPTION
This PR adds support to using Bun to watch for file changes, as described in #749.

With Bun gaining traction in the JavaScript ecosystem, having good compatibility with Node and having landed in Sail recently, adding support for it can prove beneficial for those wanting to use Bun as their main runtime without needing to also install Node.

## Tests

Unfortunately, due to the interactive nature of the file watcher, I was unsure how to add tests for this. Since this is developer focused and implemented in a backwards compatible manner, it could be acceptable to handle this using smoke testing. I ran the file watcher using `bun bin/file-watcher.cjs` and `node bin/file-watcher.cjs` with a temporary folder and found that the behaviour is identical:

![image](https://github.com/laravel/octane/assets/46111684/ced29a51-943a-471a-8163-535caeebc1d3)
![image](https://github.com/laravel/octane/assets/46111684/dde10fa1-5c9a-4b61-ad0b-e09e62f05f4c)


The bash script I used to simulate this is:

```sh
#!/usr/bin/env bash

set -euo pipefail

touch test-files/a.js
sleep 1
echo "const a = 1;" > test-files/a.js
sleep 1
mkdir test-files/test
sleep 1
touch test-files/test/b.js
sleep 1
rm -rf test-files/test
sleep 1
rm test-files/a.js
```

And run with `bash +x test.sh`

## Documentation

I create a PR in the documentation repository to add documentation on using Bun with Octane. See https://github.com/laravel/docs/pull/9064.