### PR TITLE
Fix swoole host only configurable via `--host` parameter

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -3,13 +3,13 @@
 $config = $serverState['octaneConfig'];
 
 try {
-    $host = $serverState['host'] ?? '127.0.0.1';
+    $host = $config['host'] ?? '127.0.0.1';
 
     $sock = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? SWOOLE_SOCK_TCP : SWOOLE_SOCK_TCP6;
 
     $server = new Swoole\Http\Server(
         $host,
-        $serverState['port'] ?? 8080,
+        $config['port'] ?? 8080,
         $config['swoole']['mode'] ?? SWOOLE_PROCESS,
         ($config['swoole']['ssl'] ?? false)
             ? $sock | SWOOLE_SSL

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -15,7 +15,7 @@ class StartCommand extends Command implements SignalableCommandInterface
      */
     public $signature = 'octane:start
                     {--server= : The server that should be used to serve the application}
-                    {--host=127.0.0.1 : The IP address the server should bind to}
+                    {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}


### PR DESCRIPTION
## Description:
When attempting to configure Swoole to bind on a different host using anything except `--host` in the commandline, it wouldn't work and always stick to `127.0.0.1`.

## The issue:
- When you configure the config value `octane.host`, the `$serverState['host']` will stay at `127.0.0.1`, and only `$serverState['octaneConfig']['host']` changes to the configured value. 

- `bin/createSwooleServer.php` references on line 6 and 12 the `$serverState` variable for `host` and `port`, instead of the `$config` variable (which points to `$serverState['octaneConfig']`). Other values all make use of the `$config` value instead. 

- When fixing this, the binding works, but the log output keeps saying `127.0.0.1` regardless.

## Root cause
- The log output mismatch is because `src/Commands/StartCommand.php` by default passed a value of `127.0.0.1` to `--host` when not provided in the command. But because `src/Commands/Concerns/InteractsWithServers.php`'s `getHost` looks at this option first, it will always use the value `127.0.0.1` when you want to configure it using any method except the command line.

- The issue above, combined with the usage of `$serverState` instead of `$config` in the `createSwooleServer.php` file, explains both the mismatched output & configuration behaviour. Because the `$config` will contain the correct value from the config, but the stateFile uses the output of the `getHost` command to print to the terminal.

## The fix

- In `bin/CreateSwooleServer.php` replace `$serverState` with `$config`
- In `src/Commands/StartCommand.php` remove the default value of `127.0.0.1` for `--host` as that's already handled by `src/Commands/Concerns/InteractsWithServers.php` at the `getHost` method