### PR TITLE
Fix swoole host only configurable via --host parameter + incorrect default port

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -9,7 +9,7 @@ try {
 
     $server = new Swoole\Http\Server(
         $host,
-        $serverState['port'] ?? 8080,
+        $serverState['port'] ?? 8000,
         $config['swoole']['mode'] ?? SWOOLE_PROCESS,
         ($config['swoole']['ssl'] ?? false)
             ? $sock | SWOOLE_SSL

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -15,7 +15,7 @@ class StartCommand extends Command implements SignalableCommandInterface
      */
     public $signature = 'octane:start
                     {--server= : The server that should be used to serve the application}
-                    {--host=127.0.0.1 : The IP address the server should bind to}
+                    {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -22,7 +22,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
      * @var string
      */
     public $signature = 'octane:roadrunner
-                    {--host=127.0.0.1 : The IP address the server should bind to}
+                    {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -20,7 +20,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
      * @var string
      */
     public $signature = 'octane:swoole
-                    {--host=127.0.0.1 : The IP address the server should bind to}
+                    {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}


### PR DESCRIPTION
## Description:
When attempting to configure Swoole to bind on a different host using anything except `--host` in the commandline, it wouldn't work and always stick to `127.0.0.1`.

Additionally, `bin/createSwooleServer.php` contains a default port value of `8080` despite the [command stating](https://github.com/laravel/octane/blob/d6b29ee456d00ebf359685ff952b6b55a1230592/src/Commands/StartCommand.php#L19) the default is `8000`.

## The issue
- When you configure the config value `octane.host`, the `$serverState['host']` will stay at `127.0.0.1`, and only `$serverState['octaneConfig']['host']` changes to the configured value. 

## The cause
- `src/Commands/StartCommand.php` is using a default value of `127.0.0.1` for `--host` when this argument is not provided in the command. But because `src/Commands/Concerns/InteractsWithServers.php`'s `getHost` looks at this option first, it will always use the value `127.0.0.1` when you want to configure it using any method except the command line.

## The fix

- In `src/Commands/StartCommand.php` & `src/Commands/StartSwooleCommand.php` I removed the default value of `127.0.0.1` for `--host` as that's already handled by `src/Commands/Concerns/InteractsWithServers.php` in the [`getHost()` method](https://github.com/laravel/octane/blob/d6b29ee456d00ebf359685ff952b6b55a1230592/src/Commands/Concerns/InteractsWithServers.php#L130).
    - the same `getHost` method is also used with Roadrunner, so I did the same modification for `src/Commands/StartRoadRunnerCommand.php`.

- The current default port value is provided via the [`InteractsWithServers.php` Concern](https://github.com/laravel/octane/blob/d6b29ee456d00ebf359685ff952b6b55a1230592/src/Commands/Concerns/InteractsWithServers.php#L140) using the correct value of `8000` to `createSwooleServer`. Therefor the modification of `8080` to `8000` in `createSwooleServer` should have no effect on existing deployments (ie: there should be no way for the `createSwooleServer`  `port` variable to ever be empty and having to resort to the default).