### PR TITLE
[2.x] Prefix FrankenPHP version with `v` for `version_compare()`

### DIFF
--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -17,7 +17,7 @@ trait InstallsFrankenPhpDependencies
      *
      * @var string
      */
-    protected $requiredFrankenPhpVersion = '1.0.0';
+    protected $requiredFrankenPhpVersion = 'v1.0.0';
 
     /**
      * Ensure the FrankenPHP's Caddyfile and worker script are installed.


### PR DESCRIPTION
I was experimenting with creating a Docker image to run a FrankenPHP web server with Octane. I made the following `Dockerfile`:

```
FROM dunglas/frankenphp

RUN install-php-extensions \
    pcntl

COPY . /app

ENTRYPOINT ["php", "artisan", "octane:frankenphp"]
```

When I started the container it immediately exited, and when inspecting the logs I found that Octane was attempting to download the FrankenPHP binary despite it already existing in the Docker image at `/usr/local/bin/frankenphp`:

```
   WARN  Your FrankenPHP binary version (v1.0.1) may be incompatible with Octane.

 Should Octane download the latest FrankenPHP binary version for your operating system? (yes/no) [yes]:
 > 
   ERROR  FrankenPHP binaries are currently only available for Linux (x86_64) and macOS. Other systems should use the Docker images or compile FrankenPHP manually.

   INFO  Server running…

  Local: http://127.0.0.1:8000 

  Press Ctrl+C to stop the server


   INFO  sh: 1: exec: /usr/local/bin/frankenphp: not found

```

After some debugging I found that the [version_compare() on this line](https://github.com/laravel/octane/blob/2.x/src/Commands/Concerns/InstallsFrankenPhpDependencies.php#L141) might not be working the way we think. The frankenphp binary returns `v1.0.1` as its version and it's being compared to `1.0.0` without the `v`. As you can see here `v1.0.1 >= 1.0.0` returns false, and causes Octane to re-download the binary: https://3v4l.org/uWjgX

After changing `$requiredFrankenPhpVersion` to `v1.0.1` in my local files and starting the container again, Octane doesn't try to re-download the frankenphp binary and the container runs successfully.