### PR TITLE
[2.x] Ignores `write error` message for now

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -37,6 +37,7 @@ trait InteractsWithIO
         '[INFO] sdnotify: not notified',
         'exiting; byeee!!',
         'storage cleaning happened too recently',
+        'write error',
     ];
 
     /**


### PR DESCRIPTION
This pull request ignores `write error` message for now, while @dunglas updates the message to `DEBUG` level. 

https://github.com/dunglas/frankenphp/blob/b7c8d4cd490ba4a869b3021a10a1ca5423e9e2cc/frankenphp.go#L519