### PR TITLE
[2.x] Improves version fetching

### DIFF
--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -14,11 +14,6 @@ trait InstallsFrankenPhpDependencies
     use FindsFrankenPhpBinary;
 
     /**
-     * The message that should be displayed Octane is unable to determine the current FrankenPHP binary version.
-     */
-    protected const UNABLE_TO_DETERMINE_CURRENT_VERSION = 'Unable to determine the current FrankenPHP binary version. Please report this issue: https://github.com/laravel/octane/issues/new.';
-
-    /**
      * The minimum required version of the FrankenPHP binary.
      *
      * @var string
@@ -142,13 +137,17 @@ trait InstallsFrankenPhpDependencies
             });
 
         if ($lineWithVersion === null) {
-            return $this->warn(static::UNABLE_TO_DETERMINE_CURRENT_VERSION);
+            return $this->warn(
+                'Unable to determine the current FrankenPHP binary version. Please report this issue: https://github.com/laravel/octane/issues/new.',
+            );
         }
 
         $version = Str::of($lineWithVersion)->trim()->afterLast('v')->value();
 
         if (preg_match('/\d+\.\d+\.\d+/', $version) !== 1) {
-            return $this->warn(static::UNABLE_TO_DETERMINE_CURRENT_VERSION);
+            return $this->warn(
+                'Unable to determine the current FrankenPHP binary version. Please report this issue: https://github.com/laravel/octane/issues/new.',
+            );
         }
 
         if (version_compare($version, $this->requiredFrankenPhpVersion, '>=')) {

--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -132,7 +132,7 @@ trait InstallsFrankenPhpDependencies
      */
     protected function ensureFrankenPhpBinaryMeetsRequirements($frakenPhpBinary)
     {
-        $buildInfo = tap(new Process([$frakenPhpBinary, 'build-info',], base_path()))
+        $buildInfo = tap(new Process([$frakenPhpBinary, 'build-info'], base_path()))
             ->run()
             ->getOutput();
 


### PR DESCRIPTION
This pull request improves the version fetching, as apparently the builds in different OSs display the version differently. So, using a `build-info` command is a better, more reliable way.

Fixes https://github.com/laravel/octane/issues/774, https://github.com/laravel/octane/issues/771.