### PR TITLE
[2.x] Uses Octane's max execution time

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -36,7 +36,7 @@ $requestCount = 0;
 $maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'];
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
 
-if (! is_null($requestMaxExecutionTime)) {
+if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {
     set_time_limit((int) $requestMaxExecutionTime);
 }
 

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -34,6 +34,11 @@ $frankenPhpClient = new FrankenPhpClient();
 $worker = null;
 $requestCount = 0;
 $maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'];
+$requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
+
+if (! is_null($requestMaxExecutionTime)) {
+    set_time_limit((int) $requestMaxExecutionTime);
+}
 
 try {
     $handleRequest = static function () use (&$worker, $basePath, $frankenPhpClient) {

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -88,6 +88,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'APP_PUBLIC_PATH' => public_path(),
             'LARAVEL_OCTANE' => 1,
             'MAX_REQUESTS' => $this->option('max-requests'),
+            'REQUEST_MAX_EXECUTION_TIME' => $this->maxExecutionTime(),
             'CADDY_SERVER_ADMIN_PORT' => $this->adminPort(),
             'CADDY_SERVER_LOG_LEVEL' => $this->option('log-level') ?: (app()->environment('local') ? 'INFO' : 'WARN'),
             'CADDY_SERVER_LOGGER' => 'json',
@@ -177,6 +178,16 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         }
 
         return "$config\n\t\t}";
+    }
+
+    /**
+     * Get the maximum number of seconds that workers should be allowed to execute a single request.
+     *
+     * @return int
+     */
+    protected function maxExecutionTime()
+    {
+        return config('octane.max_execution_time', 30);
     }
 
     /**

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -293,6 +293,11 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             }
 
             if ($debug['level'] !== 'info') {
+                // Request timeout...
+                if (isset($debug['exit_status']) && $debug['exit_status'] === 255) {
+                    return;
+                }
+
                 return $this->error($debug['msg']);
             }
         });


### PR DESCRIPTION
Allows to set Octane's max execution time using the configuration file just like in RoadRunner or Swoole.