### PR TITLE
[2.x] make adminPort always > 0

### DIFF
--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -207,7 +207,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
     {
         $defaultPort = 2019;
 
-        return $defaultPort + ($this->getPort() - 8000);
+        return $defaultPort + ($this->getPort() + 8000);
     }
 
     /**


### PR DESCRIPTION
When a port number lower than `5980` is used, it results in the admin port being set to a value below `0`, which triggers an error as shown below:

```
  GuzzleHttp\Psr7\Exception\MalformedUriException 

  Unable to parse URI: http://localhost:-1/config/apps/frankenphp

  at vendor/guzzlehttp/psr7/src/Uri.php:85
     81▕     {
     82▕         if ($uri !== '') {
     83▕             $parts = self::parse($uri);
     84▕             if ($parts === false) {
  ➜  85▕                 throw new MalformedUriException("Unable to parse URI: $uri");
     86▕             }
     87▕             $this->applyParts($parts);
     88▕         }
     89▕     }

      +50 vendor frames 

  51  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

This PR fixes the above issue. 