### PR TITLE
[2.x] Adds `--admin-port`

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,7 +17,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
-                    {--admin-port= : The port the admin server should be available on}
+                    {--admin-port= : The port the admin server should be available on [FrankenPHP only]}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -17,6 +17,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
+                    {--admin-port= : The port the admin server should be available on}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
@@ -102,6 +103,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:frankenphp', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
+            '--admin-port' => $this->option('admin-port'),
             '--workers' => $this->option('workers'),
             '--max-requests' => $this->option('max-requests'),
             '--caddyfile' => $this->option('caddyfile'),

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -25,6 +25,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
     public $signature = 'octane:frankenphp
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
+                    {--admin-port= : The port the admin server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
@@ -205,9 +206,19 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
      */
     protected function adminPort()
     {
+        if ($this->option('admin-port')) {
+            return (int) $this->option('admin-port');
+        }
+
         $defaultPort = 2019;
 
-        return $defaultPort + ($this->getPort() - 8000);
+        return tap($defaultPort + ($this->getPort() - 8000), function ($adminPort) {
+            if ($adminPort < 0) {
+                throw new InvalidArgumentException(
+                    'Unable to determine admin port. Please specify the [--admin-port] option.',
+                );
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This pull request adds the  `--admin-port` option, in case Octane is not able to determine the admin port by himself.