### PR TITLE
Fix public path for roadrunner

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -84,7 +84,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
             '-o', 'rpc.listen=tcp://'.$this->rpcHost().':'.$this->rpcPort(),
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
-            '-o', 'http.static.dir='.base_path('public'),
+            '-o', 'http.static.dir='.public_path(),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
             '-o', 'logs.mode=production',
             '-o', 'logs.level='.($this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn')),


### PR DESCRIPTION
This pull request fix problem with roadrunner static dir when it`s not default `public` directory in root of project.
![image](https://github.com/laravel/octane/assets/46485085/ec0b647d-a7df-4e5f-b946-159ac01e22c1)

For example in one of my project it need to be set to `site/public`.