### PR TITLE
[2.x] Require pcntl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.1.0",
+        "ext-pcntl": "*",
         "laravel/framework": "^10.10.1",
         "laminas/laminas-diactoros": "^3.0",
         "laravel/serializable-closure": "^1.3.0",


### PR DESCRIPTION
As mentioned in [https://github.com/laravel/octane/issues/796](https://github.com/laravel/octane/issues/796)
This PR makes octane require pcntl extension.
