### PR TITLE
Draft: Add Atomic Locking to the Swoole Cache and Octane tick method

### DIFF
--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -171,6 +171,7 @@ class OctaneServiceProvider extends ServiceProvider
 
         Cache::extend('octane', fn () => Cache::repository($store));
     }
+    
 
     /**
      * Register the commands offered by Octane.

--- a/src/Swoole/InvokeTickCallable.php
+++ b/src/Swoole/InvokeTickCallable.php
@@ -18,6 +18,8 @@ class InvokeTickCallable
     ) {
     }
 
+    protected bool $lock;
+
     /**
      * Invoke the tick listener.
      *
@@ -66,6 +68,13 @@ class InvokeTickCallable
     {
         $this->immediate = true;
 
+        return $this;
+    }
+
+    public function withoutOverlapping(int $seconds)
+    {
+        $this->lock = true;
+        
         return $this;
     }
 }

--- a/src/Swoole/SwoolTableLock.php
+++ b/src/Swoole/SwoolTableLock.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Laravel\Octane\Swoole;
+
+use Illuminate\Cache\Lock;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class SwoolTableLock extends Lock
+{
+    protected $store;
+
+    /**
+     * Create a new lock instance.
+     *
+     * @param  \Illuminate\Cache\ArrayStore  $store
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct($store, $name, $seconds, $owner = null)
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->store = $store;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        $expiration = $this->store->locks[$this->name]['expiresAt'] ?? Carbon::now()->addSecond();
+
+        if ($this->exists() && $expiration->isFuture()) {
+            return false;
+        }
+
+        $this->store->locks[$this->name] = [
+            'owner' => $this->owner,
+            'expiresAt' => $this->seconds === 0 ? null : Carbon::now()->addSeconds($this->seconds),
+        ];
+
+        return true;
+    }
+
+    /**
+     * Determine if the current lock exists.
+     *
+     * @return bool
+     */
+    protected function exists()
+    {
+        return isset($this->store->locks[$this->name]);
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        if (! $this->exists()) {
+            return false;
+        }
+
+        if (! $this->isOwnedByCurrentProcess()) {
+            return false;
+        }
+
+        $this->forceRelease();
+
+        return true;
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return string
+     */
+    protected function getCurrentOwner()
+    {
+        if (! $this->exists()) {
+            return null;
+        }
+
+        return $this->store->locks[$this->name]['owner'];
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        unset($this->store->locks[$this->name]);
+    }
+}


### PR DESCRIPTION
Add the ability to use atomic locking via the Swoole cache and add atomic locking to the Octane::tick

The octane tick method will use the same  nomenclature as the commands in base Laravel `withoutOverlapping()`.

