### PR TITLE
[2.x] Fix missing array key issue with FrankenPHP

### DIFF
--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -268,11 +268,13 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                 return $this->info($output);
             }
 
-            if (is_array($stream = json_decode($debug['msg'], true))) {
+            $message = $debug['msg'] ?? '';
+
+            if (is_array($stream = json_decode($message, true))) {
                 return $this->handleStream($stream);
             }
 
-            if ($debug['msg'] == 'handled request') {
+            if ($message == 'handled request') {
                 if (! $this->laravel->isLocal()) {
                     return;
                 }
@@ -300,7 +302,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             }
 
             if ($debug['level'] === 'warn') {
-                return $this->warn($debug['msg']);
+                return $this->warn($message);
             }
 
             if ($debug['level'] !== 'info') {
@@ -309,7 +311,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                     return;
                 }
 
-                return $this->error($debug['msg']);
+                return $this->error($message);
             }
         });
     }


### PR DESCRIPTION
I'm not entirely sure this is the correct fix or if I should apply a better fallback message than `''`. Maybe "Unknown error"?

Fixes https://github.com/laravel/octane/issues/803