### PR TITLE
FrankenPHP: Remove unnecessary use statement to fix PHP warning

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -6,7 +6,6 @@ use Laravel\Octane\RequestContext;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Worker;
 use Symfony\Component\HttpFoundation\Response;
-use Throwable;
 
 if ((! ($_SERVER['FRANKENPHP_WORKER'] ?? false)) || ! function_exists('frankenphp_handle_request')) {
     echo 'FrankenPHP must be in worker mode to use this script.';


### PR DESCRIPTION
Currently when running `php artisan octane:work --server=frankenphp` with full error reporting enabled, the following warning is displayed, which this PR fixes:

```
WARN  PHP Warning:  The use statement with non-compound name 'Throwable' has no effect in /app/vendor/laravel/octane/bin/frankenphp-worker.php on line 9
```
---

<details>
    <summary>Steps to reproduce</summary>



1. Create a new Laravel app in `example-app/` and install octane (type `yes` to accept still in Beta):
    ```bash
    docker run --rm -it -u $(id -u $USER) -v $PWD:/app composer:latest composer create-project laravel/laravel example-app
    cd example-app
    docker run --rm -it -u $(id -u $USER) -v $PWD:/app composer:latest composer require laravel/octane
    docker run --rm -it -u $(id -u $USER) -v $PWD:/app dunglas/frankenphp:1.0-php8.3 php artisan octane:install --server=frankenphp
    ```

2. Create the following `Dockerfile`:
    ```Dockerfile
    FROM dunglas/frankenphp:1.0-php8.3

    RUN install-php-extensions pcntl;

    # Using php.ini-development enables full error reporting 
    RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini; \
        sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/' $PHP_INI_DIR/php.ini;

    ENTRYPOINT ["php", "artisan", "octane:start", "--server=frankenphp"]
    ```
3. Create the following `docker-compose.yml`, as per the [FrakenPHP docs](https://frankenphp.dev/docs/docker/#using-a-volume-in-development):
    ```yaml
    services:
      php:
        build: .
        ports:
          - 8000:8000
        volumes:
          - ./:/app:z
          - caddy_data:/data:z
          - caddy_config:/config:z
        tty: true

    volumes:
      caddy_data:
      caddy_config:
    ```
4. Run the following command to start octane 
    ```bash
    docker-compose up --build
    Building php
    DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
                Install the buildx component to build images with BuildKit:
                https://docs.docker.com/go/buildx/

    Sending build context to Docker daemon  59.64MB
    Step 1/4 : FROM dunglas/frankenphp:1.0-php8.3
     ---> 0cfa433eac62
    Step 2/4 : RUN install-php-extensions pcntl;
     ---> Using cache
     ---> 8c7d04a009a8
    Step 3/4 : RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini;     sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/' $PHP_INI_DIR/php.ini;
     ---> Running in 026ced34ecba
    Removing intermediate container 026ced34ecba
     ---> 592b6db9944e
    Step 4/4 : ENTRYPOINT ["php", "artisan", "octane:start", "--server=frankenphp"]
     ---> Running in aef1f1d18d72
    Removing intermediate container aef1f1d18d72
     ---> 1ad87e24ec0d
    Successfully built 1ad87e24ec0d
    Successfully tagged example-app_php:latest
    Recreating example-app_php_1 ... done
    Attaching to example-app_php_1

    INFO  Server running…

    Local: http://0.0.0.0:8000

    Press Ctrl+C to stop the server

       WARN  PHP Warning:  The use statement with non-compound name 'Throwable' has no effect in /app/vendor/laravel/octane/bin/frankenphp-worker.php on line 9
       WARN  PHP Warning:  The use statement with non-compound name 'Throwable' has no effect in /app/vendor/laravel/octane/bin/frankenphp-worker.php on line 9
       WARN  PHP Warning:  The use statement with non-compound name 'Throwable' has no effect in /app/vendor/laravel/octane/bin/frankenphp-worker.php on line 9
       ...
</details>