### PR TITLE
feat(frankenphp): make HTTP to HTTPS redirection opt-in

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -26,6 +26,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]}
+                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed [FrankenPHP only]}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';
@@ -108,6 +109,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--max-requests' => $this->option('max-requests'),
             '--caddyfile' => $this->option('caddyfile'),
             '--https' => $this->option('https'),
+            '--http-redirect' => $this->option('http-redirect'),
             '--watch' => $this->option('watch'),
             '--poll' => $this->option('poll'),
             '--log-level' => $this->option('log-level'),

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -26,7 +26,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]}
-                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed [FrankenPHP only]}
+                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -30,7 +30,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates}
-                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed}
+                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed)}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';
@@ -77,6 +77,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $port = $this->getPort();
 
         $https = $this->option('https');
+
         $serverName = $https
             ? "https://$host:$port"
             : "http://:$port";

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -76,7 +76,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $host = $this->option('host');
         $port = $this->getPort();
 
-        $https =  $this->option('https');
+        $https = $this->option('https');
         $serverName = $https
             ? "https://$host:$port"
             : "http://:$port";

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -30,6 +30,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates}
+                    {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';
@@ -75,7 +76,8 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $host = $this->option('host');
         $port = $this->getPort();
 
-        $serverName = $this->option('https')
+        $https =  $this->option('https');
+        $serverName = $https
             ? "https://$host:$port"
             : "http://:$port";
 
@@ -90,6 +92,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'LARAVEL_OCTANE' => 1,
             'MAX_REQUESTS' => $this->option('max-requests'),
             'REQUEST_MAX_EXECUTION_TIME' => $this->maxExecutionTime(),
+            'CADDY_GLOBAL_OPTIONS' => ($https && $this->option('http-redirect')) ? '' : 'auto_https disable_redirects',
             'CADDY_SERVER_ADMIN_PORT' => $this->adminPort(),
             'CADDY_SERVER_LOG_LEVEL' => $this->option('log-level') ?: (app()->environment('local') ? 'INFO' : 'WARN'),
             'CADDY_SERVER_LOGGER' => 'json',


### PR DESCRIPTION
While checking https://github.com/laravel/octane/issues/811, I discovered that by default, HTTP to HTTP redirection is enabled, even when using the non-default HTTPS port:

```console
./artisan octane:start --https
```

This starts an HTTPS server on port 8000, but also an HTTP server on port 80, which will likely be unavailable.

This patch makes the redirection opt-in, and disables it by default:

```console
./artisan octane:start --https --redirect-http
```
