### PR TITLE
Listen Caddy admin port on all interfaces

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -40,6 +40,7 @@ trait InteractsWithIO
         'write error',
         'unable to determine directory for user configuration; falling back to current directory',
         '$HOME environment variable is empty',
+        'admin endpoint on open interface; host checking disabled',
     ];
 
     /**

--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -1,7 +1,7 @@
 {
 	{$CADDY_GLOBAL_OPTIONS}
 
-	admin localhost:{$CADDY_SERVER_ADMIN_PORT}
+	admin :{$CADDY_SERVER_ADMIN_PORT}
 
 	frankenphp {
 		worker "{$APP_PUBLIC_PATH}/frankenphp-worker.php" {$CADDY_SERVER_WORKER_COUNT}


### PR DESCRIPTION
Currently, Caddy admin APIs are not accessible from outside of container. This PR allows accessing Caddy admin APIs inside a container by listening on all interfaces.