### PR TITLE
Fix Swoole in-memory table size

### DIFF
--- a/src/Tables/TableFactory.php
+++ b/src/Tables/TableFactory.php
@@ -14,8 +14,8 @@ class TableFactory
         static::ensureDependenciesAreLoaded();
 
         return extension_loaded('openswoole')
-            ? new OpenSwooleTable($size)
-            : new SwooleTable($size);
+            ? new OpenSwooleTable($size, 1)
+            : new SwooleTable($size, 1);
     }
 
     /**

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -63,6 +63,17 @@ class TableTest extends TestCase
         return $this->assertInstanceOf(SwooleTable::class, $table);
     }
 
+    public function test_can_use_all_available_rows()
+    {
+        $table = $this->createSwooleTable();
+
+        for ($i = 0; $i < 1000; $i++) {
+            $table->set($i, ['string' => 'foo']);
+        }
+
+        $this->assertSame(1000, $table->count());
+    }
+
     /**
      * @dataProvider validStringValues
      */


### PR DESCRIPTION
Octane considers that the Swoole table size parameter is the number of rows it can store. But this is not true; calculating the number of rows a table can store is hard as it contains the table header, key size, and conflict proportion. Their wiki page does not explain exactly how it works: https://wiki.swoole.com/#/memory/table?id=__construct.

The current Octane implementation is not working as expected. By trying to insert 1000 rows in the example table provided, which sets 1000 as the table size, Swoole was only able to store 596 rows.

This PR adds a test to check if octane can use all available table rows and sets the table conflict proportion to 1 to ensure that the table has allocated memory to at least the defined row counts.

 > The conflict proportion default value for the original Swoole is 0.2. OpenSwoole uses 1 as a default according to their documentation (https://openswoole.com/docs/modules/swoole-table-construct). So this issue is only happening on the original swoole.  I added 1 as the conflict parameter to both to ensure both implementations use the same value. 