### PR TITLE
Fix Swoole in-memory timer table size

### DIFF
--- a/bin/createSwooleTimerTable.php
+++ b/bin/createSwooleTimerTable.php
@@ -6,7 +6,7 @@ use Swoole\Table;
 require_once __DIR__.'/../src/Tables/TableFactory.php';
 
 if (($serverState['octaneConfig']['max_execution_time'] ?? 0) > 0) {
-    $timerTable = TableFactory::make($serverState['octaneConfig']['max_timer_table_size'] ?? 250);
+    $timerTable = TableFactory::make($serverState['workers']);
 
     $timerTable->column('worker_pid', Table::TYPE_INT);
     $timerTable->column('time', Table::TYPE_INT);


### PR DESCRIPTION
The current implementation of the timer table starts to throw some insufficient memory errors when there are a lot of workers ~200 and when all those workers are processing requests at the same time (as reported at https://github.com/laravel/octane/issues/648).

The https://github.com/laravel/octane/pull/650 PR introduced the `max_timer_table_size` undocumented config value so we can control the timer table size manually to avoid this problem.

However, ensuring the $size passed to the table creation will guarantee the desired number of rows (with  https://github.com/laravel/octane/pull/818). We can now use the number of workers to define the timer table size and get rid of the undocumented manual parameter.

