### PR TITLE
[2.x] Flushes `Once::class` on Operation Terminated

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -15,6 +15,7 @@ use Laravel\Octane\Listeners\CollectGarbage;
 use Laravel\Octane\Listeners\DisconnectFromDatabases;
 use Laravel\Octane\Listeners\EnsureUploadedFilesAreValid;
 use Laravel\Octane\Listeners\EnsureUploadedFilesCanBeMoved;
+use Laravel\Octane\Listeners\FlushOnce;
 use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
 use Laravel\Octane\Listeners\FlushUploadedFiles;
 use Laravel\Octane\Listeners\ReportException;
@@ -101,6 +102,7 @@ return [
         ],
 
         OperationTerminated::class => [
+            FlushOnce::class,
             FlushTemporaryContainerInstances::class,
             // DisconnectFromDatabases::class,
             // CollectGarbage::class,

--- a/src/Listeners/FlushOnce.php
+++ b/src/Listeners/FlushOnce.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Support\Once;
+
+class FlushOnce
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function handle($event): void
+    {
+        if (class_exists(Once::class)) {
+            Once::flush();
+        }
+    }
+}

--- a/src/Listeners/FlushOnce.php
+++ b/src/Listeners/FlushOnce.php
@@ -10,7 +10,6 @@ class FlushOnce
      * Handle the event.
      *
      * @param  mixed  $event
-     * @return void
      */
     public function handle($event): void
     {

--- a/tests/Listeners/FlushOnceTest.php
+++ b/tests/Listeners/FlushOnceTest.php
@@ -2,11 +2,9 @@
 
 namespace Laravel\Octane\Listeners;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Once;
 use Laravel\Octane\Tests\TestCase;
-use ReflectionClass;
 
 class FlushOnceTest extends TestCase
 {
@@ -40,4 +38,3 @@ function my_rand()
 {
     return once(fn () => rand(1, PHP_INT_MAX));
 }
-

--- a/tests/Listeners/FlushOnceTest.php
+++ b/tests/Listeners/FlushOnceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Support\Once;
+use Laravel\Octane\Tests\TestCase;
+use ReflectionClass;
+
+class FlushOnceTest extends TestCase
+{
+    public function test_once_is_flushed()
+    {
+        if (! class_exists(Once::class)) {
+            $this->markTestSkipped('Once is only supported in Laravel 11+');
+        }
+
+        [$app, $worker] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+            Request::create('/', 'GET'),
+            Request::create('/', 'GET'),
+        ]);
+
+        $results = [];
+
+        $app['router']->middleware('web')->get('/', function () use (&$results) {
+            $results[] = my_rand();
+        });
+
+        $worker->run();
+
+        $this->assertTrue($results[0] !== $results[1]);
+        $this->assertTrue($results[0] !== $results[2]);
+        $this->assertTrue($results[1] !== $results[2]);
+    }
+}
+
+function my_rand()
+{
+    return once(fn () => rand(1, PHP_INT_MAX));
+}
+


### PR DESCRIPTION
This pull request flushes the `Once::class` on the `OperationTerminated` event. This event is fired when:

- Request is handled.
- Tick is handled.
- Task is handled.

This pull request can be merged before or after : https://github.com/laravel/framework/pull/49744.