### PR TITLE
Add octane.roadrunner.config_version settings to roadrunner start binary

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -77,7 +77,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         $server = tap(new Process(array_filter([
             $roadRunnerBinary,
             '-c', $this->configPath(),
-            '-o', 'version=3',
+            '-o', 'version='.config('octane.roadrunner.config_version', '3'),
             '-o', 'http.address='.$this->option('host').':'.$this->getPort(),
             '-o', 'server.command='.(new PhpExecutableFinder)->find().','.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -86,10 +86,10 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-o', 'http.pool.supervisor.exec_ttl='.$this->maxExecutionTime(),
             '-o', 'http.static.dir='.public_path(),
             '-o', 'http.middleware='.config('octane.roadrunner.http_middleware', 'static'),
-            '-o', 'logs.mode=production',
+            '-o', 'logs.mode='.config('octane.roadrunner.logs.mode', 'production'),
             '-o', 'logs.level='.($this->option('log-level') ?: (app()->environment('local') ? 'debug' : 'warn')),
-            '-o', 'logs.output=stdout',
-            '-o', 'logs.encoding=json',
+            '-o', 'logs.output='.config('octane.roadrunner.logs.output', 'stdout'),
+            '-o', 'logs.encoding='.config('octane.roadrunner.logs.encoding', 'json'),
             'serve',
         ]), base_path(), [
             'APP_ENV' => app()->environment(),


### PR DESCRIPTION
 For more comfortable developing i add an opportunity to set RoadRunner version via config.
 
 UPD
 
Also add:
- logs.mode
- logs.output
- logs.encoding