### PR TITLE
Update InstallCommand.php

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -126,7 +126,10 @@ class InstallCommand extends Command
      */
     public function installFrankenPhpServer()
     {
-        if (! $this->confirm("FrankenPHP's Octane integration is in beta and should be used with caution in production. Do you wish to continue?")) {
+        if ($this->option('no-interaction')) {
+            $this->info("FrankenPHP's Octane integration is in beta and should be used with caution in production.");
+            $this->newLine();
+        } elseif (! $this->confirm("FrankenPHP's Octane integration is in beta and should be used with caution in production. Do you wish to continue?")) {
             return false;
         }
 


### PR DESCRIPTION
The commit fixes the issue when FrankenPHP install fails when no-interaction flag is present.

Octane Version
2.3.2

Laravel Version
10.43.0

PHP Version
8.3

What server type are you using?
FrankenPHP

Steps To Reproduce
`php artisan octane:install --server=frankenphp --no-interaction`
