### PR TITLE
fix swoole file streaming

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -11,6 +11,7 @@ use Laravel\Octane\MimeType;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use ReflectionClass;
 use Swoole\Http\Response as SwooleResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -201,7 +202,10 @@ class SwooleClient implements Client, ServesStaticFiles
     protected function sendResponseContent(OctaneResponse $octaneResponse, SwooleResponse $swooleResponse): void
     {
         if ($octaneResponse->response instanceof BinaryFileResponse) {
-            $swooleResponse->sendfile($octaneResponse->response->getFile()->getPathname());
+            $swooleResponse->sendfile(
+                $octaneResponse->response->getFile()->getPathname(),
+                (new ReflectionClass(BinaryFileResponse::class))->getProperty('offset')->getValue($octaneResponse->response)
+            );
 
             return;
         }


### PR DESCRIPTION
fix #763

as explain in the Swoole / Openswoole [documentation](https://openswoole.com/docs/modules/swoole-server-sendfile) if `offset` parameter is unset, the whole file is send resulting in issues with file streaming.