### PR TITLE
[2.x] Ignores `storage clean stamps will be incomplete`

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -40,6 +40,7 @@ trait InteractsWithIO
         'write error',
         'unable to determine directory for user configuration; falling back to current directory',
         '$HOME environment variable is empty',
+        'unable to get instance ID',
     ];
 
     /**


### PR DESCRIPTION
This pull request fixes issues [https://github.com/laravel/octane/issues/774](https://github.com/laravel/octane/issues/774) and [https://github.com/laravel/octane/issues/810](https://github.com/laravel/octane/issues/810) by ignoring a debug message that does not affect anything regarding FrankenPHP.