### PR TITLE
Fix #851: When docker stop container, db connections still persists

### DIFF
--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -149,7 +149,7 @@ trait InteractsWithServers
      */
     public function getSubscribedSignals(): array
     {
-        return [SIGINT, SIGTERM];
+        return [SIGINT, SIGTERM, SIGHUP];
     }
 
     /**


### PR DESCRIPTION
fix for https://github.com/laravel/octane/issues/851

Problem:

When we run octane+openswoole in docker container we can't use CTRL+C combination to stop the server. 
In docker case, container operation system will be ripped during stop phase. In common cases, docker send SIGTERM signal into bash/sh terminal, that is an owner of the container. But, terminal SIGTERM not propagated into "octane" commands. 

Solution:

We should trap SIGHUP (terminal connection disrupted) signal, because only this signal will be sent into "octane" command, when terminal window closed. That can be easily tested on local machine: open OS task manager, find php stack and run "octane:start --server=swoole", and  close the terminal process. You will see, that php processes still there. But if we trap SIGHUP signal, octane command will receive the signal to stop the server.

That's it 