### PR TITLE
[2.x] Closes monolog handlers by event listener if the worker stops

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -11,6 +11,7 @@ use Laravel\Octane\Events\TickTerminated;
 use Laravel\Octane\Events\WorkerErrorOccurred;
 use Laravel\Octane\Events\WorkerStarting;
 use Laravel\Octane\Events\WorkerStopping;
+use Laravel\Octane\Listeners\CloseMonologHandlers;
 use Laravel\Octane\Listeners\CollectGarbage;
 use Laravel\Octane\Listeners\DisconnectFromDatabases;
 use Laravel\Octane\Listeners\EnsureUploadedFilesAreValid;
@@ -114,6 +115,7 @@ return [
         ],
 
         WorkerStopping::class => [
+            CloseMonologHandlers::class,
             //
         ],
     ],

--- a/config/octane.php
+++ b/config/octane.php
@@ -116,7 +116,6 @@ return [
 
         WorkerStopping::class => [
             CloseMonologHandlers::class,
-            //
         ],
     ],
 

--- a/src/Listeners/CloseMonologHandlers.php
+++ b/src/Listeners/CloseMonologHandlers.php
@@ -4,6 +4,11 @@ namespace Laravel\Octane\Listeners;
 
 class CloseMonologHandlers
 {
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
     public function handle($event): void
     {
         if (! $event->app->resolved('log')) {
@@ -11,8 +16,10 @@ class CloseMonologHandlers
         }
 
         collect($event->app->make('log')->getChannels())
-            ->map->getLogger()
+            ->map
+            ->getLogger()
             ->filter(fn ($logger) => method_exists($logger, 'close'))
-            ->each->close();
+            ->each
+            ->close();
     }
 }

--- a/src/Listeners/CloseMonologHandlers.php
+++ b/src/Listeners/CloseMonologHandlers.php
@@ -4,17 +4,15 @@ namespace Laravel\Octane\Listeners;
 
 class CloseMonologHandlers
 {
-
     public function handle($event): void
     {
-        if (!$event->app->resolved('log')) {
+        if (! $event->app->resolved('log')) {
             return;
         }
 
         collect($event->app->make('log')->getChannels())
             ->map->getLogger()
-            ->filter(fn($logger) => method_exists($logger, 'close'))
+            ->filter(fn ($logger) => method_exists($logger, 'close'))
             ->each->close();
     }
-
 }

--- a/src/Listeners/CloseMonologHandlers.php
+++ b/src/Listeners/CloseMonologHandlers.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class CloseMonologHandlers
+{
+
+    public function handle($event): void
+    {
+        if (!$event->app->resolved('log')) {
+            return;
+        }
+
+        collect($event->app->make('log')->getChannels())
+            ->map->getLogger()
+            ->filter(fn($logger) => method_exists($logger, 'close'))
+            ->each->close();
+    }
+
+}

--- a/tests/Listeners/CloseMonologHandlersTest.php
+++ b/tests/Listeners/CloseMonologHandlersTest.php
@@ -39,6 +39,6 @@ class CloseMonologHandlersTest extends TestCase
         });
 
         // The listener should call close on the monolog handlers after terminating the worker.
-        $worker->terminate();
+        // $worker->terminate();
     }
 }

--- a/tests/Listeners/CloseMonologHandlersTest.php
+++ b/tests/Listeners/CloseMonologHandlersTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Illuminate\Log\Logger;
+use Laravel\Octane\Tests\TestCase;
+use Mockery;
+use Monolog;
+
+class FlushMonologStateTest extends TestCase
+{
+    /** @doesNotPerformAssertions */
+    public function test_logger_are_reset()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+            Request::create('/', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/', function () {
+            // ..
+        });
+
+        $worker->run();
+
+        $log = $app['log'];
+
+        $app['log'] = tap(Mockery::mock($log), function ($logger) {
+            $logger->shouldReceive('getChannels')->once()->andReturn([
+                tap(Mockery::mock(Logger::class), function ($logger) {
+                    $logger->shouldReceive('getLogger')->once()->andReturn(
+                        tap(Mockery::mock(Monolog\Logger::class), function ($logger) {
+                            $logger->shouldReceive('close')->once();
+                        }),
+                    );
+                }),
+            ]);
+        });
+
+        // The listener should call close on the monolog handlers after terminating the worker.
+        $worker->terminate();
+    }
+}

--- a/tests/Listeners/CloseMonologHandlersTest.php
+++ b/tests/Listeners/CloseMonologHandlersTest.php
@@ -39,6 +39,6 @@ class CloseMonologHandlersTest extends TestCase
         });
 
         // The listener should call close on the monolog handlers after terminating the worker.
-        // $worker->terminate();
+        $worker->terminate();
     }
 }

--- a/tests/Listeners/CloseMonologHandlersTest.php
+++ b/tests/Listeners/CloseMonologHandlersTest.php
@@ -8,7 +8,7 @@ use Laravel\Octane\Tests\TestCase;
 use Mockery;
 use Monolog;
 
-class FlushMonologStateTest extends TestCase
+class CloseMonologHandlersTest extends TestCase
 {
     /** @doesNotPerformAssertions */
     public function test_logger_are_closed_after_worker_termination()

--- a/tests/Listeners/CloseMonologHandlersTest.php
+++ b/tests/Listeners/CloseMonologHandlersTest.php
@@ -11,7 +11,7 @@ use Monolog;
 class FlushMonologStateTest extends TestCase
 {
     /** @doesNotPerformAssertions */
-    public function test_logger_are_reset()
+    public function test_logger_are_closed_after_worker_termination()
     {
         [$app, $worker, $client] = $this->createOctaneContext([
             Request::create('/', 'GET'),


### PR DESCRIPTION
Fix for #850 
Laravel uses Monolog for logging, some monolog handler have a important close() function.
Octane does never call this function! In normal laravel applications, monolog calls close by itself via __destruct().
It seams like __destruct() is never called in Swoole, so close the handler manually per event.