### PR TITLE
Fix #838: The Symfony VarDumper dumps correctly when in HTML context

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -68,7 +68,7 @@ return [
         WorkerStarting::class => [
             EnsureUploadedFilesAreValid::class,
             EnsureUploadedFilesCanBeMoved::class,
-            EnsureTheCorrectVarDumperIsUsed::class
+            EnsureTheCorrectVarDumperIsUsed::class,
         ],
 
         RequestReceived::class => [

--- a/config/octane.php
+++ b/config/octane.php
@@ -13,6 +13,7 @@ use Laravel\Octane\Events\WorkerStarting;
 use Laravel\Octane\Events\WorkerStopping;
 use Laravel\Octane\Listeners\CollectGarbage;
 use Laravel\Octane\Listeners\DisconnectFromDatabases;
+use Laravel\Octane\Listeners\EnsureTheCorrectVarDumperIsUsed;
 use Laravel\Octane\Listeners\EnsureUploadedFilesAreValid;
 use Laravel\Octane\Listeners\EnsureUploadedFilesCanBeMoved;
 use Laravel\Octane\Listeners\FlushOnce;
@@ -67,6 +68,7 @@ return [
         WorkerStarting::class => [
             EnsureUploadedFilesAreValid::class,
             EnsureUploadedFilesCanBeMoved::class,
+            EnsureTheCorrectVarDumperIsUsed::class
         ],
 
         RequestReceived::class => [

--- a/src/Listeners/EnsureTheCorrectVarDumperIsUsed.php
+++ b/src/Listeners/EnsureTheCorrectVarDumperIsUsed.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+class EnsureTheCorrectVarDumperIsUsed
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        VarDumper::setHandler(function ($var, ?string $label = null) {
+            $cloner = new VarCloner();
+            $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+            $var = $cloner->cloneVar($var);
+            if (null !== $label) {
+                $var = $var->withContext(['label' => $label]);
+            }
+            $dumper = app()->runningInConsole() ? new CliDumper() : new HtmlDumper();
+            $dumper->dump($var);
+        });
+    }
+}

--- a/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
+++ b/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane\Tests\Listeners;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Blade;
+use Laravel\Octane\Tests\TestCase;
+
+class EnsureTheCorrectVarDumperIsUsedTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_ENV['APP_RUNNING_IN_CONSOLE']);
+        parent::tearDown();
+    }
+
+    public function test_a_variable_is_contained_within_the_html_if_dumped_in_a_blade_view()
+    {
+        $variableToDump = "someString";
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/view', 'GET')
+        ]);
+        $app['router']->get('/view', function (Application $app) use ($variableToDump) {
+            return Blade::render('@dump($variableToDump)', [
+                'variableToDump' => $variableToDump
+            ]);
+        });
+
+        $worker->run();
+
+        $htmlFromResponse = $client->responses[0]->getContent();
+        $this->assertStringContainsString($variableToDump, $htmlFromResponse);
+    }
+
+}

--- a/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
+++ b/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
@@ -9,7 +9,6 @@ use Laravel\Octane\Tests\TestCase;
 
 class EnsureTheCorrectVarDumperIsUsedTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -39,5 +38,4 @@ class EnsureTheCorrectVarDumperIsUsedTest extends TestCase
         $htmlFromResponse = $client->responses[0]->getContent();
         $this->assertStringContainsString($variableToDump, $htmlFromResponse);
     }
-
 }

--- a/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
+++ b/tests/Listeners/EnsureTheCorrectVarDumperIsUsedTest.php
@@ -24,13 +24,13 @@ class EnsureTheCorrectVarDumperIsUsedTest extends TestCase
 
     public function test_a_variable_is_contained_within_the_html_if_dumped_in_a_blade_view()
     {
-        $variableToDump = "someString";
+        $variableToDump = 'someString';
         [$app, $worker, $client] = $this->createOctaneContext([
-            Request::create('/view', 'GET')
+            Request::create('/view', 'GET'),
         ]);
         $app['router']->get('/view', function (Application $app) use ($variableToDump) {
             return Blade::render('@dump($variableToDump)', [
-                'variableToDump' => $variableToDump
+                'variableToDump' => $variableToDump,
             ]);
         });
 


### PR DESCRIPTION
Fixes [#838](https://github.com/laravel/octane/issues/838)

When using `dump()` or `@dump` in Octane nothing is displayed when we're in the context of a request.
One would expect a dump in form of HTML like it's the case in regular Laravel

This commit fixes the Symfony `VarDumper` so it detects whether we're in console or not by using `app()->runningInConsole()` instead of looking at the value of `PHP_SAPI`.

The test I wrote checks that Blade explicity renders a dumped variable. It is unfortunate that I have to explicitly set `$_ENV['APP_RUNNING_IN_CONSOLE']` in the test and unset it afterwards. It probably would be better to generally mock `app()->runningInConsole()` so it returns false for all tests. In the scope of this fix I did not want to touch other tests though.

Cheers

