### PR TITLE
[2.x] Fix #838: The Symfony VarDumper properly dumps in html context

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -6,6 +6,7 @@ use Laravel\Octane\Octane;
 ini_set('display_errors', 'stderr');
 
 $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
+$_SERVER['VAR_DUMPER_FORMAT'] = 'html';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes [#838](https://github.com/laravel/octane/issues/838) 
When using `dump(...)` for debugging purposes in a request/response context, nothing is displayed in the HTML response. 
One would expect to see the dumped variable as HTML in the response as is the case with regular Laravel

This one-line fix sets a global parameter that tells the Symfony `VarDumper` to always dump as html when we are in the context of a request/response with octane. Without this line the `VarDumper `will check PHP_SAPI to determine the context of the variable dump (which is always 'cli' with Octane).

Cheers