### PR TITLE
[2.x] Add clear opcode cache switch

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -30,7 +30,9 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
-        $this->clearOpcodeCache();
+        if($this->serverState['octaneConfig']['clear_opcode_cache'] ?? true){
+            $this->clearOpcodeCache();
+        }
 
         $this->workerState->server = $server;
         $this->workerState->workerId = $workerId;

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -30,7 +30,7 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
-        if($this->serverState['octaneConfig']['clear_opcode_cache'] ?? true){
+        if ($this->serverState['octaneConfig']['clear_opcode_cache'] ?? true) {
             $this->clearOpcodeCache();
         }
 


### PR DESCRIPTION
Clearing opcache is optional during containerized deployments