### PR TITLE
Fix undefined array key "assets"

### DIFF
--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Commands\Concerns;
 
 use GuzzleHttp\Client;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Octane\FrankenPhp\Concerns\FindsFrankenPhpBinary;
@@ -55,6 +56,8 @@ trait InstallsFrankenPhpDependencies
      * Download the latest version of the FrankenPHP binary.
      *
      * @return string
+     *
+     * @throws RequestException
      */
     protected function downloadFrankenPhpBinary()
     {
@@ -71,9 +74,12 @@ trait InstallsFrankenPhpDependencies
             throw new RuntimeException('FrankenPHP binaries are currently only available for Linux (x86_64, aarch64) and macOS. Other systems should use the Docker images or compile FrankenPHP manually.');
         }
 
-        $assets = Http::accept('application/vnd.github+json')
+        $response = Http::accept('application/vnd.github+json')
             ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
-            ->get('https://api.github.com/repos/dunglas/frankenphp/releases/latest')['assets'];
+            ->get('https://api.github.com/repos/dunglas/frankenphp/releases/latest')
+            ->throw(fn () => $this->error("Get FrankenPHP's latest release failed, see the response below:"));
+
+        $assets = $response['assets'] ?? [];
 
         foreach ($assets as $asset) {
             if ($asset['name'] !== $assetName) {

--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -77,7 +77,7 @@ trait InstallsFrankenPhpDependencies
         $response = Http::accept('application/vnd.github+json')
             ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
             ->get('https://api.github.com/repos/dunglas/frankenphp/releases/latest')
-            ->throw(fn () => $this->error("Get FrankenPHP's latest release failed, see the response below:"));
+            ->throw(fn () => $this->error("Failed to download FrankenPHP."));
 
         $assets = $response['assets'] ?? [];
 


### PR DESCRIPTION
Failure to fetch assets due to API rate limit exceeded, The `RequestException` will now be thrown.

<img width="1207" alt="image" src="https://github.com/laravel/octane/assets/33931153/1dde2c07-0df7-43f5-9ef5-7abf20701972">


close #863