### PR TITLE
Display correct elapsed time with Roadrunner

### DIFF
--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -258,6 +258,10 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             return mb_substr($elapsed, 0, -2) * 0.001;
         }
 
+        if (filter_var($elapsed, FILTER_VALIDATE_INT) !== false) {
+            return $elapsed;
+        }
+
         return (float) $elapsed * 1000;
     }
 

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -230,7 +230,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                         'method' => $method,
                         'url' => $url,
                         'statusCode' => $statusCode,
-                        'duration' => $elapsed,
+                        'duration' => $this->calculateElapsedTime($elapsed),
                     ]);
                 }
             });
@@ -243,6 +243,22 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     $this->error($output);
                 }
             });
+    }
+
+    /**
+     * Calculate the elapsed time for a request.
+     */
+    protected function calculateElapsedTime(string $elapsed): float
+    {
+        if (Str::endsWith($elapsed, 'ms')) {
+            return substr($elapsed, 0, -2);
+        }
+
+        if (Str::endsWith($elapsed, 'µs')) {
+            return mb_substr($elapsed, 0, -2) * 0.001;
+        }
+
+        return (float) $elapsed * 1000;
     }
 
     /**

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -230,7 +230,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                         'method' => $method,
                         'url' => $url,
                         'statusCode' => $statusCode,
-                        'duration' => $this->calculateElapsedTime($elapsed),
+                        'duration' => $elapsed,
                     ]);
                 }
             });
@@ -243,22 +243,6 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
                     $this->error($output);
                 }
             });
-    }
-
-    /**
-     * Calculate the elapsed time for a request.
-     */
-    protected function calculateElapsedTime(string $elapsed): float
-    {
-        if (Str::endsWith($elapsed, 'ms')) {
-            return substr($elapsed, 0, -2);
-        }
-
-        if (Str::endsWith($elapsed, 'µs')) {
-            return mb_substr($elapsed, 0, -2) * 0.001;
-        }
-
-        return (float) $elapsed * 1000;
     }
 
     /**


### PR DESCRIPTION
## Problem
After the latest release of Roadrunner [v2023.3.12](https://github.com/roadrunner-server/roadrunner/releases/tag/v2023.3.12) all the timestamps are in ms without any unit.

> All since log entries are now always shown as milliseconds

This makes the current timestamps 1000 times too big.

See debug statement below
<img width="725" alt="image" src="https://github.com/laravel/octane/assets/60270137/402108c9-e213-42aa-85d5-c5555424d59b">

## Solution
I propose to just remove the calculation function. I'm not sure however how you handle backwards compatibility or you just want to bump the min-version? 

## Environment
Fresh install with:
Laravel: v11.0.7
Octane: v2.3.5
Roadrunner: v2023.3.12


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
