### PR TITLE
Add failing test for UrlGenerator warming up issue

### DIFF
--- a/tests/UrlGeneratorStateTest.php
+++ b/tests/UrlGeneratorStateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\URL;
+
+class UrlGeneratorStateTest extends TestCase
+{
+    public function test_url_generator_creates_correct_urls_across_subsequent_with_bind()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('foo/bar', 'GET'),
+            Request::create('foo/wibble', 'GET'),
+        ]);
+
+        $app['router']->bind('param', function (string $value)
+        {
+            URL::defaults(['param' => strtoupper($value)]);
+
+            return $value;
+        });
+
+        $app['router']->get('foo/{param}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function () {
+                return URL::getDefaultParameters()['param'];
+            },
+        ]);
+
+        $worker->run();
+
+        $this->assertEquals('BAR', $client->responses[0]->getContent());
+        $this->assertEquals('WIBBLE', $client->responses[1]->getContent());
+    }
+}

--- a/tests/UrlGeneratorStateTest.php
+++ b/tests/UrlGeneratorStateTest.php
@@ -2,36 +2,41 @@
 
 namespace Laravel\Octane\Tests;
 
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Support\Facades\URL;
+use Orchestra\Testbench\Http\Middleware\RedirectIfAuthenticated;
 
 class UrlGeneratorStateTest extends TestCase
 {
     public function test_url_generator_creates_correct_urls_across_subsequent_with_bind()
     {
         [$app, $worker, $client] = $this->createOctaneContext([
-            Request::create('foo/bar', 'GET'),
-            Request::create('foo/wibble', 'GET'),
+            Request::create('foo/bar/home', 'GET'),
+            Request::create('foo/baz/home', 'GET'),
         ]);
 
-        $app['router']->bind('param', function (string $value)
+        $app['router']->bind('param', function (string $value) use ($app)
         {
-            URL::defaults(['param' => strtoupper($value)]);
+            $app['url']->defaults(['param' => strtoupper($value)]);
 
             return $value;
         });
 
-        $app['router']->get('foo/{param}', [
-            'middleware' => SubstituteBindings::class,
-            'uses' => function () {
-                return URL::getDefaultParameters()['param'];
-            },
-        ]);
+        $app['router']->get('/foo/{param}/login', function (Application $app)
+        {
+            return $app['url']->getDefaultParameters()['param'];
+        })->middleware([SubstituteBindings::class, RedirectIfAuthenticated::class])->name('login');
+
+        $app['router']->get('/foo/{param}/home', function (Application $app)
+        {
+            return $app['url']->getDefaultParameters()['param'];
+        })->middleware([SubstituteBindings::class, Authenticate::class])->name('home');
 
         $worker->run();
 
         $this->assertEquals('BAR', $client->responses[0]->getContent());
-        $this->assertEquals('WIBBLE', $client->responses[1]->getContent());
+        $this->assertEquals('BAZ', $client->responses[1]->getContent());
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This aims to add failing test for https://github.com/laravel/octane/issues/809. To recap, the issue is when using Route::bind() and URL::defaults() with Octane, it seems that UrlGenerator keeps the same instance of RouteUrlGenerator, and so the defaults are cached between requests.

There is another problem in this test which I got `Route [login] not defined`.  It doesn't really make sense to me since I put `->name('login')` in route definition, but I might be wrong.

Please let me know if you have any questions.