### PR TITLE
fix: windows install error, don`t need to chmod (rr.exe)

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -177,7 +177,9 @@ trait InstallsRoadRunnerDependencies
             }
         });
 
-        chmod(base_path('rr'), 0755);
+        if (! windows_os()) {
+            chmod(base_path('rr'), 0755);
+        }
 
         $this->line('');
     }


### PR DESCRIPTION
fix: windows install error, don`t need to chmod (rr.exe)
```shell
ErrorException 

 chmod(): No such file or directory
```