### PR TITLE
fix: use capture to populate global request with json array

### DIFF
--- a/src/FrankenPhp/FrankenPhpClient.php
+++ b/src/FrankenPhp/FrankenPhpClient.php
@@ -19,7 +19,7 @@ class FrankenPhpClient implements Client
     public function marshalRequest(RequestContext $context): array
     {
         return [
-            Request::createFromGlobals(),
+            Request::capture(),
             $context,
         ];
     }


### PR DESCRIPTION
Request::capture is using createFromBase that checks is request is json and replace request with json array

``` 
       if ($newRequest->isJson()) {
            $newRequest->request = $newRequest->json();
        } 
```

and later when in controller you can use request->get('some-json-key') to get value as its a default laravel behavior [check index.php:53]

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
