### PR TITLE
Ignored http-chunk usage in open_http2_protocol

### DIFF
--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -240,7 +240,7 @@ class SwooleClient implements Client, ServesStaticFiles
             return;
         }
 
-        if ($length <= $this->chunkSize) {
+        if ($length <= $this->chunkSize || config('octane.swoole.options.open_http2_protocol', false)) {
             $swooleResponse->end($content);
 
             return;


### PR DESCRIPTION
close #873

The issue's feedback is correct.

swoole can't directly determine if http2 is enabled or not, so it uses the config file to determine that.