### PR TITLE
Boot RoadRunner worker before first request

### DIFF
--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -38,11 +38,11 @@ $roadRunnerClient = new RoadRunnerClient($psr7Client = new PSR7Worker(
 $worker = null;
 
 try {
-    while ($psr7Request = $psr7Client->waitRequest()) {
-        $worker = $worker ?: tap((new Worker(
-            new ApplicationFactory($basePath), $roadRunnerClient
-        )))->boot();
+    $worker = $worker ?: tap((new Worker(
+        new ApplicationFactory($basePath), $roadRunnerClient
+    )))->boot();
 
+    while ($psr7Request = $psr7Client->waitRequest()) {
         if (! $psr7Request instanceof ServerRequestInterface) {
             break;
         }


### PR DESCRIPTION
The RoadRunner worker is currently only initialized and booted once a request is made. 

With this change, the worker is already booted when the first request is received. As a result, the first request will be executed much faster because the configured 'warm' services are already booted. 

Before commit d9b2a33 this was already the case. In 6b4db3a the while & try is flipped.  