### PR TITLE
[2.x] Removes frankenphp out of beta

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -128,13 +128,6 @@ class InstallCommand extends Command
      */
     public function installFrankenPhpServer()
     {
-        if ($this->option('no-interaction')) {
-            $this->info("FrankenPHP's Octane integration is in beta and should be used with caution in production.");
-            $this->newLine();
-        } elseif (! $this->confirm("FrankenPHP's Octane integration is in beta and should be used with caution in production. Do you wish to continue?", true)) {
-            return false;
-        }
-
         $gitIgnorePath = base_path('.gitignore');
 
         if (File::exists($gitIgnorePath)) {


### PR DESCRIPTION
At this point, FrankenPHP seems stable enough that we can remove this warning.