### PR TITLE
fix: use capture to populate global request with json array

### DIFF
--- a/src/FrankenPhp/FrankenPhpClient.php
+++ b/src/FrankenPhp/FrankenPhpClient.php
@@ -19,7 +19,7 @@ class FrankenPhpClient implements Client
     public function marshalRequest(RequestContext $context): array
     {
         return [
-            Request::createFromGlobals(),
+            Request::capture(),
             $context,
         ];
     }


### PR DESCRIPTION
To replicate : 

Create route with FrankenPHP server.

```
Route::post('/test', static function (Request $request) {
    return new JsonResponse($request->get('key'));
});
```

POST json 

```
curl --location 'localhost/test/' \                                                                                                                               
--header 'Content-Type: application/json' \
--data '{"key":"value"}'
```

Expected `"value"`
Current  "{}"


Laravel is using ```$response = $kernel->handle($request = Request::capture())->send();``` in index.php but FrankenPhpClient is just doing Request::createFromGlobals() and its not passing by \Illuminate\Http\Request::createFromBase that populate request using incoming json values using this code fragment.

```     
       if ($newRequest->isJson()) {
            $newRequest->request = $newRequest->json();
        }
``` 



