### PR TITLE
Fixing memory leaks that stem from the cloned application instance

### DIFF
--- a/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
+++ b/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
@@ -24,7 +24,7 @@ class GiveNewApplicationInstanceToViewFactory
         });
 
         $provider = $event->sandbox->getProvider(ViewServiceProvider::class);
-        if($provider && method_exists($provider, 'setApplication')){
+        if ($provider && method_exists($provider, 'setApplication')){
             $provider->setApplication($event->sandbox);
         }
     }

--- a/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
+++ b/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
@@ -24,7 +24,7 @@ class GiveNewApplicationInstanceToViewFactory
         });
 
         $provider = $event->sandbox->getProvider(ViewServiceProvider::class);
-        if ($provider && method_exists($provider, 'setApplication')){
+        if ($provider && method_exists($provider, 'setApplication')) {
             $provider->setApplication($event->sandbox);
         }
     }

--- a/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
+++ b/src/Listeners/GiveNewApplicationInstanceToViewFactory.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Octane\Listeners;
 
+use Illuminate\View\ViewServiceProvider;
+
 class GiveNewApplicationInstanceToViewFactory
 {
     /**
@@ -20,5 +22,10 @@ class GiveNewApplicationInstanceToViewFactory
 
             $view->share('app', $event->sandbox);
         });
+
+        $provider = $event->sandbox->getProvider(ViewServiceProvider::class);
+        if($provider && method_exists($provider, 'setApplication')){
+            $provider->setApplication($event->sandbox);
+        }
     }
 }


### PR DESCRIPTION
This pull request seeks to fix memory leaks like the one in [#887](https://github.com/laravel/octane/issues/887).
One big downside about Octane's approach of cloning a new application instance on each request is that it's not really possible to track down all references to the original application instance. This can lead to memory leaks that are hard to detect and incompatibilities with other Laravel libraries.

In this pull request I put forward a new approach that seeks to instead keep the same application instance but reset it to a previous state:

![octane drawio](https://github.com/laravel/octane/assets/45872305/ba334315-c116-4a63-ac2b-de69f9c62a9a)

This can be achieved pretty elegantly by creating an `ApplicationSnapshot` that extends the base Application and stores its initial state. Since PHP objects have access to the protected scope of other objects of the same class, the Snapshot is able to reset all Application properties via `get_object_vars()`. This ends up doing the same thing as `clone`, but without creating a new instance.

I tested this approach with the Swoole and FrankenPHP runtimes and it indeed fixes the memory leak in [#887](https://github.com/laravel/octane/issues/887) and should generally make integrating Octane with other `ServiceProviders `easier.

The main changes are in the `Worker.php` class and the newly added `ApplicationSnapshot.php` class. All other other changes mainly remove code that becomes redundant through this PR and adjusts tests that expect the application instance to change.

This is just an initial draft. There is probably potential for more code removal and the approach should be thoroughly tested with other first party packages.
 