### PR TITLE
Fix to stuck in "Application change detected. Restarting workers" with Octane + FrankenPHP + Sail.

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -186,7 +186,7 @@ return [
     'watch' => [
         'app',
         'bootstrap',
-        'config',
+        'config/**/*.php',
         'database/**/*.php',
         'public/**/*.php',
         'resources/**/*.php',


### PR DESCRIPTION
This pull request seeks to fix #884.

The actual bug is, when we use  Octane + FrankenPHP + Sail, along with env `XDG_CONFIG_HOME:/var/www/html/config`, FrankenPHP generates and updates `/var/www/html/config/caddy/autosave.json` automatically. Therefore, we see continuous "Application change detected. Restarting workers" message and process would be stucked.

This fix would ignore the case.