### PR TITLE
Allow debug in CADDY_GLOBAL_OPTIONS

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -29,6 +29,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]}
                     {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]}
+                    {--server-debug : Enable debug mode for the selected server [FrankenPHP only]}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';
@@ -112,6 +113,7 @@ class StartCommand extends Command implements SignalableCommandInterface
             '--caddyfile' => $this->option('caddyfile'),
             '--https' => $this->option('https'),
             '--http-redirect' => $this->option('http-redirect'),
+            '--server-debug' => $this->option('server-debug'),
             '--watch' => $this->option('watch'),
             '--poll' => $this->option('poll'),
             '--log-level' => $this->option('log-level'),

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -95,7 +95,11 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'LARAVEL_OCTANE' => 1,
             'MAX_REQUESTS' => $this->option('max-requests'),
             'REQUEST_MAX_EXECUTION_TIME' => $this->maxExecutionTime(),
-            'CADDY_GLOBAL_OPTIONS' => ($https && $this->option('http-redirect')) ? '' : 'auto_https disable_redirects',
+            'CADDY_GLOBAL_OPTIONS' => trim(sprintf(
+                '%s %s',
+                ($debug['level'] ?? '') === 'debug' ? 'debug' : '',
+                ($https && $this->option('http-redirect')) ? '' : 'auto_https disable_redirects',
+            )),
             'CADDY_SERVER_ADMIN_PORT' => $this->adminPort(),
             'CADDY_SERVER_LOG_LEVEL' => $this->option('log-level') ?: (app()->environment('local') ? 'INFO' : 'WARN'),
             'CADDY_SERVER_LOGGER' => 'json',

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -33,6 +33,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates}
                     {--http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed)}
+                    {--server-debug : Enable debug mode}
                     {--watch : Automatically reload the server when the application is modified}
                     {--poll : Use file system polling while watching in order to watch files over a network}
                     {--log-level= : Log messages at or above the specified log level}';
@@ -96,9 +97,9 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'MAX_REQUESTS' => $this->option('max-requests'),
             'REQUEST_MAX_EXECUTION_TIME' => $this->maxExecutionTime(),
             'CADDY_GLOBAL_OPTIONS' => trim(sprintf(
-                '%s %s',
-                ($debug['level'] ?? '') === 'debug' ? 'debug' : '',
-                ($https && $this->option('http-redirect')) ? '' : 'auto_https disable_redirects',
+                "%s\n%s",
+                $this->option('server-debug') ? 'debug' : '',
+                $https && $this->option('http-redirect') ? '' : 'auto_https disable_redirects',
             )),
             'CADDY_SERVER_ADMIN_PORT' => $this->adminPort(),
             'CADDY_SERVER_LOG_LEVEL' => $this->option('log-level') ?: (app()->environment('local') ? 'INFO' : 'WARN'),


### PR DESCRIPTION
This PR let `debug` option to be appended in CADDY_GLOBAL_OPTIONS. See https://caddyserver.com/docs/caddyfile/options#debug
