### PR TITLE
Add enable_access_logs boolean config for swoole

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -97,7 +97,7 @@ class OnWorkerStart
             if (! config('octane.swoole.enable_access_logs', true)) {
                 return;
             }
-            
+
             Stream::request(
                 $request->getMethod(),
                 $request->fullUrl(),

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -94,10 +94,10 @@ class OnWorkerStart
     protected function streamRequestsToConsole($server)
     {
         $this->workerState->worker->onRequestHandled(function ($request, $response, $sandbox) {
-            if (! $sandbox->environment('local', 'testing')) {
+            if (! config('octane.swoole.enable_access_logs', true)) {
                 return;
             }
-
+            
             Stream::request(
                 $request->getMethod(),
                 $request->fullUrl(),

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -94,7 +94,7 @@ class OnWorkerStart
     protected function streamRequestsToConsole($server)
     {
         $this->workerState->worker->onRequestHandled(function ($request, $response, $sandbox) {
-            if (! config('octane.swoole.enable_access_logs', true)) {
+            if (! config('octane.swoole.enable_access_logs', false)) {
                 return;
             }
 


### PR DESCRIPTION
Adds `octane.swoole.enable_access_log` config variable to toggle access logs for swoole server.
See https://github.com/laravel/octane/issues/893

~~**It defaults to `true`, that means it will enable the logs for non-local environments if it's not set to false explicitly in the config file.~~

**It defaults to `false`, that means it won't enable the logs for non-local environments, but it will stop logging for local/testing

