### PR TITLE
UrlGenerator Sandbox

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -28,6 +28,7 @@ trait ProvidesDefaultConfigurationOptions
     {
         return [
             \Laravel\Octane\Listeners\CreateConfigurationSandbox::class,
+            \Laravel\Octane\Listeners\CreateUrlGeneratorSandbox::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToAuthorizationGate::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToBroadcastManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToDatabaseManager::class,

--- a/src/Listeners/CreateUrlGeneratorSandbox.php
+++ b/src/Listeners/CreateUrlGeneratorSandbox.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class CreateUrlGeneratorSandbox
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        $event->sandbox->instance('url', clone $event->sandbox['url']);
+    }
+}

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -123,6 +123,7 @@ class OctaneServiceProvider extends ServiceProvider
     {
         $this->app->singleton(Listeners\CollectGarbage::class);
         $this->app->singleton(Listeners\CreateConfigurationSandbox::class);
+        $this->app->singleton(Listeners\CreateUrlGeneratorSandbox::class);
         $this->app->singleton(Listeners\DisconnectFromDatabases::class);
         $this->app->singleton(Listeners\EnforceRequestScheme::class);
         $this->app->singleton(Listeners\EnsureRequestServerPortMatchesScheme::class);

--- a/tests/UrlGeneratorSandboxTest.php
+++ b/tests/UrlGeneratorSandboxTest.php
@@ -23,14 +23,14 @@ class UrlGeneratorSandboxTest extends TestCase
 
             return [
                 'default' => $app['url']->getDefaultParameters(),
-                'url' => $app['url']->to('/')
+                'url' => $app['url']->to('/'),
             ];
         });
 
         $app['router']->get('/second', function (Application $app) {
             return [
                 'default' => $app['url']->getDefaultParameters(),
-                'url' => $app['url']->to('/')
+                'url' => $app['url']->to('/'),
             ];
         });
 
@@ -38,12 +38,12 @@ class UrlGeneratorSandboxTest extends TestCase
 
         $this->assertEquals([
             'default' => ['param' => 'changed'],
-            'url' => 'http://changed'
+            'url' => 'http://changed',
         ], $client->responses[0]->getData(true));
 
         $this->assertEquals([
             'default' => ['param' => 'original'],
-            'url' => 'http://original'
+            'url' => 'http://original',
         ], $client->responses[1]->getData(true));
     }
 }

--- a/tests/UrlGeneratorSandboxTest.php
+++ b/tests/UrlGeneratorSandboxTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+class UrlGeneratorSandboxTest extends TestCase
+{
+    public function test_url_is_reset_between_requests()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/second', 'GET'),
+        ]);
+
+        $app['url']->defaults(['param' => 'original']);
+        $app['url']->forceRootUrl('http://original');
+
+        $app['router']->get('/first', function (Application $app) {
+            $app['url']->defaults(['param' => 'changed']);
+            $app['url']->forceRootUrl('http://changed');
+
+            return [
+                'default' => $app['url']->getDefaultParameters(),
+                'url' => $app['url']->to('/')
+            ];
+        });
+
+        $app['router']->get('/second', function (Application $app) {
+            return [
+                'default' => $app['url']->getDefaultParameters(),
+                'url' => $app['url']->to('/')
+            ];
+        });
+
+        $worker->run();
+
+        $this->assertEquals([
+            'default' => ['param' => 'changed'],
+            'url' => 'http://changed'
+        ], $client->responses[0]->getData(true));
+
+        $this->assertEquals([
+            'default' => ['param' => 'original'],
+            'url' => 'http://original'
+        ], $client->responses[1]->getData(true));
+    }
+}


### PR DESCRIPTION
Currently we're sending the same instance of URL across all requests, when changing `defaults` or `forceRootUrl`, the change is happening across all requests...

This should also fix https://github.com/laravel/octane/issues/809