### PR TITLE
Finishes garbage collection before restarting the FrankenPHP worker process

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -76,4 +76,5 @@ try {
     }
 } finally {
     $worker?->terminate();
+    gc_collect_cycles();
 }

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -76,5 +76,6 @@ try {
     }
 } finally {
     $worker?->terminate();
+
     gc_collect_cycles();
 }


### PR DESCRIPTION
I noticed random server crashes when the FrankenPHP worker gracefully restarts. Usually `php artisan octane:start` will just exit with code `139`.

This merge request mitigates these crashes by triggering garbage collection before restarting the server.

FrankenPHP generally recommends in its [docs](https://frankenphp.dev/docs/worker/#custom-apps) to trigger garbage collection after each request. I don't know if this is necessary, it slows down workers on simple request by ~10% in my tests.

What seems to be necessary though is finishing garbage collection before restarting the FrankenPHP process, otherwise memory can potentially be reused before it is freed by the GC (at least that's what I think happens). This will also not slow down the worker process.

[might also be related](https://github.com/laravel/octane/issues/791).

