### PR TITLE
Give New Application to Routes

### DIFF
--- a/src/Listeners/GiveNewApplicationInstanceToRouter.php
+++ b/src/Listeners/GiveNewApplicationInstanceToRouter.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Octane\Listeners;
 
+use Illuminate\Routing\RouteCollection;
+
 class GiveNewApplicationInstanceToRouter
 {
     /**
@@ -16,5 +18,11 @@ class GiveNewApplicationInstanceToRouter
         }
 
         $event->sandbox->make('router')->setContainer($event->sandbox);
+
+        if ($event->sandbox->resolved('routes') && $event->sandbox->make('routes') instanceof RouteCollection) {
+            foreach ($event->sandbox->make('routes') as $route) {
+                $route->setContainer($event->sandbox);
+            }
+        }
     }
 }

--- a/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
+++ b/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Laravel\Octane\Tests\TestCase;
+
+use function Livewire\invade;
+
+class GiveNewApplicationInstanceToRouterTest extends TestCase
+{
+    public function test_router_has_new_instance()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/second', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/first', function () {
+            $route = collect(app('router')->getRoutes()->getRoutes())->firstWhere(fn (Route $route) => $route->uri() === 'second');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container)
+            ];
+        });
+
+        $app['router']->middleware('web')->get('/second', function () {
+            $route = collect(app('router')->getRoutes()->getRoutes())->firstWhere(fn (Route $route) => $route->uri() === 'first');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container)
+            ];
+        });
+
+        $worker->run();
+
+        $this->assertEquals($client->responses[0]->getData()[0], $client->responses[0]->getData()[1]);
+        $this->assertEquals($client->responses[1]->getData()[0], $client->responses[1]->getData()[1]);
+    }
+}

--- a/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
+++ b/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
@@ -22,7 +22,7 @@ class GiveNewApplicationInstanceToRouterTest extends TestCase
 
             return [
                 spl_object_id(app()),
-                spl_object_id(invade($route)->container)
+                spl_object_id(invade($route)->container),
             ];
         });
 
@@ -31,7 +31,7 @@ class GiveNewApplicationInstanceToRouterTest extends TestCase
 
             return [
                 spl_object_id(app()),
-                spl_object_id(invade($route)->container)
+                spl_object_id(invade($route)->container),
             ];
         });
 


### PR DESCRIPTION
Routes instances are still referencing the old container...

I was hitting this error in a filament / livewire app, more specifically here: https://github.com/livewire/livewire/blob/main/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php#L149

Using cached routes does not hit this problem, that's why i'm only doing to uncached routes.