### PR TITLE
Refreshes log manager container

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -35,6 +35,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToDatabaseSessionHandler::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToFilesystemManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToHttpKernel::class,
+            \Laravel\Octane\Listeners\GiveNewApplicationInstanceToLogManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToMailManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToNotificationChannelManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToPipelineHub::class,

--- a/src/Listeners/GiveNewApplicationInstanceToLogManager.php
+++ b/src/Listeners/GiveNewApplicationInstanceToLogManager.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class GiveNewApplicationInstanceToLogManager
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('log')) {
+            return;
+        }
+
+        if (method_exists($log = $event->sandbox->make('log'), 'setApplication')) {
+            $log->setApplication($event->sandbox);
+        }
+    }
+}

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -136,6 +136,7 @@ class OctaneServiceProvider extends ServiceProvider
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToAuthorizationGate::class);
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToBroadcastManager::class);
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToHttpKernel::class);
+        $this->app->singleton(Listeners\GiveNewApplicationInstanceToLogManager::class);
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToMailManager::class);
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToNotificationChannelManager::class);
         $this->app->singleton(Listeners\GiveNewApplicationInstanceToPipelineHub::class);

--- a/tests/Listeners/GiveNewApplicationInstanceToLogManagerTest.php
+++ b/tests/Listeners/GiveNewApplicationInstanceToLogManagerTest.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Octane\Tests\Listeners;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
-use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Log;
 use Laravel\Octane\Tests\TestCase;
@@ -31,7 +29,6 @@ class GiveNewApplicationInstanceToLogManagerTest extends TestCase
 
         $worker->run();
 
-        $this->assertStringContainsString('{"foo":"bar"}', file_get_contents($path),);
+        $this->assertStringContainsString('{"foo":"bar"}', file_get_contents($path));
     }
 }
-

--- a/tests/Listeners/GiveNewApplicationInstanceToLogManagerTest.php
+++ b/tests/Listeners/GiveNewApplicationInstanceToLogManagerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Octane\Tests\Listeners;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
+use Laravel\Octane\Tests\TestCase;
+
+class GiveNewApplicationInstanceToLogManagerTest extends TestCase
+{
+    public function test_context_is_appened_to_logs()
+    {
+        if (! class_exists(Context::class)) {
+            $this->markTestSkipped('Context is not available in this version of Laravel.');
+        }
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/', 'GET'),
+        ]);
+        $path = $app['config']->get('logging.channels.single.path');
+        @unlink($path);
+
+        $this->assertFileDoesNotExist($path);
+
+        $app['router']->middleware('web')->get('/', function () {
+            Context::add('foo', 'bar');
+            Log::info('Hello world');
+        });
+
+        $worker->run();
+
+        $this->assertStringContainsString('{"foo":"bar"}', file_get_contents($path),);
+    }
+}
+


### PR DESCRIPTION
This PR ensures that the log manager gets its container refreshed. Context is not being appended to log files as expected due to the stale container.

This is required because we do not eagerly resolve context from the container, so the parent container will never a context repository instance resolved (they belong to the sandbox application).

https://github.com/laravel/framework/blob/02a0b5f6f83b13ea750f959364aefa324441a354/src/Illuminate/Log/LogManager.php#L142-L149

fixes https://github.com/laravel/octane/issues/907

