### PR TITLE
Rollback existing transactions after request ended

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -20,6 +20,7 @@ use Laravel\Octane\Listeners\FlushOnce;
 use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
 use Laravel\Octane\Listeners\FlushUploadedFiles;
 use Laravel\Octane\Listeners\ReportException;
+use Laravel\Octane\Listeners\RollbackActiveTransactions;
 use Laravel\Octane\Listeners\StopWorkerIfNecessary;
 use Laravel\Octane\Octane;
 
@@ -77,7 +78,7 @@ return [
         ],
 
         RequestHandled::class => [
-            //
+            RollbackActiveTransactions::class
         ],
 
         RequestTerminated::class => [

--- a/src/Listeners/RollbackActiveTransactions.php
+++ b/src/Listeners/RollbackActiveTransactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+use Illuminate\Support\Facades\DB;
+
+class RollbackActiveTransactions
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        if (class_exists(DB::class) && DB::getPdo()->inTransaction()) {
+            DB::getPdo()->rollBack();
+        }
+    }
+}


### PR DESCRIPTION
> When the script ends or when a connection is about to be closed, if you have an outstanding transaction, PDO will automatically roll it back. This is a safety measure to help avoid inconsistency in the cases where the script terminates unexpectedly--if you didn't explicitly commit the transaction, then it is assumed that something went awry, so the rollback is performed for the safety of your data.

[PHP PDO transactions](https://www.php.net/manual/en/pdo.transactions.php)

Since Octane never actually quits, the transaction will still exist after the request has ended.

Consider the following code:

```
DB::beginTransaction();
User::create(['name' => $request->input('name')]);
if (someCondition()) {
   abort(403);
)
DB::commit();
```

If for some reason someCondition() is true, the request is aborted, but the transaction is not ended.
If the user tries again and someCondition() is false, then both the new and previous 'User' model is created.

Fixes
#909 

Unfortunately I don't know how to test this. Hopefully someone will add it.