### PR TITLE
[2.x] Flush container between tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Laravel\Octane\Tests;
 
 use Carbon\Laravel\ServiceProvider as CarbonServiceProvider;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
@@ -71,6 +73,11 @@ class TestCase extends BaseTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
 
         Mockery::close();
     }


### PR DESCRIPTION
Intentionally failing tests to show the inter-test dependencies in the test suite.