### PR TITLE
[2.x] Fix inter test dependencies

### DIFF
--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -50,6 +50,7 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_roadrunner_server_process_can_be_reloaded()
     {
+        $this->createApplication();
         $inspector = new ServerProcessInspector(
             $processIdFile = new ServerStateFile(sys_get_temp_dir().'/swoole.pid'),
             $processFactory = Mockery::mock(SymfonyProcessFactory::class),

--- a/tests/SequentialTaskDispatcherTest.php
+++ b/tests/SequentialTaskDispatcherTest.php
@@ -27,6 +27,7 @@ class SequentialTaskDispatcherTest extends TestCase
 
     public function test_resolving_tasks_with_exceptions_do_not_effect_other_tasks()
     {
+        $this->createApplication();
         $dispatcher = new SequentialTaskDispatcher;
 
         $a = false;
@@ -77,6 +78,7 @@ class SequentialTaskDispatcherTest extends TestCase
 
     public function test_resolving_tasks_propagate_exceptions()
     {
+        $this->createApplication();
         $dispatcher = new SequentialTaskDispatcher();
 
         $this->expectException(TaskException::class);
@@ -89,6 +91,7 @@ class SequentialTaskDispatcherTest extends TestCase
 
     public function test_resolving_tasks_propagate_dd_calls()
     {
+        $this->createApplication();
         $dispatcher = new SequentialTaskDispatcher();
 
         $this->expectException(DdException::class);

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -124,6 +124,7 @@ class SwooleClientTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_static_file_headers_can_be_sent(): void
     {
+        $this->createApplication();
         $client = new SwooleClient;
 
         $request = Request::create('/foo.txt', 'GET');
@@ -206,6 +207,7 @@ class SwooleClientTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_respond_method_send_streamed_response_to_swoole(): void
     {
+        $this->createApplication();
         $client = new SwooleClient;
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
@@ -227,6 +229,7 @@ class SwooleClientTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_respond_method_with_laravel_specific_status_code_sends_response_to_swoole(): void
     {
+        $this->createApplication();
         $client = new SwooleClient;
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');
@@ -286,6 +289,7 @@ class SwooleClientTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_respond_method_send_not_chunked_response_to_swoole(): void
     {
+        $this->createApplication();
         $client = new SwooleClient;
 
         $swooleResponse = Mockery::mock(SwooleResponse::class);
@@ -307,6 +311,7 @@ class SwooleClientTest extends TestCase
     /** @doesNotPerformAssertions @test */
     public function test_respond_method_send_chunked_response_to_swoole(): void
     {
+        $this->createApplication();
         $client = new SwooleClient(6);
 
         $swooleResponse = Mockery::mock('Swoole\Http\Response');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Laravel\Octane\Tests;
 
 use Carbon\Laravel\ServiceProvider as CarbonServiceProvider;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
@@ -71,6 +73,11 @@ class TestCase extends BaseTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
 
         Mockery::close();
     }


### PR DESCRIPTION
This PR fixes some inter-test dependencies. Currently, certain tests depend on other test to be run first and can not be run individually.

Specifically, these tests rely on the container singleton to have been created by another test and to be shared between tests.

I noticed this issue when creating another PR and some unrelated tests randomly started failing with the change.

You can see these failures by running `phpunit --process-isolation` against the `2.x` branch.


You can see the failing tests, in all their glory, in this test run (https://github.com/laravel/octane/actions/runs/9573937368/job/26396301757) which is tied to the commit that flushes the container between tests (https://github.com/laravel/octane/pull/914/commits/326bdc6ece335305bd4a6c3c6729f55aaec7686d)

This PR includes the container flushing and individual test fixes.