### PR TITLE
[2.x] Add `laravel/prompts`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^8.1.0",
         "laminas/laminas-diactoros": "^3.0",
         "laravel/framework": "^10.10.1|^11.0",
+        "laravel/prompts": "^0.1.24",
         "laravel/serializable-closure": "^1.3.0",
         "nesbot/carbon": "^2.66.0|^3.0",
         "symfony/console": "^6.0|^7.0",

--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -11,6 +11,8 @@ use RuntimeException;
 use Symfony\Component\Process\Process;
 use Throwable;
 
+use function Laravel\Prompts\confirm;
+
 trait InstallsFrankenPhpDependencies
 {
     use FindsFrankenPhpBinary;
@@ -45,7 +47,7 @@ trait InstallsFrankenPhpDependencies
             return $frankenphpBinary;
         }
 
-        if ($this->confirm('Unable to locate FrankenPHP binary. Should Octane download the binary for your operating system?', true)) {
+        if (confirm('Unable to locate FrankenPHP binary. Should Octane download the binary for your operating system?', true)) {
             $this->downloadFrankenPhpBinary();
         }
 
@@ -77,7 +79,7 @@ trait InstallsFrankenPhpDependencies
         $response = Http::accept('application/vnd.github+json')
             ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
             ->get('https://api.github.com/repos/dunglas/frankenphp/releases/latest')
-            ->throw(fn () => $this->error('Failed to download FrankenPHP.'));
+            ->throw(fn () => $this->components->error('Failed to download FrankenPHP.'));
 
         $assets = $response['assets'] ?? [];
 
@@ -141,7 +143,7 @@ trait InstallsFrankenPhpDependencies
             });
 
         if ($lineWithVersion === null) {
-            return $this->warn(
+            return $this->components->warn(
                 'Unable to determine the current FrankenPHP binary version. Please report this issue: https://github.com/laravel/octane/issues/new.',
             );
         }
@@ -149,7 +151,7 @@ trait InstallsFrankenPhpDependencies
         $version = Str::of($lineWithVersion)->trim()->afterLast('v')->value();
 
         if (preg_match('/\d+\.\d+\.\d+/', $version) !== 1) {
-            return $this->warn(
+            return $this->components->warn(
                 'Unable to determine the current FrankenPHP binary version. Please report this issue: https://github.com/laravel/octane/issues/new.',
             );
         }
@@ -158,9 +160,9 @@ trait InstallsFrankenPhpDependencies
             return;
         }
 
-        $this->warn("Your FrankenPHP binary version (<fg=red>$version</>) may be incompatible with Octane.");
+        $this->components->warn("Your FrankenPHP binary version (<fg=red>$version</>) may be incompatible with Octane.");
 
-        if ($this->confirm('Should Octane download the latest FrankenPHP binary version for your operating system?', true)) {
+        if (confirm('Should Octane download the latest FrankenPHP binary version for your operating system?', true)) {
             rename($frankenPhpBinary, "$frankenPhpBinary.backup");
 
             try {
@@ -170,7 +172,7 @@ trait InstallsFrankenPhpDependencies
 
                 rename("$frankenPhpBinary.backup", $frankenPhpBinary);
 
-                return $this->warn('Unable to download FrankenPHP binary. The underlying error has been logged.');
+                return $this->components->warn('Unable to download FrankenPHP binary. The underlying error has been logged.');
             }
 
             unlink("$frankenPhpBinary.backup");

--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -12,6 +12,8 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Throwable;
 
+use function Laravel\Prompts\confirm;
+
 trait InstallsRoadRunnerDependencies
 {
     use FindsRoadRunnerBinary;
@@ -44,8 +46,8 @@ trait InstallsRoadRunnerDependencies
             return true;
         }
 
-        if (! $this->confirm('Octane requires "spiral/roadrunner-http:^3.3.0" and "spiral/roadrunner-cli:^2.6.0". Do you wish to install them as a dependencies?')) {
-            $this->error('Octane requires "spiral/roadrunner-http" and "spiral/roadrunner-cli".');
+        if (! confirm('Octane requires "spiral/roadrunner-http:^3.3.0" and "spiral/roadrunner-cli:^2.6.0". Do you wish to install them as a dependencies?')) {
+            $this->components->error('Octane requires "spiral/roadrunner-http" and "spiral/roadrunner-cli".');
 
             return false;
         }
@@ -102,7 +104,7 @@ trait InstallsRoadRunnerDependencies
             return $roadRunnerBinary;
         }
 
-        if ($this->confirm('Unable to locate RoadRunner binary. Should Octane download the binary for your operating system?', true)) {
+        if (confirm('Unable to locate RoadRunner binary. Should Octane download the binary for your operating system?', true)) {
             $this->downloadRoadRunnerBinary();
 
             copy(__DIR__.'/../stubs/rr.yaml', base_path('.rr.yaml'));
@@ -124,7 +126,7 @@ trait InstallsRoadRunnerDependencies
             ->getOutput();
 
         if (! Str::startsWith($version, 'rr version')) {
-            return $this->warn(
+            return $this->components->warn(
                 'Unable to determine the current RoadRunner binary version. Please report this issue: https://github.com/laravel/octane/issues/new.'
             );
         }
@@ -135,9 +137,9 @@ trait InstallsRoadRunnerDependencies
             return;
         }
 
-        $this->warn("Your RoadRunner binary version (<fg=red>$version</>) may be incompatible with Octane.");
+        $this->components->warn("Your RoadRunner binary version (<fg=red>$version</>) may be incompatible with Octane.");
 
-        if ($this->confirm('Should Octane download the latest RoadRunner binary version for your operating system?', true)) {
+        if (confirm('Should Octane download the latest RoadRunner binary version for your operating system?', true)) {
             rename($roadRunnerBinary, "$roadRunnerBinary.backup");
 
             try {
@@ -147,7 +149,7 @@ trait InstallsRoadRunnerDependencies
 
                 rename("$roadRunnerBinary.backup", $roadRunnerBinary);
 
-                return $this->warn('Unable to download RoadRunner binary. The HTTP request exception has been logged.');
+                return $this->components->warn('Unable to download RoadRunner binary. The HTTP request exception has been logged.');
             }
 
             unlink("$roadRunnerBinary.backup");

--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -248,7 +248,7 @@ trait InteractsWithIO
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),
             'raw' => $this->raw(json_encode($stream)),
-            default => $this->info(json_encode($stream), $verbosity)
+            default => $this->components->info(json_encode($stream), $verbosity)
         };
     }
 }

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -37,11 +37,11 @@ trait InteractsWithServers
 
                 if ($watcher->isRunning() &&
                     $watcher->getIncrementalOutput()) {
-                    $this->info('Application change detected. Restarting workers…');
+                    $this->components->info('Application change detected. Restarting workers…');
 
                     $inspector->reloadServer();
                 } elseif ($watcher->isTerminated()) {
-                    $this->error(
+                    $this->components->error(
                         'Watcher process has terminated. Please ensure Node and chokidar are installed.'.PHP_EOL.
                         $watcher->getErrorOutput()
                     );
@@ -100,7 +100,7 @@ trait InteractsWithServers
      */
     protected function writeServerRunningMessage()
     {
-        $this->info('Server running…');
+        $this->components->info('Server running…');
 
         $this->output->writeln([
             '',

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -8,6 +8,8 @@ use Laravel\Octane\Swoole\SwooleExtension;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
+use function Laravel\Prompts\select;
+
 #[AsCommand(name: 'octane:install')]
 class InstallCommand extends Command
 {
@@ -36,9 +38,10 @@ class InstallCommand extends Command
      */
     public function handle()
     {
-        $server = $this->option('server') ?: $this->choice(
-            'Which application server you would like to use?',
-            ['roadrunner', 'swoole', 'frankenphp'],
+        $server = $this->option('server') ?: select(
+            label: 'Which application server you would like to use?',
+            options: ['roadrunner', 'swoole', 'frankenphp'],
+            default: 'roadrunner'
         );
 
         return (int) ! tap(match ($server) {
@@ -52,7 +55,7 @@ class InstallCommand extends Command
 
                 $this->callSilent('vendor:publish', ['--tag' => 'octane-config', '--force' => true]);
 
-                $this->info('Octane installed successfully.');
+                $this->components->info('Octane installed successfully.');
                 $this->newLine();
             }
         });
@@ -75,7 +78,7 @@ class InstallCommand extends Command
                     PHP_EOL.'OCTANE_SERVER='.$server.PHP_EOL,
                 );
             } else {
-                $this->warn('Please adjust the `OCTANE_SERVER` environment variable.');
+                $this->components->warn('Please adjust the `OCTANE_SERVER` environment variable.');
             }
         }
     }
@@ -115,7 +118,7 @@ class InstallCommand extends Command
     public function installSwooleServer()
     {
         if (! resolve(SwooleExtension::class)->isInstalled()) {
-            $this->warn('The Swoole extension is missing.');
+            $this->components->warn('The Swoole extension is missing.');
         }
 
         return true;
@@ -147,7 +150,7 @@ class InstallCommand extends Command
         try {
             $this->ensureFrankenPhpBinaryIsInstalled();
         } catch (Throwable $e) {
-            $this->error($e->getMessage());
+            $this->components->error($e->getMessage());
 
             return false;
         }
@@ -162,7 +165,7 @@ class InstallCommand extends Command
      */
     protected function invalidServer(string $server)
     {
-        $this->error("Invalid server: {$server}.");
+        $this->components->error("Invalid server: {$server}.");
 
         return false;
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -40,8 +40,8 @@ class InstallCommand extends Command
     {
         $server = $this->option('server') ?: select(
             label: 'Which application server you would like to use?',
-            options: ['roadrunner', 'swoole', 'frankenphp'],
-            default: 'roadrunner'
+            options: ['frankenphp', 'roadrunner', 'swoole'],
+            default: 'frankenphp'
         );
 
         return (int) ! tap(match ($server) {

--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -51,12 +51,12 @@ class ReloadCommand extends Command
         $inspector = app(SwooleServerProcessInspector::class);
 
         if (! $inspector->serverIsRunning()) {
-            $this->error('Octane server is not running.');
+            $this->components->error('Octane server is not running.');
 
             return 1;
         }
 
-        $this->info('Reloading workers...');
+        $this->components->info('Reloading workers...');
 
         $inspector->reloadServer();
 
@@ -73,12 +73,12 @@ class ReloadCommand extends Command
         $inspector = app(RoadRunnerServerProcessInspector::class);
 
         if (! $inspector->serverIsRunning()) {
-            $this->error('Octane server is not running.');
+            $this->components->error('Octane server is not running.');
 
             return 1;
         }
 
-        $this->info('Reloading workers...');
+        $this->components->info('Reloading workers...');
 
         $inspector->reloadServer();
 
@@ -95,12 +95,12 @@ class ReloadCommand extends Command
         $inspector = app(FrankenPhpServerProcessInspector::class);
 
         if (! $inspector->serverIsRunning()) {
-            $this->error('Octane server is not running.');
+            $this->components->error('Octane server is not running.');
 
             return 1;
         }
 
-        $this->info('Reloading workers...');
+        $this->components->info('Reloading workers...');
 
         $inspector->reloadServer();
 
@@ -114,7 +114,7 @@ class ReloadCommand extends Command
      */
     protected function invalidServer(string $server)
     {
-        $this->error("Invalid server: {$server}.");
+        $this->components->error("Invalid server: {$server}.");
 
         return 1;
     }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -125,7 +125,7 @@ class StartCommand extends Command implements SignalableCommandInterface
      */
     protected function invalidServer(string $server)
     {
-        $this->error("Invalid server: {$server}.");
+        $this->components->error("Invalid server: {$server}.");
 
         return 1;
     }

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -65,7 +65,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $frankenphpBinary = $this->ensureFrankenPhpBinaryIsInstalled();
 
         if ($inspector->serverIsRunning()) {
-            $this->error('FrankenPHP server is already running.');
+            $this->components->error('FrankenPHP server is already running.');
 
             return 1;
         }
@@ -274,7 +274,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
 
         $errorOutput->each(function ($output) {
             if (! is_array($debug = json_decode($output, true))) {
-                return $this->info($output);
+                return $this->components->info($output);
             }
 
             $message = $debug['msg'] ?? 'unknown error';
@@ -312,7 +312,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
 
             if (isset($debug['level'])) {
                 if ($debug['level'] === 'warn') {
-                    return $this->warn($message);
+                    return $this->components->warn($message);
                 }
 
                 if ($debug['level'] !== 'info') {
@@ -321,7 +321,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                         return;
                     }
 
-                    return $this->error($message);
+                    return $this->components->error($message);
                 }
             }
         });

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -57,7 +57,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
     public function handle(ServerProcessInspector $inspector, ServerStateFile $serverStateFile)
     {
         if (! $this->isRoadRunnerInstalled()) {
-            $this->error('RoadRunner not installed. Please execute the `octane:install` Artisan command.');
+            $this->components->error('RoadRunner not installed. Please execute the `octane:install` Artisan command.');
 
             return 1;
         }
@@ -67,7 +67,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         $this->ensurePortIsAvailable();
 
         if ($inspector->serverIsRunning()) {
-            $this->error('RoadRunner server is already running.');
+            $this->components->error('RoadRunner server is already running.');
 
             return 1;
         }
@@ -204,7 +204,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             ->filter()
             ->each(function ($output) {
                 if (! is_array($debug = json_decode($output, true))) {
-                    return $this->info($output);
+                    return $this->components->info($output);
                 }
 
                 if (is_array($stream = json_decode($debug['msg'], true))) {
@@ -240,7 +240,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             ->filter()
             ->each(function ($output) {
                 if (! Str::contains($output, ['DEBUG', 'INFO', 'WARN'])) {
-                    $this->error($output);
+                    $this->components->error($output);
                 }
             });
     }

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -55,7 +55,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         SwooleExtension $extension
     ) {
         if (! $extension->isInstalled()) {
-            $this->error('The Swoole extension is missing.');
+            $this->components->error('The Swoole extension is missing.');
 
             return 1;
         }
@@ -63,13 +63,13 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
         $this->ensurePortIsAvailable();
 
         if ($inspector->serverIsRunning()) {
-            $this->error('Server is already running.');
+            $this->components->error('Server is already running.');
 
             return 1;
         }
 
         if (config('octane.swoole.ssl', false) === true && ! defined('SWOOLE_SSL')) {
-            $this->error('You must configure Swoole with `--enable-openssl` to support ssl.');
+            $this->components->error('You must configure Swoole with `--enable-openssl` to support ssl.');
 
             return 1;
         }
@@ -177,7 +177,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             ->filter()
             ->each(fn ($output) => is_array($stream = json_decode($output, true))
                 ? $this->handleStream($stream)
-                : $this->info($output)
+                : $this->components->info($output)
             );
 
         Str::of($errorOutput)

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -42,8 +42,8 @@ class StatusCommand extends Command
 
         return ! tap($isRunning, function ($isRunning) {
             $isRunning
-                ? $this->info('Octane server is running.')
-                : $this->info('Octane server is not running.');
+                ? $this->components->info('Octane server is running.')
+                : $this->components->info('Octane server is not running.');
         });
     }
 
@@ -87,7 +87,7 @@ class StatusCommand extends Command
      */
     protected function invalidServer(string $server)
     {
-        $this->error("Invalid server: {$server}.");
+        $this->components->error("Invalid server: {$server}.");
 
         return false;
     }

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -56,15 +56,15 @@ class StopCommand extends Command
         if (! $inspector->serverIsRunning()) {
             app(SwooleServerStateFile::class)->delete();
 
-            $this->error('Swoole server is not running.');
+            $this->components->error('Swoole server is not running.');
 
             return 1;
         }
 
-        $this->info('Stopping server...');
+        $this->components->info('Stopping server...');
 
         if (! $inspector->stopServer()) {
-            $this->error('Failed to stop Swoole server.');
+            $this->components->error('Failed to stop Swoole server.');
 
             return 1;
         }
@@ -86,12 +86,12 @@ class StopCommand extends Command
         if (! $inspector->serverIsRunning()) {
             app(RoadRunnerServerStateFile::class)->delete();
 
-            $this->error('RoadRunner server is not running.');
+            $this->components->error('RoadRunner server is not running.');
 
             return 1;
         }
 
-        $this->info('Stopping server...');
+        $this->components->info('Stopping server...');
 
         $inspector->stopServer();
 
@@ -112,12 +112,12 @@ class StopCommand extends Command
         if (! $inspector->serverIsRunning()) {
             app(FrankenPhpStateFile::class)->delete();
 
-            $this->error('FrankenPHP server is not running.');
+            $this->components->error('FrankenPHP server is not running.');
 
             return 1;
         }
 
-        $this->info('Stopping server...');
+        $this->components->info('Stopping server...');
 
         $inspector->stopServer();
 
@@ -133,7 +133,7 @@ class StopCommand extends Command
      */
     protected function invalidServer(string $server)
     {
-        $this->error("Invalid server: {$server}.");
+        $this->components->error("Invalid server: {$server}.");
 
         return 1;
     }


### PR DESCRIPTION
This PR utilizes the `laravel/prompts` to improve mostly the `$this->choice` and the `$this->confirm` prompts.

Also change the `info`, `warn` and `error` to use the `$this->components` version.

## Before:

https://github.com/laravel/octane/assets/823088/08d739d1-4e35-4e2a-9cea-c99056da018a

## After:

https://github.com/laravel/octane/assets/823088/3a88d9ab-5660-4fae-94ac-4ba504ee490e

Cheers