### PR TITLE
[2.x] Swoole `$verbosity` must be of type int, null given.

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -248,7 +248,7 @@ trait InteractsWithIO
             'throwable' => $this->throwableInfo($stream, $verbosity),
             'shutdown' => $this->shutdownInfo($stream, $verbosity),
             'raw' => $this->raw(json_encode($stream)),
-            default => $this->components->info(json_encode($stream), $verbosity)
+            default => $this->components->info(json_encode($stream), $this->parseVerbosity($verbosity))
         };
     }
 }


### PR DESCRIPTION
This PR fixes the issue reported on #918.