### PR TITLE
Add .mjs extension to MIME types

### DIFF
--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -41,6 +41,7 @@ class MimeType
         'ser' => 'application/java-serialized-object',
         'class' => 'application/java-vm',
         'js' => 'application/javascript',
+        'mjs' => 'application/javascript',
         'json' => 'application/json',
         'jsonml' => 'application/jsonml+json',
         'lostxml' => 'application/lost+xml',


### PR DESCRIPTION
This PR adds support for the `.mjs` file extension in the MIME types array. 
