### PR TITLE
Introduce operation scoped service providers

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -121,6 +121,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Operation Scoped ServiceProviders
+    |--------------------------------------------------------------------------
+    |
+    | Here you can list service providers which should be registered
+    | on start of each operation, rather than during boot process.
+    |
+    */
+
+    'op_service_providers' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Warm / Flush Bindings
     |--------------------------------------------------------------------------
     |

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -61,10 +61,16 @@ class ApplicationFactory
 
         $method->setAccessible(true);
 
+        $bootstrappers = $method->invoke($kernel);
+
+        // Replace RegisterProviders with OctaneRegisterProviders
+        $replaceIndex = array_search(RegisterProviders::class, $bootstrappers, true);
+        $bootstrappers = array_replace($bootstrappers, [$replaceIndex => OctaneRegisterProviders::class]);
+
         return $this->injectBootstrapperBefore(
-            RegisterProviders::class,
+            OctaneRegisterProviders::class,
             SetRequestForConsole::class,
-            $method->invoke($kernel)
+            $bootstrappers
         );
     }
 

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -63,7 +63,6 @@ class ApplicationFactory
 
         $bootstrappers = $method->invoke($kernel);
 
-        // Replace RegisterProviders with OctaneRegisterProviders
         $replaceIndex = array_search(RegisterProviders::class, $bootstrappers, true);
         $bootstrappers = array_replace($bootstrappers, [$replaceIndex => OctaneRegisterProviders::class]);
 

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -45,7 +45,14 @@ class ApplicationFactory
 
         $app->bootstrapWith($this->getBootstrappers($app));
 
-        $app->loadDeferredProviders();
+        // We will register all but operation scoped deferred providers right away so
+        // they are resolved once, during boot. Remaining operation providers will 
+        // be registered with classical approach, during the occasions of need.
+        foreach ($app->getDeferredServices() as $service => $provider) {
+            if (!in_array($provider, $app->make('config')->get('octane.op_service_providers', []))) {
+                $app->loadDeferredProvider($service);
+            }
+        }
 
         return $app;
     }

--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -53,6 +53,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\FlushMonologState::class,
             \Laravel\Octane\Listeners\FlushStrCache::class,
             \Laravel\Octane\Listeners\FlushTranslatorCache::class,
+            \Laravel\Octane\Listeners\RegisterOperationServiceProviders::class,
 
             // First-Party Packages...
             \Laravel\Octane\Listeners\PrepareInertiaForNextOperation::class,

--- a/src/Listeners/RegisterOperationServiceProviders.php
+++ b/src/Listeners/RegisterOperationServiceProviders.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class RegisterOperationServiceProviders
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        foreach ($event->sandbox->make('config')->get('octane.op_service_providers', []) as $provider) {
+            $event->sandbox->register($provider);
+        }
+    }
+}

--- a/src/Listeners/RegisterOperationServiceProviders.php
+++ b/src/Listeners/RegisterOperationServiceProviders.php
@@ -14,6 +14,8 @@ class RegisterOperationServiceProviders
         $resolved_providers = [];
 
         foreach ($event->sandbox->make('config')->get('octane.op_service_providers', []) as $provider) {
+            $provider = $event->sandbox->resolveProvider($provider);
+            if ($provider->isDeferred()) continue;
             $resolved_providers[] = $event->sandbox->register($provider, boot: false);
         }
 

--- a/src/Listeners/RegisterOperationServiceProviders.php
+++ b/src/Listeners/RegisterOperationServiceProviders.php
@@ -11,8 +11,15 @@ class RegisterOperationServiceProviders
      */
     public function handle($event): void
     {
+        $resolved_providers = [];
+
         foreach ($event->sandbox->make('config')->get('octane.op_service_providers', []) as $provider) {
-            $event->sandbox->register($provider);
+            $resolved_providers[] = $event->sandbox->register($provider, boot: false);
+        }
+
+        // After all service providers have been registered, we will boot them.
+        foreach ($resolved_providers as $provider) {
+            $event->sandbox->bootProvider($provider);
         }
     }
 }

--- a/src/OctaneProviderRepository.php
+++ b/src/OctaneProviderRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Octane;
+
+use Illuminate\Foundation\ProviderRepository;
+
+class OctaneProviderRepository extends ProviderRepository
+{
+    /**
+     * Register the application service providers.
+     *
+     * @param  array  $providers
+     * @return void
+     */
+    public function load(array $providers)
+    {
+        $manifest = $this->loadManifest();
+
+        // First we will load the service manifest, which contains information on all
+        // service providers registered with the application and which services it
+        // provides. This is used to know which services are "deferred" loaders.
+        if ($this->shouldRecompile($manifest, $providers)) {
+            $manifest = $this->compileManifest($providers);
+        }
+
+        // Next, we will register events to load the providers for each of the events
+        // that it has requested. This allows the service provider to defer itself
+        // while still getting automatically loaded when a certain event occurs.
+        foreach ($manifest['when'] as $provider => $events) {
+            $this->registerLoadEvents($provider, $events);
+        }
+
+        // We will register eagerly loaded providers, just like base ProviderRepository,
+        // except we will leave out the ones specified in op_service_providers array.
+        foreach ($manifest['eager'] as $provider) {
+            if (!in_array($provider, $this->app->make('config')->get('octane.op_service_providers', []))) {
+                $this->app->register($provider);
+            }
+        }
+
+        $this->app->addDeferredServices($manifest['deferred']);
+    }
+}

--- a/src/OctaneRegisterProviders.php
+++ b/src/OctaneRegisterProviders.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Octane;
+
+use Illuminate\Contracts\Foundation\Application;
+use Laravel\Octane\OctaneProviderRepository;
+use Illuminate\Filesystem\FileSystem;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
+
+class OctaneRegisterProviders extends RegisterProviders
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function bootstrap(Application $app)
+    {
+        if (
+            !$app->bound('config_loaded_from_cache') ||
+            $app->make('config_loaded_from_cache') === false
+        ) {
+            $this->mergeAdditionalProviders($app);
+        }
+
+        $providerRepository = new OctaneProviderRepository($app, new FileSystem, $app->getCachedServicesPath());
+
+        $app->registerConfiguredProviders($providerRepository);
+    }
+}

--- a/src/OctaneRegisterProviders.php
+++ b/src/OctaneRegisterProviders.php
@@ -4,7 +4,7 @@ namespace Laravel\Octane;
 
 use Illuminate\Contracts\Foundation\Application;
 use Laravel\Octane\OctaneProviderRepository;
-use Illuminate\Filesystem\FileSystem;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 
 class OctaneRegisterProviders extends RegisterProviders
@@ -24,7 +24,7 @@ class OctaneRegisterProviders extends RegisterProviders
             $this->mergeAdditionalProviders($app);
         }
 
-        $providerRepository = new OctaneProviderRepository($app, new FileSystem, $app->getCachedServicesPath());
+        $providerRepository = new OctaneProviderRepository($app, new Filesystem, $app->getCachedServicesPath());
 
         $app->registerConfiguredProviders($providerRepository);
     }


### PR DESCRIPTION
Octane and service providers have somewhat delicate relationship. You have to consider a lot of nuances when creating a provider that should work with Octane. One careless resolution of a singleton during the boot process can cause strange behaviors, if the state is not handled correctly.

Currently, for most of the first-party packages, application state is managed in an Octane compatible way. Also, if you are writing an application or a package yourself, there are sufficient mechanisms to run it safely on Octane.

However, problems start to arise when you use third-party packages which might not be Octane friendly. That can cause bugs so critical that you might even consider ditching Octane altogether (speaking from personal experience). Right now, to make sure that the third-party packages work safely with Octane, you have to check every service provider of every package (even the ones that  you are not using directly). Inspecting the third-party codebase, you should check for the singletons which are resolved during the boot process and add them to the **octane.flush** config. This will get the instances deleted after each request/operation. It must also be mentioned that you will also need to do that for every update, because any update may introduce new “unsafe” singleton resolutions. This means that you can not reliably use most of the community packages with Octane, limiting you from enjoying the Laravel Ecosystem fully.

With this PR, I am proposing to add the ability for Laravel Octane to register (and boot) specific service providers on each request/operation, rather than during the boot process. The list of the specific providers can be managed through configuration. With this approach, all singleton associated issues become easily manageable as it allows developers to simply use third-party packages in an Octane safe way. If Octane is considered as a future default runtime for Laravel (we think so) based applications, more and more packages will become Octane friendly and if that’s the case, developers can always manage to revert back to the traditional booting process through configuration.

To sum up, as a result of merging this PR, Laravel Octane will become safer to use in combination with any third party package, which in turn will encourage the community to more actively adopt Octane, without second thoughts about the problems it may cause.

This solution comes in two parts, second part is a minor refactor of the framework, please refer to the [PR](https://github.com/laravel/framework/pull/52549) in laravel/framework.

If I am missing something, please fill free to share your thoughts. Any insights are highly appreciated. 