### PR TITLE
fix: RoadRunner streaming through generators

### DIFF
--- a/src/RoadRunner/RoadRunnerClient.php
+++ b/src/RoadRunner/RoadRunnerClient.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\RoadRunner;
 
+use Generator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Laravel\Octane\Contracts\Client;
@@ -10,6 +11,7 @@ use Laravel\Octane\MarshalsPsr7RequestsAndResponses;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use ReflectionFunction;
 use Spiral\RoadRunner\Http\PSR7Worker;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -45,6 +47,20 @@ class RoadRunnerClient implements Client, StoppableClient
             $octaneResponse->response->setContent(
                 $octaneResponse->outputBuffer.$octaneResponse->response->getContent()
             );
+        }
+
+        if (
+            ($octaneResponse->response instanceof StreamedResponse) &&
+            ($responseCallback = $octaneResponse->response->getCallback()) &&
+            (((new ReflectionFunction($responseCallback))->getReturnType()?->getName()) === Generator::class)
+        ) {
+            $this->client->getHttpWorker()->respond(
+                $octaneResponse->response->getStatusCode(),
+                $responseCallback(),
+                $this->toPsr7Response($octaneResponse->response)->getHeaders(),
+            );
+
+            return;
         }
 
         $this->client->respond($this->toPsr7Response($octaneResponse->response));

--- a/src/RoadRunner/RoadRunnerClient.php
+++ b/src/RoadRunner/RoadRunnerClient.php
@@ -52,7 +52,7 @@ class RoadRunnerClient implements Client, StoppableClient
         if (
             ($octaneResponse->response instanceof StreamedResponse) &&
             ($responseCallback = $octaneResponse->response->getCallback()) &&
-            (((new ReflectionFunction($responseCallback))->getReturnType()?->getName()) === Generator::class)
+            ((new ReflectionFunction($responseCallback))->getReturnType()?->getName() === Generator::class)
         ) {
             $this->client->getHttpWorker()->respond(
                 $octaneResponse->response->getStatusCode(),


### PR DESCRIPTION
Fixes #903.

RoadRunner supports streamed responses, but not in the same way that other servers do. Instead out using the output buffer with `echo`, it supports using a `Generator` function as the response  callback to "yield" each chunk of the response.

Previous fixes have involved collecting the output buffer and returning it at once from the server. This is not streaming as all chunks are collected into memory and sent at once.

This implementation allows you to use a `Generator` as the callable in the streamed response. Each `yield` sends a chunk in the response. It is quite simple and just interacts with the underlying `HttpWorker` that is used by the Roadrunner client. The new code is only invoked if the streamed response function is a generator, else the old behaviour still persists.

```php
use Generator;

return response()->stream(function (): Generator {
    yield 1;

    sleep(1);

    yield 2;

    sleep(1);

    yield 3;

    sleep(1);

    yield 4;

    sleep(1);

    yield 5;
}, 200, [
    'Content-Type' => 'text/html; charset=utf-8;',
    'Cache-Control' => 'no-cache',
    'X-Accel-Buffering' => 'no',
]);
```

Note: we do not need to evaluate the function to know if we need to stream it in this way, we use reflection to do this ahead of time, ensuring that the function returns a `Generator` object.

I would like to thank @donnysim for his investigative work and initial solution which was adapted into this PR.