### PR TITLE
Do not perform deletion operations during traversal

### DIFF
--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -37,7 +37,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
             }
 
             $this->timerTable->del($workerId);
-            if ($this->server instanceof Server && !$this->server->exists($row['fd'])) {
+            if ($this->server instanceof Server && ! $this->server->exists($row['fd'])) {
                 continue;
             }
 

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -30,7 +30,6 @@ class EnsureRequestsDontExceedMaxExecutionTime
             }
         }
 
-
         foreach ($rows as $workerId => $row) {
             if ($this->timerTable->get($workerId, 'fd') !== $row['fd']) {
                 continue;

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -24,6 +24,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
     public function __invoke()
     {
         $rows = [];
+
         foreach ($this->timerTable as $workerId => $row) {
             if ((time() - $row['time']) > $this->maxExecutionTime) {
                 $rows[$workerId] = $row;
@@ -36,6 +37,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
             }
 
             $this->timerTable->del($workerId);
+
             if ($this->server instanceof Server && ! $this->server->exists($row['fd'])) {
                 continue;
             }
@@ -44,6 +46,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
 
             if ($this->server instanceof Server) {
                 $response = Response::create($this->server, $row['fd']);
+
                 if ($response) {
                     $response->status(408);
                     $response->end();

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -23,23 +23,31 @@ class EnsureRequestsDontExceedMaxExecutionTime
      */
     public function __invoke()
     {
+        $rows = [];
         foreach ($this->timerTable as $workerId => $row) {
             if ((time() - $row['time']) > $this->maxExecutionTime) {
-                $this->timerTable->del($workerId);
+                $rows[$workerId] = $row;
+            }
+        }
 
-                if ($this->server instanceof Server && ! $this->server->exists($row['fd'])) {
-                    continue;
-                }
 
-                $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
+        foreach ($rows as $workerId => $row) {
+            if ($this->timerTable->get($workerId, 'fd') !== $row['fd']) {
+                continue;
+            }
 
-                if ($this->server instanceof Server) {
-                    $response = Response::create($this->server, $row['fd']);
+            $this->timerTable->del($workerId);
+            if ($this->server instanceof Server && !$this->server->exists($row['fd'])) {
+                continue;
+            }
 
-                    if ($response) {
-                        $response->status(408);
-                        $response->end();
-                    }
+            $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
+
+            if ($this->server instanceof Server) {
+                $response = Response::create($this->server, $row['fd']);
+                if ($response) {
+                    $response->status(408);
+                    $response->end();
                 }
             }
         }

--- a/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
+++ b/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
@@ -39,4 +39,9 @@ class FakeTimerTable extends ArrayObject
     {
         $this->deleted[] = $workerId;
     }
+
+    public function get($workerId, $field = null)
+    {
+        return 1;
+    }
 }

--- a/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
+++ b/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
@@ -17,6 +17,7 @@ class EnsureRequestsDontExceedMaxExecutionTimeTest extends TestCase
         $table['fake-worker-id'] = [
             'worker_pid' => 111,
             'time' => time() - 60,
+            'fd' => 1,
         ];
 
         $action = new EnsureRequestsDontExceedMaxExecutionTime(


### PR DESCRIPTION
[Do not perform deletion operations during traversal (all keys can be taken out for deletion after traversal) ](https://wiki.swoole.com/en/#/memory/table?id=%e9%ab%98%e6%80%a7%e8%83%bd%e5%85%b1%e4%ba%ab%e5%86%85%e5%ad%98-table)