### PR TITLE
Fix: Removes dd() workaround for Frankenphp.

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
 
-use Laravel\Octane\Exceptions\DdException;
 use Laravel\Octane\Octane;
 
 ini_set('display_errors', 'stderr');
@@ -24,13 +23,6 @@ if (! is_string($basePath)) {
     Octane::writeError('Cannot find application base path.');
 
     exit(11);
-}
-
-if (! function_exists('dd')) {
-    function dd(...$vars)
-    {
-        throw new DdException($vars);
-    }
 }
 
 /*

--- a/bin/roadrunner-worker
+++ b/bin/roadrunner-worker
@@ -15,6 +15,8 @@ use Spiral\Goridge\Relay;
 use Spiral\RoadRunner\Http\PSR7Worker;
 use Spiral\RoadRunner\Worker as RoadRunnerWorker;
 
+require __DIR__.'/../fixes/fix-symfony-dd.php';
+
 $basePath = require __DIR__.'/bootstrap.php';
 
 /*

--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -15,6 +15,8 @@ ini_set('display_errors', 'stderr');
 
 require_once __DIR__.'/../src/Stream.php';
 
+require __DIR__.'/../fixes/fix-symfony-dd.php';
+
 $bootstrap = fn ($serverState) => require __DIR__.'/bootstrap.php';
 
 /*

--- a/fixes/fix-symfony-dd.php
+++ b/fixes/fix-symfony-dd.php
@@ -1,0 +1,10 @@
+<?php
+
+use Laravel\Octane\Exceptions\DdException;
+
+if (! function_exists('dd')) {
+    function dd(...$vars)
+    {
+        throw new DdException($vars);
+    }
+}


### PR DESCRIPTION
Symfony's `dd()` function natively calls the `exit` method, which is not supported in Swoole and RoadRunner. Octane therefore uses a special `DdException` as a workaround.

This exception will lead to slightly different behaviour though (200 status code instead of 500) as discussed [here](https://github.com/dunglas/frankenphp/discussions/1021)

For Frankenphp this workaround is not necessary since it handles `exit` regularly. This PR removes the workaround when booting Frankenphp and restores the default behaviour.