### PR TITLE
Add keep-config option to install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -23,7 +23,7 @@ class InstallCommand extends Command
      */
     public $signature = 'octane:install
                     {--server= : The server that should be used to serve the application}
-                    {--keep-config : Do not overwrite the existing configuration}';
+                    {--force : Overwrite any existing configuration files}';
 
     /**
      * The command's description.
@@ -56,7 +56,7 @@ class InstallCommand extends Command
 
                 $this->callSilent('vendor:publish', [
                     '--tag' => 'octane-config',
-                    '--force' => ! $this->option('keep-config'),
+                    '--force' => $this->option('force'),
                 ]);
 
                 $this->components->info('Octane installed successfully.');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -22,7 +22,8 @@ class InstallCommand extends Command
      * @var string
      */
     public $signature = 'octane:install
-                    {--server= : The server that should be used to serve the application}';
+                    {--server= : The server that should be used to serve the application}
+                    {--keep-config : Do not overwrite the existing configuration}';
 
     /**
      * The command's description.
@@ -53,7 +54,10 @@ class InstallCommand extends Command
             if ($installed) {
                 $this->updateEnvironmentFile($server);
 
-                $this->callSilent('vendor:publish', ['--tag' => 'octane-config', '--force' => true]);
+                $this->callSilent('vendor:publish', [
+                    '--tag' => 'octane-config',
+                    '--force' => ! $this->option('keep-config'),
+                ]);
 
                 $this->components->info('Octane installed successfully.');
                 $this->newLine();

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -82,6 +82,7 @@ class InstallCommand extends Command
                     PHP_EOL.'OCTANE_SERVER='.$server.PHP_EOL,
                 );
             } else {
+                $this->newLine();
                 $this->components->warn('Please adjust the `OCTANE_SERVER` environment variable.');
             }
         }


### PR DESCRIPTION
In our company, we are building docker image containing octane. One of the build step is installing roadrunner (`php artisan octane:install --server=roadrunner`), which is overwriting our existing configuration for octane.