### PR TITLE
[2.x] Supports Laravel Prompts 0.2 and 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1.0",
         "laminas/laminas-diactoros": "^3.0",
         "laravel/framework": "^10.10.1|^11.0",
-        "laravel/prompts": "^0.1.24",
+        "laravel/prompts": "^0.1.24|^0.2",
         "laravel/serializable-closure": "^1.3.0",
         "nesbot/carbon": "^2.66.0|^3.0",
         "symfony/console": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1.0",
         "laminas/laminas-diactoros": "^3.0",
         "laravel/framework": "^10.10.1|^11.0",
-        "laravel/prompts": "^0.1.24|^0.2",
+        "laravel/prompts": "^0.1.24|^0.2.0|^0.3.0",
         "laravel/serializable-closure": "^1.3.0",
         "nesbot/carbon": "^2.66.0|^3.0",
         "symfony/console": "^6.0|^7.0",


### PR DESCRIPTION
`laravel/framework` introduces `laravel/prompts:^0.2`, but `laravel/octane` still requires `^0.1`.

This is just a simple change in composer.json. I’m not sure if Octane should support both versions or only `^0.2`, so I’ve left both versions for now.