### PR TITLE
Fixed host argument to use the getHost() function

### DIFF
--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -28,7 +28,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
                     {--host=127.0.0.1 : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
                     {--admin-host=localhost : The host the admin server should be available on}
-                    {--admin-port= : The port the admin server should be available on}
+                    {--admin-port=2019 : The port the admin server should be available on}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--max-requests=500 : The number of requests to process before reloading the server}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
@@ -76,7 +76,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
 
         $this->forgetEnvironmentVariables();
 
-        $host = $this->option('host');
+        $host = $this->getHost();
         $port = $this->getPort();
 
         $https = $this->option('https');

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -82,7 +82,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             $roadRunnerBinary,
             '-c', $this->configPath(),
             '-o', 'version=3',
-            '-o', 'http.address='.$this->option('host').':'.$this->getPort(),
+            '-o', 'http.address='.$this->getHost().':'.$this->getPort(),
             '-o', 'server.command='.(new PhpExecutableFinder)->find().','.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),


### PR DESCRIPTION
This is in response to issue #943, this should make it more aligned to the standard way octane:start works.