### PR TITLE
Git ignore the `**/caddy` directories

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -141,7 +141,7 @@ class InstallCommand extends Command
         if (File::exists($gitIgnorePath)) {
             $contents = File::get($gitIgnorePath);
 
-            $filesToAppend = collect(['/caddy', 'frankenphp', 'frankenphp-worker.php'])
+            $filesToAppend = collect(['**/caddy', 'frankenphp', 'frankenphp-worker.php'])
                 ->filter(fn ($file) => ! str_contains($contents, $file.PHP_EOL))
                 ->implode(PHP_EOL);
 


### PR DESCRIPTION
This will successfully ignore the following files:

- `config/caddy/autosave.json`.
- `data/caddy/instance.uuid`.
- `data/caddy/last_clean.json`.
