### PR TITLE
FrankenPHP: Allow running Octane without artisan command

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -32,7 +32,7 @@ $frankenPhpClient = new FrankenPhpClient();
 
 $worker = null;
 $requestCount = 0;
-$maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'];
+$maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
 
 if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {

--- a/src/Commands/stubs/frankenphp-worker.php
+++ b/src/Commands/stubs/frankenphp-worker.php
@@ -1,7 +1,7 @@
 <?php
 
-// set a default for the app base path if it is missing
-$_SERVER['APP_BASE_PATH'] = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? __DIR__ . '/..';
-$_SERVER['APP_PUBLIC_PATH'] = $_SERVER['APP_PUBLIC_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? __DIR__;
+// set a default for the app base and public path if they are missing
+$_SERVER['APP_BASE_PATH'] = $_ENV['APP_BASE_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__ . '/..';
+$_SERVER['APP_PUBLIC_PATH'] = $_ENV['APP_PUBLIC_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__;
 
 require __DIR__.'/../vendor/laravel/octane/bin/frankenphp-worker.php';

--- a/src/Commands/stubs/frankenphp-worker.php
+++ b/src/Commands/stubs/frankenphp-worker.php
@@ -1,7 +1,7 @@
 <?php
 
 // set a default for the app base and public path if they are missing
-$_SERVER['APP_BASE_PATH'] = $_ENV['APP_BASE_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__ . '/..';
+$_SERVER['APP_BASE_PATH'] = $_ENV['APP_BASE_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__.'/..';
 $_SERVER['APP_PUBLIC_PATH'] = $_ENV['APP_PUBLIC_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__;
 
 require __DIR__.'/../vendor/laravel/octane/bin/frankenphp-worker.php';

--- a/src/Commands/stubs/frankenphp-worker.php
+++ b/src/Commands/stubs/frankenphp-worker.php
@@ -1,3 +1,7 @@
 <?php
 
+// set a default for the app base path if it is missing
+$_SERVER['APP_BASE_PATH'] = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? __DIR__ . '/..';
+$_SERVER['APP_PUBLIC_PATH'] = $_SERVER['APP_PUBLIC_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? __DIR__;
+
 require __DIR__.'/../vendor/laravel/octane/bin/frankenphp-worker.php';

--- a/src/Commands/stubs/frankenphp-worker.php
+++ b/src/Commands/stubs/frankenphp-worker.php
@@ -1,6 +1,6 @@
 <?php
 
-// set a default for the app base and public path if they are missing
+// Set a default for the application base path and public path if they are missing...
 $_SERVER['APP_BASE_PATH'] = $_ENV['APP_BASE_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__.'/..';
 $_SERVER['APP_PUBLIC_PATH'] = $_ENV['APP_PUBLIC_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__;
 


### PR DESCRIPTION
This PR is the minimum required to run Octane without `pcntl` and the `artisan octane` wrapper process.

Through a [discussion](https://github.com/dunglas/frankenphp/discussions/1189) in the FrankenPHP repo we realized that when working with a Laravel app that was embedded as a binary, the embedded repository path gets apparently lost along the way, preventing worker mode from working properly.

One way of circumventing this is by starting the process directly through an embedded Caddyfile with `frankenphp run `or `frankenphp php-server`. This PR sets sensible defaults for APP_BASE_PATH, APP_PUBLIC_PATH and MAX_REQUESTS, therefore allowing to run the `frankenphp-worker.php` script independently from `php artisan octane:start`.

This will not affect the current behavior for users using `php artisan octane:start` or `php artisan octane:frankenphp`.