### PR TITLE
Use FrankenPHP's built-in file watcher

### DIFF
--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -22,7 +22,7 @@ trait InstallsFrankenPhpDependencies
      *
      * @var string
      */
-    protected $requiredFrankenPhpVersion = '1.1.0';
+    protected $requiredFrankenPhpVersion = '1.3.0';
 
     /**
      * Ensure the FrankenPHP's Caddyfile and worker script are installed.

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -192,6 +192,22 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
     }
 
     /**
+     * Always return a no-op object, because FrankenPHP has native watcher support.
+     *
+     * @return object
+     */
+    protected function startServerWatcher()
+    {
+        return new class
+        {
+            public function __call($method, $parameters)
+            {
+                return null;
+            }
+        };
+    }
+
+    /**
      * Generate the file watcher configuration snippet to include in the Caddyfile.
      *
      * @return string
@@ -202,7 +218,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             return '';
         }
 
-        // If paths are not specified, fall back to FrankenPHP's default watcher pattern
+        // If paths are not specified, fall back to FrankenPHP's default watcher pattern...
         if (empty($paths = config('octane.watch'))) {
             return "\t\twatch";
         }
@@ -368,20 +384,5 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $this->callSilent('octane:stop', [
             '--server' => 'frankenphp',
         ]);
-    }
-
-    /**
-     * Always return a no-op object, because FrankenPHP has native
-     * watcher support, so there is no need for an external watcher.
-     */
-    protected function startServerWatcher()
-    {
-        return new class
-        {
-            public function __call($method, $parameters)
-            {
-                return null;
-            }
-        };
     }
 }

--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -4,7 +4,11 @@
 	admin {$CADDY_SERVER_ADMIN_HOST}:{$CADDY_SERVER_ADMIN_PORT}
 
 	frankenphp {
-		worker "{$APP_PUBLIC_PATH}/frankenphp-worker.php" {$CADDY_SERVER_WORKER_COUNT}
+		worker {
+			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php"
+			{$CADDY_SERVER_WORKER_DIRECTIVE}
+			{$CADDY_SERVER_WATCH_DIRECTIVES}
+		}
 	}
 }
 


### PR DESCRIPTION
Since [version 1.3](https://github.com/dunglas/frankenphp/releases/tag/v1.3.0), FrankenPHP now has a native file watcher.

This PR switches to use that watcher, instead of needing a separate NodeJS process that restarts the entire server every time a file changes.

For example. this will allow running watch mode in a Docker container that does not have NodeJS.

It might also help fix the same issue as #932 without needing to disable worker mode, though I have not tested that myself.