### PR TITLE
feat: add a way to define frankenphp version

### DIFF
--- a/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
+++ b/src/Commands/Concerns/InstallsFrankenPhpDependencies.php
@@ -4,6 +4,7 @@ namespace Laravel\Octane\Commands\Concerns;
 
 use GuzzleHttp\Client;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Octane\FrankenPhp\Concerns\FindsFrankenPhpBinary;
@@ -76,9 +77,11 @@ trait InstallsFrankenPhpDependencies
             throw new RuntimeException('FrankenPHP binaries are currently only available for Linux (x86_64, aarch64) and macOS. Other systems should use the Docker images or compile FrankenPHP manually.');
         }
 
+        $frankenPHPVersion = Env::get('OCTANE_FRANKENPHP_VERSION', 'latest');
+
         $response = Http::accept('application/vnd.github+json')
             ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
-            ->get('https://api.github.com/repos/dunglas/frankenphp/releases/latest')
+            ->get('https://api.github.com/repos/dunglas/frankenphp/releases/tags/'.$frankenPHPVersion)
             ->throw(fn () => $this->components->error('Failed to download FrankenPHP.'));
 
         $assets = $response['assets'] ?? [];


### PR DESCRIPTION
Recently, due to an issue with FrankenPHP (see [issue #1276](https://github.com/dunglas/frankenphp/issues/1276)), the install command was temporarily non-functional. 

I believe there should be a way to specify the underlying FrankenPHP version in the install command. This would allow us to use a specific version if there are problems with the underlying worker servers.

Let me know if you not happy with the current implementation as I can change implementation to pass the worker server version from the command itself.