### PR TITLE
[WIP] Enable WebSockets via Swoole

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -7,7 +7,9 @@ try {
 
     $sock = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? SWOOLE_SOCK_TCP : SWOOLE_SOCK_TCP6;
 
-    $server = new Swoole\Http\Server(
+    $serverClass = ($config['swoole']['enableWebSockets'] ?? false) ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
+
+    $server = new $serverClass(
         $host,
         $serverState['port'] ?? 8000,
         $config['swoole']['mode'] ?? SWOOLE_PROCESS,

--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -9,6 +9,7 @@ use Laravel\Octane\Swoole\ServerStateFile;
 use Laravel\Octane\Swoole\SwooleExtension;
 use Laravel\Octane\Swoole\WorkerState;
 use Swoole\Http\Server;
+use Swoole\WebSocket\Server as WServer;
 use Swoole\Timer;
 
 ini_set('display_errors', 'stderr');
@@ -49,7 +50,7 @@ $timerTable = require __DIR__.'/createSwooleTimerTable.php';
 |
 */
 
-$server->on('start', fn (Server $server) => $bootstrap($serverState) && (new OnServerStart(
+$server->on('start', fn (Server|WServer $server) => $bootstrap($serverState) && (new OnServerStart(
     new ServerStateFile($serverStateFile),
     new SwooleExtension,
     $serverState['appName'],
@@ -91,7 +92,7 @@ $workerState->cacheTable = require __DIR__.'/createSwooleCacheTable.php';
 $workerState->timerTable = $timerTable;
 $workerState->tables = require __DIR__.'/createSwooleTables.php';
 
-$server->on('workerstart', fn (Server $server, $workerId) =>
+$server->on('workerstart', fn (Server|WServer $server, $workerId) =>
     (fn ($basePath) => (new OnWorkerStart(
         new SwooleExtension, $basePath, $serverState, $workerState
     ))($server, $workerId))($bootstrap($serverState))
@@ -142,13 +143,67 @@ $server->on('request', function ($request, $response) use ($server, $workerState
 |
 */
 
-$server->on('task', fn (Server $server, int $taskId, int $fromWorkerId, $data) =>
+$server->on('task', fn (Server|WServer $server, int $taskId, int $fromWorkerId, $data) =>
     $data === 'octane-tick'
             ? $workerState->worker->handleTick()
             : $workerState->worker->handleTask($data)
 );
 
-$server->on('finish', fn (Server $server, int $taskId, $result) => $result);
+$server->on('finish', fn (Server|WServer $server, int $taskId, $result) => $result);
+
+
+if($serverState['octaneConfig']['swoole']['enableWebSockets'] ?? false){
+
+    /*
+    |--------------------------------------------------------------------------
+    | Handle Incoming WebSocket Connections
+    |--------------------------------------------------------------------------
+    */
+    $server->on('handshake', function ($request, $response) use ($server, $workerState, $serverState) {
+        $workerState->lastRequestTime = microtime(true);
+    
+        if ($workerState->timerTable) {
+            $workerState->timerTable->set($workerState->workerId, [
+                'worker_pid' => $workerState->workerPid,
+                'time' => time(),
+                'fd' => $request->fd,
+            ]);
+        }
+    
+        $workerState->worker->handle(...$workerState->client->marshalRequest(new RequestContext([
+            'swooleRequest' => $request,
+            'swooleResponse' => $response,
+            'publicPath' => $serverState['publicPath'],
+            'octaneConfig' => $serverState['octaneConfig'],
+        ])));
+    
+        if ($workerState->timerTable) {
+            $workerState->timerTable->del($workerState->workerId);
+        }
+    });
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Handle Incoming WebSocket Messages
+    |--------------------------------------------------------------------------
+    */
+
+    $server->on('message', function (Server $server, Frame $frame) use ($workerState) {
+        $workerState->worker->handleWebSocketMessage($server, $frame);
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Handle Closed WebSocket Connections
+    |--------------------------------------------------------------------------
+    */
+
+    $server->on('close', function (Server $server, int $fd) use ($workerState) {
+        $workerState->worker->handleWebSocketDisconnect($server, $fd);
+    });
+
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -189,7 +189,7 @@ if($serverState['octaneConfig']['swoole']['enableWebSockets'] ?? false){
     |--------------------------------------------------------------------------
     */
 
-    $server->on('message', function (Server $server, Frame $frame) use ($workerState) {
+    $server->on('message', function (WServer $server, Swoole\WebSocket\Frame $frame) use ($workerState) {
         $workerState->worker->handleWebSocketMessage($server, $frame);
     });
 
@@ -199,7 +199,7 @@ if($serverState['octaneConfig']['swoole']['enableWebSockets'] ?? false){
     |--------------------------------------------------------------------------
     */
 
-    $server->on('close', function (Server $server, int $fd) use ($workerState) {
+    $server->on('close', function (WServer $server, int $fd) use ($workerState) {
         $workerState->worker->handleWebSocketDisconnect($server, $fd);
     });
 

--- a/config/octane.php
+++ b/config/octane.php
@@ -8,6 +8,8 @@ use Laravel\Octane\Events\TaskReceived;
 use Laravel\Octane\Events\TaskTerminated;
 use Laravel\Octane\Events\TickReceived;
 use Laravel\Octane\Events\TickTerminated;
+use Laravel\Octane\Events\WebSocketMessageReceived;
+use Laravel\Octane\Events\WebSocketDisconnectReceived;
 use Laravel\Octane\Events\WorkerErrorOccurred;
 use Laravel\Octane\Events\WorkerStarting;
 use Laravel\Octane\Events\WorkerStopping;
@@ -99,6 +101,16 @@ return [
         ],
 
         TickTerminated::class => [
+            //
+        ],
+
+        WebSocketMessageReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            //
+        ],
+
+        WebSocketDisconnectReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
             //
         ],
 

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -105,7 +105,7 @@ trait InteractsWithServers
         $this->output->writeln([
             '',
             '  Local: <fg=white;options=bold>'.($this->hasOption('https') && $this->option('https') ? 'https://' : 'http://').$this->getHost().':'.$this->getPort().' </>',
-            '',
+            config('octane.swoole.enableWebSockets') ? ('         <fg=white;options=bold>'.($this->hasOption('https') && $this->option('https') ? 'wss://' : 'ws://').$this->getHost().':'.$this->getPort()." </>\n") : '',
             '  <fg=yellow>Press Ctrl+C to stop the server</>',
             '',
         ]);

--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -7,7 +7,6 @@ use Laravel\Octane\SequentialTaskDispatcher;
 use Laravel\Octane\Swoole\ServerStateFile;
 use Laravel\Octane\Swoole\SwooleHttpTaskDispatcher;
 use Laravel\Octane\Swoole\SwooleTaskDispatcher;
-use Swoole\Http\Server;
 
 trait ProvidesConcurrencySupport
 {
@@ -33,10 +32,11 @@ trait ProvidesConcurrencySupport
      */
     public function tasks()
     {
+        $serverClass = app('config')->get('octane.swoole.enableWebSockets') ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
         return match (true) {
             app()->bound(DispatchesTasks::class) => app(DispatchesTasks::class),
-            app()->bound(Server::class) => new SwooleTaskDispatcher,
-            class_exists(Server::class) => (fn (array $serverState) => new SwooleHttpTaskDispatcher(
+            app()->bound($serverClass) => new SwooleTaskDispatcher,
+            class_exists($serverClass) => (fn (array $serverState) => new SwooleHttpTaskDispatcher(
                 $serverState['state']['host'] ?? '127.0.0.1',
                 $serverState['state']['port'] ?? '8000',
                 new SequentialTaskDispatcher

--- a/src/Events/WebSocketDisconnectReceived.php
+++ b/src/Events/WebSocketDisconnectReceived.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Octane\Events;
+
+use Illuminate\Foundation\Application;
+use Swoole\WebSocket\Server;
+
+class WebSocketDisconnectReceived
+{
+    public function __construct(
+        public Application $app,
+        public Application $sandbox,
+        public Server $server,
+        public int $fd
+    ) {
+    }
+}

--- a/src/Events/WebSocketMessageReceived.php
+++ b/src/Events/WebSocketMessageReceived.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Events;
 
 use Illuminate\Foundation\Application;
+use Swoole\WebSocket\Frame;
 use Swoole\WebSocket\Server;
 
 class WebSocketMessageReceived

--- a/src/Events/WebSocketMessageReceived.php
+++ b/src/Events/WebSocketMessageReceived.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Octane\Events;
+
+use Illuminate\Foundation\Application;
+use Swoole\WebSocket\Server;
+
+class WebSocketMessageReceived
+{
+    public function __construct(
+        public Application $app,
+        public Application $sandbox,
+        public Server $server,
+        public Frame $frame
+    ) {
+    }
+}

--- a/src/Octane.php
+++ b/src/Octane.php
@@ -4,7 +4,6 @@ namespace Laravel\Octane;
 
 use Exception;
 use Laravel\Octane\Swoole\WorkerState;
-use Swoole\Http\Server;
 use Swoole\Table;
 use Throwable;
 
@@ -20,7 +19,8 @@ class Octane
      */
     public function table(string $table): Table
     {
-        if (! app()->bound(Server::class)) {
+        $serverClass = app('config')->get('octane.swoole.enableWebSockets') ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
+        if (! app()->bound($serverClass)) {
             throw new Exception('Tables may only be accessed when using the Swoole server.');
         }
 

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -86,8 +86,8 @@ class OctaneServiceProvider extends ServiceProvider
             ));
         });
 
-        $serverClass = $app['config']->get('octane.swoole.enableWebSockets') ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
         $this->app->bind(DispatchesCoroutines::class, function ($app) {
+            $serverClass = $app['config']->get('octane.swoole.enableWebSockets') ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
             return class_exists($serverClass)
                         ? new SwooleCoroutineDispatcher($app->bound($serverClass))
                         : $app->make(SequentialCoroutineDispatcher::class);

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -86,9 +86,10 @@ class OctaneServiceProvider extends ServiceProvider
             ));
         });
 
+        $serverClass = $app['config']->get('octane.swoole.enableWebSockets') ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
         $this->app->bind(DispatchesCoroutines::class, function ($app) {
-            return class_exists('Swoole\Http\Server')
-                        ? new SwooleCoroutineDispatcher($app->bound('Swoole\Http\Server'))
+            return class_exists($serverClass)
+                        ? new SwooleCoroutineDispatcher($app->bound($serverClass))
                         : $app->make(SequentialCoroutineDispatcher::class);
         });
     }

--- a/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
+++ b/src/Swoole/Actions/ConvertSwooleRequestToIlluminateRequest.php
@@ -24,7 +24,7 @@ class ConvertSwooleRequestToIlluminateRequest
         $request = new SymfonyRequest(
             $swooleRequest->get ?? [],
             $swooleRequest->post ?? [],
-            [],
+            ['fd' => $swooleRequest->fd],
             $swooleRequest->cookie ?? [],
             $swooleRequest->files ?? [],
             $serverVariables,

--- a/src/Swoole/Handlers/OnServerStart.php
+++ b/src/Swoole/Handlers/OnServerStart.php
@@ -23,7 +23,7 @@ class OnServerStart
     /**
      * Handle the "start" Swoole event.
      *
-     * @param  \Swoole\Http\Server  $server
+     * @param  \Swoole\Http\Server|\Swoole\WebSocket\Server  $server
      * @return void
      */
     public function __invoke($server)

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -8,7 +8,6 @@ use Laravel\Octane\Swoole\SwooleClient;
 use Laravel\Octane\Swoole\SwooleExtension;
 use Laravel\Octane\Swoole\WorkerState;
 use Laravel\Octane\Worker;
-use Swoole\Http\Server;
 use Throwable;
 
 class OnWorkerStart
@@ -25,7 +24,7 @@ class OnWorkerStart
     /**
      * Handle the "workerstart" Swoole event.
      *
-     * @param  \Swoole\Http\Server  $server
+     * @param  \Swoole\Http\Server|\Swoole\WebSocket\Server  $server
      * @return void
      */
     public function __invoke($server, int $workerId)
@@ -53,18 +52,19 @@ class OnWorkerStart
     /**
      * Boot the Octane worker and application.
      *
-     * @param  \Swoole\Http\Server  $server
+     * @param  \Swoole\Http\Server|\Swoole\WebSocket\Server  $server
      * @return \Laravel\Octane\Worker|null
      */
     protected function bootWorker($server)
     {
         try {
+            $serverClass = ($this->serverState['octaneConfig']['swoole']['enableWebSockets'] ?? false) ? 'Swoole\WebSocket\Server' : 'Swoole\Http\Server';
             return tap(new Worker(
                 new ApplicationFactory($this->basePath),
                 $this->workerState->client = new SwooleClient
             ))->boot([
                 'octane.cacheTable' => $this->workerState->cacheTable,
-                Server::class => $server,
+                $serverClass => $server,
                 WorkerState::class => $this->workerState,
             ]);
         } catch (Throwable $e) {
@@ -77,7 +77,7 @@ class OnWorkerStart
     /**
      * Start the Octane server tick to dispatch the tick task every second.
      *
-     * @param  \Swoole\Http\Server  $server
+     * @param  \Swoole\Http\Server|\Swoole\WebSocket\Server  $server
      * @return void
      */
     protected function dispatchServerTickTaskEverySecond($server)
@@ -88,7 +88,7 @@ class OnWorkerStart
     /**
      * Register the request handled listener that will output request information per request.
      *
-     * @param  \Swoole\Http\Server  $server
+     * @param  \Swoole\Http\Server|\Swoole\WebSocket\Server  $server
      * @return void
      */
     protected function streamRequestsToConsole($server)


### PR DESCRIPTION
## [WIP] Laravel Octane Swoole WebSockets

Already using Laravel Octane via Swoole?

Take full advantage of Swoole built-in WebSockets features to serve Laravel powered WebSockets!

Configure `octane.swoole.enableWebSockets` to `true` to enable