### PR TITLE
Feat: add support for Swoole task_enable_coroutine & task_use_object/task_object option

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -9,6 +9,7 @@ use Laravel\Octane\Swoole\ServerStateFile;
 use Laravel\Octane\Swoole\SwooleExtension;
 use Laravel\Octane\Swoole\WorkerState;
 use Swoole\Http\Server;
+use Swoole\Server\Task;
 use Swoole\Timer;
 
 ini_set('display_errors', 'stderr');
@@ -142,11 +143,31 @@ $server->on('request', function ($request, $response) use ($server, $workerState
 |
 */
 
-$server->on('task', fn (Server $server, int $taskId, int $fromWorkerId, $data) =>
+/**
+ * **NOTE:** SWOOLE_THREAD mode in Swoole 6.0.0 has a bug that makes
+ * `$server->setting` of workers and task workers being *NULL*.
+ * This bug is already fixed, see this [issue](https://github.com/swoole/swoole-src/issues/5651).
+ */
+if ($server->setting['task_enable_coroutine'] || $server->setting['task_use_object']) {
+    $server->on(
+        'task',
+        function (Server $server, Task $task) use ($workerState) {
+            $data = $task->data;
+            return $data === 'octane-tick'
+                ? $workerState->worker->handleTick()
+                : $task->finish($workerState->worker->handleTask($data));
+        }
+    );
+} else {
+    $server->on(
+        'task',
+        fn(Server $server, int $taskId, int $fromWorkerId, $data) =>
     $data === 'octane-tick'
             ? $workerState->worker->handleTick()
             : $workerState->worker->handleTask($data)
 );
+}
+
 
 $server->on('finish', fn (Server $server, int $taskId, $result) => $result);
 

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -41,6 +41,11 @@ class OnWorkerStart
         $this->streamRequestsToConsole($server);
 
         if ($this->shouldSetProcessName) {
+            /**
+             * **NOTE:** SWOOLE_THREAD mode in Swoole 6.0.0 has a bug that makes
+             * `$server->setting` of workers and task workers being *NULL*.
+             * This bug is already fixed, see this [issue](https://github.com/swoole/swoole-src/issues/5651).
+             */
             $isTaskWorker = $workerId >= $server->setting['worker_num'];
 
             $this->extension->setProcessName(


### PR DESCRIPTION
This PR modify on task callback of Swoole server to support options `task_enable_coroutine` & `task_use_object` set to `true`. As you can see in [Swoole document](https://wiki.swoole.com/en/#/server/setting?id=task_enable_coroutine). When the option `task_enable_coroutine` is enabled, php code can directly use Swoole coroutine api in onTask callback, as well as in Octane::concurrently like bellow code:
```php
Route::get(('/get-post'), function () {
    [$msg] = Octane::concurrently([
        function () {
            $msg = Post::all();
            Log::info('TASK DONE!');
            return $msg;
        },
        function () {
            Coroutine::sleep(1);
        }
    ]);

    return [
        "message" => "ok",
        "data" => $msg
    ];
});
```

Teh option `task_use_object`/`task_object` allows to use the same callback like option `task_enable_coroutine`