### PR TITLE
Add manifest.json to watch default list

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -189,6 +189,7 @@ return [
         'config/**/*.php',
         'database/**/*.php',
         'public/**/*.php',
+        'public/build/manifest.json',
         'resources/**/*.php',
         'routes',
         'composer.lock',


### PR DESCRIPTION
Currently many of the projects work with Vite, currently if you build the manifest file it is modified and not watch that the previous files were deleted and new ones exist in the `manifest.json`.