### PR TITLE
perf: improve performance with FrankenPHP

### DIFF
--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -32,6 +32,7 @@
 
 		php_server {
 			index frankenphp-worker.php
+			try_files {path} frankenphp-worker.php
 			# Required for the public/storage/ directory...
 			resolve_root_symlink
 		}


### PR DESCRIPTION
This config change unlock an optimization we recently added in FrankenPHP allowing to prevent a useless disk access per request for frameworks like Laravel.