### PR TITLE
Chokidar v4 wildcards support

### DIFF
--- a/bin/file-watcher.cjs
+++ b/bin/file-watcher.cjs
@@ -3,21 +3,20 @@ const chokidar = require('chokidar');
 const paths = JSON.parse(process.argv[2]);
 const poll = process.argv[3] ? true : false;
 
-/*
-* Chokidar removed support for glob in version 4
-* As a result some minor changes are needed to support the wildcards
- */
+// Chokidar removed support for glob in version 4...
 const chokidarPackagePath = require.resolve('chokidar').replace('index.js', 'package.json');
-const chokidarVersionV4 = require(chokidarPackagePath).version.startsWith('4.');
+const chokidarVersion4 = require(chokidarPackagePath).version.startsWith('4.');
 
 const extractWildcardExtension = (path) => {
     // Match patterns like *.php, **/*.blade.php
     const match = path.match(/\/\*\.((\w|\.)+)$/);
+
     return match ? match[1] : null;
 };
 
 const getPathBeforeWildcard = (path) => {
     const match = path.match(/^(.*?)(\*|$)/);
+
     return match ? match[1] : path;
 };
 
@@ -25,24 +24,26 @@ const extractedPaths = paths.map(path => {
     return { path: getPathBeforeWildcard(path), extension: extractWildcardExtension(path) };
 });
 
-const watcherPaths = chokidarVersionV4 ? extractedPaths.map(ep => ep.path) : paths;
-const watcherIgnoredFn = chokidarVersionV4 ? (path, stats) => {
+const watcherPaths = chokidarVersion4 ? extractedPaths.map(ep => ep.path) : paths;
+
+const watcherIgnored = chokidarVersion4 ? (path, stats) => {
     if (! stats?.isFile()) {
         return false;
     }
+
     const matchedPattern = extractedPaths.find(ep => path.startsWith(ep.path));
 
     if (! matchedPattern) {
         return true;
     }
 
-    return matchedPattern.extension ? !path.endsWith(`.${matchedPattern.extension}`) : false;
+    return matchedPattern.extension ? ! path.endsWith(`.${matchedPattern.extension}`) : false;
 } : undefined;
 
 const watcher = chokidar.watch(watcherPaths, {
     ignoreInitial: true,
     usePolling: poll,
-    ignored: watcherIgnoredFn,
+    ignored: watcherIgnored,
 });
 
 watcher

--- a/bin/file-watcher.cjs
+++ b/bin/file-watcher.cjs
@@ -3,9 +3,46 @@ const chokidar = require('chokidar');
 const paths = JSON.parse(process.argv[2]);
 const poll = process.argv[3] ? true : false;
 
-const watcher = chokidar.watch(paths, {
+/*
+* Chokidar removed support for glob in version 4
+* As a result some minor changes are needed to support the wildcards
+ */
+const chokidarPackagePath = require.resolve('chokidar').replace('index.js', 'package.json');
+const chokidarVersionV4 = require(chokidarPackagePath).version.startsWith('4.');
+
+const extractWildcardExtension = (path) => {
+    // Match patterns like *.php, **/*.blade.php
+    const match = path.match(/\/\*\.((\w|\.)+)$/);
+    return match ? match[1] : null;
+};
+
+const getPathBeforeWildcard = (path) => {
+    const match = path.match(/^(.*?)(\*|$)/);
+    return match ? match[1] : path;
+};
+
+const extractedPaths = paths.map(path => {
+    return { path: getPathBeforeWildcard(path), extension: extractWildcardExtension(path) };
+});
+
+const watcherPaths = chokidarVersionV4 ? extractedPaths.map(ep => ep.path) : paths;
+const watcherIgnoredFn = chokidarVersionV4 ? (path, stats) => {
+    if (! stats?.isFile()) {
+        return false;
+    }
+    const matchedPattern = extractedPaths.find(ep => path.startsWith(ep.path));
+
+    if (! matchedPattern) {
+        return true;
+    }
+
+    return matchedPattern.extension ? !path.endsWith(`.${matchedPattern.extension}`) : false;
+} : undefined;
+
+const watcher = chokidar.watch(watcherPaths, {
     ignoreInitial: true,
     usePolling: poll,
+    ignored: watcherIgnoredFn,
 });
 
 watcher


### PR DESCRIPTION
Since Chokidar v4 [removed support for glob](https://github.com/paulmillr/chokidar?tab=readme-ov-file#changelog), making wildcard file watcher paths non-functional. For reference, see the open [issue](https://github.com/laravel/octane/issues/962)

This PR addresses this issue by updating **file-watcher.cjs** to restore the ability to use wildcards without requiring additional dependencies or configuration changes. Note that these changes do not affect Chokidar version 3, allowing us to utilize both v3 and v4 seamlessly.