### PR TITLE
Set version=3 for RoadRunner's reload

### DIFF
--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -47,7 +47,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
         tap($this->processFactory->createProcess([
             $this->findRoadRunnerBinary(),
             'reset',
-            '-o', "version=3",
+            '-o', 'version=3',
             '-o', "rpc.listen=tcp://$host:$rpcPort",
             '-s',
         ], base_path()))->start()->waitUntil(function ($type, $buffer) {

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -47,6 +47,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
         tap($this->processFactory->createProcess([
             $this->findRoadRunnerBinary(),
             'reset',
+            '-o', "version=3",
             '-o', "rpc.listen=tcp://$host:$rpcPort",
             '-s',
         ], base_path()))->start()->waitUntil(function ($type, $buffer) {

--- a/tests/RoadRunnerServerProcessInspectorTest.php
+++ b/tests/RoadRunnerServerProcessInspectorTest.php
@@ -63,7 +63,7 @@ class RoadRunnerServerProcessInspectorTest extends TestCase
         ]);
 
         $processFactory->shouldReceive('createProcess')->with(
-            [$this->findRoadRunnerBinary(), 'reset', '-o', 'rpc.listen=tcp://127.0.0.1:6002', '-s'],
+            [$this->findRoadRunnerBinary(), 'reset', '-o', 'server=3', '-o', 'rpc.listen=tcp://127.0.0.1:6002', '-s'],
             base_path(),
         )->andReturn($process = Mockery::mock('stdClass'));
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Since RoadRunner v2024.3.0 and above, running `octane:reload` command will result in an error, where the error message is `Cannot reload RoadRunner: rr configuration file should contain a version e.g: version: 3`. Setting the version when calling RoadRunner binary in `src/RoadRunner/ServerProcessInspector.php` file seems to fix it.

![image](https://github.com/user-attachments/assets/1fc6c528-41cf-443f-922f-98fef50d3ced)
