### PR TITLE
Add {$CADDY_EXTRA_CONFIG} to Caddyfile

### DIFF
--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -8,6 +8,8 @@
 	}
 }
 
+{$CADDY_EXTRA_CONFIG}
+
 {$CADDY_SERVER_SERVER_NAME} {
 	log {
 		level {$CADDY_SERVER_LOG_LEVEL}


### PR DESCRIPTION
Add {$CADDY_EXTRA_CONFIG} to the default Caddyfile for FrankenPHP

This mirrors the default Caddyfile provided and used by FrankenPHP itself

See: https://github.com/dunglas/frankenphp/blob/main/caddy/frankenphp/Caddyfile#L10