### PR TITLE
FrankenPHP: Fix ServerProcessInspector::adminUrl()

### DIFF
--- a/src/FrankenPhp/ServerProcessInspector.php
+++ b/src/FrankenPhp/ServerProcessInspector.php
@@ -64,9 +64,12 @@ class ServerProcessInspector implements ServerProcessInspectorContract
      */
     protected function adminUrl(): string
     {
-        $adminPort = $this->serverStateFile->read()['state']['adminPort'] ?? 2019;
+        $serverStateFile = $this->serverStateFile->read();
+        
+        $adminHost = $serverStateFile['state']['adminHost'] ?? 'localhost';
+        $adminPort = $serverStateFile['state']['adminPort'] ?? 2019;
 
-        return "http://localhost:{$adminPort}";
+        return "http://{$adminHost}:{$adminPort}";
     }
 
     /**


### PR DESCRIPTION
Running `octane:frankenphp --admin-host=...` with any other value than `localhost` made other commands like `octane:reload` fail as it was trying to access the host of adminUrl as a hardcoded value of `localhost`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
