### PR TITLE
Allows run server with composer vendor out of application

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -37,7 +37,9 @@ if (! is_string($basePath)) {
 |
 */
 
-if (! is_file($autoload_file = $basePath.'/vendor/autoload.php')) {
+$vendorDir = $_ENV['COMPOSER_VENDOR_DIR'] ?: "{$basePath}/vendor";
+
+if (! is_file($autoload_file = "{$vendorDir}/autoload.php")) {
     Octane::writeError("Composer autoload file was not found. Did you install the project's dependencies?");
 
     exit(10);


### PR DESCRIPTION
This change allows running octane server in projects where the vendor folder is outside of the Laravel application itself.

 `COMPOSER_VENDOR_DIR` is an existing and supported env property in the `laravel/framework` package.
