### PR TITLE
Add support for UNIX socket in Octane Swoole server

### DIFF
--- a/bin/createSwooleServer.php
+++ b/bin/createSwooleServer.php
@@ -7,14 +7,24 @@ try {
 
     $sock = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? SWOOLE_SOCK_TCP : SWOOLE_SOCK_TCP6;
 
-    $server = new Swoole\Http\Server(
-        $host,
-        $serverState['port'] ?? 8000,
-        $config['swoole']['mode'] ?? SWOOLE_PROCESS,
-        ($config['swoole']['ssl'] ?? false)
-            ? $sock | SWOOLE_SSL
-            : $sock,
-    );
+    $unixSock = $serverState['sock'] ?? null;
+    if (is_string($unixSock) && str_starts_with($unixSock, '/')) {
+        $server = new Swoole\Http\Server(
+            $unixSock,  // Use UNIX socket
+            0,          // Port is not needed
+            $config['swoole']['mode'] ?? SWOOLE_PROCESS,
+            SWOOLE_SOCK_UNIX_STREAM
+        );
+    } else {
+        $server = new Swoole\Http\Server(
+            $host,
+            $serverState['port'] ?? 8000,
+            $config['swoole']['mode'] ?? SWOOLE_PROCESS,
+            ($config['swoole']['ssl'] ?? false)
+                ? $sock | SWOOLE_SSL
+                : $sock,
+        );
+    }
 } catch (Throwable $e) {
     Laravel\Octane\Stream::shutdown($e);
 

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -102,9 +102,15 @@ trait InteractsWithServers
     {
         $this->components->info('Server running…');
 
+        if ($this->option('sock')) {
+            $str = '  Local: <fg=white;options=bold>unix:'.$this->option('sock').' </>';
+        } else {
+            $str = '  Local: <fg=white;options=bold>'.($this->hasOption('https') && $this->option('https') ? 'https://' : 'http://').$this->getHost().':'.$this->getPort().' </>';
+        }
+
         $this->output->writeln([
             '',
-            '  Local: <fg=white;options=bold>'.($this->hasOption('https') && $this->option('https') ? 'https://' : 'http://').$this->getHost().':'.$this->getPort().' </>',
+            $str,
             '',
             '  <fg=yellow>Press Ctrl+C to stop the server</>',
             '',

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -19,6 +19,7 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--server= : The server that should be used to serve the application}
                     {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on [default: "8000"]}
+                    {--sock= : The unix domain socket the server should bind to [Swoole only]}
                     {--admin-port= : The port the admin server should be available on [FrankenPHP only]}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
@@ -67,6 +68,7 @@ class StartCommand extends Command implements SignalableCommandInterface
         return $this->call('octane:swoole', [
             '--host' => $this->getHost(),
             '--port' => $this->getPort(),
+            '--sock' => $this->option('sock'),
             '--workers' => $this->option('workers') ?: config('octane.workers', 'auto'),
             '--task-workers' => $this->option('task-workers') ?: config('octane.task_workers', 'auto'),
             '--max-requests' => $this->option('max-requests') ?: config('octane.max_requests', 500),

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -24,6 +24,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
     public $signature = 'octane:swoole
                     {--host= : The IP address the server should bind to}
                     {--port= : The port the server should be available on}
+                    {--sock= : The unix socket the server should bind to [Swoole only]}
                     {--workers=auto : The number of workers that should be available to handle requests}
                     {--task-workers=auto : The number of task workers that should be available to handle tasks}
                     {--max-requests=500 : The number of requests to process before reloading the server}
@@ -105,6 +106,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'appName' => config('app.name', 'Laravel'),
             'host' => $this->getHost(),
             'port' => $this->getPort(),
+            'sock' => $this->option('sock'),
             'workers' => $this->workerCount($extension),
             'taskWorkers' => $this->taskWorkerCount($extension),
             'maxRequests' => $this->option('max-requests'),


### PR DESCRIPTION
This pull request adds support for running the Laravel Octane Swoole server via a UNIX domain socket (UDS), instead of the default TCP host/port combination.

Benefit to end users:
Using a UNIX socket can offer better performance and security when deploying Laravel behind a local reverse proxy like Nginx. It avoids unnecessary TCP overhead, simplifies internal routing, and reduces the potential attack surface by keeping inter-process communication on the filesystem.

Why it doesn’t break existing features:

This change is non-breaking and fully backward compatible.

If the sock is not set, Octane continues to use the standard host and port settings.

How it improves developer experience:

Developers using Swoole in Docker or on Linux servers now have the flexibility to bind the Octane server to a UNIX socket file.

This allows easier integration with services like Nginx (fastcgi_pass or proxy_pass to unix:/...) and enhances performance in high-throughput environments.

Notes:

This feature is ignored on Windows, as UNIX domain sockets are not supported there.

Let me know if you’d like help documentation updates to go along with the feature.

https://github.com/laravel/octane/issues/1031