### PR TITLE
Add configurable opcache clearing and static file serving options

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -30,7 +30,9 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
-        $this->clearOpcodeCache();
+        if ($this->shouldClearOpcodeCache()) {
+            $this->clearOpcodeCache();
+        }
 
         $this->workerState->server = $server;
         $this->workerState->workerId = $workerId;
@@ -105,6 +107,16 @@ class OnWorkerStart
                 (microtime(true) - $this->workerState->lastRequestTime) * 1000,
             );
         });
+    }
+
+    /**
+     * Determine if opcode cache should be cleared.
+     *
+     * @return bool
+     */
+    protected function shouldClearOpcodeCache(): bool
+    {
+        return config('octane.swoole.clear_opcache', true);
     }
 
     /**

--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -110,11 +110,11 @@ class OnWorkerStart
     }
 
     /**
-     * Determine if opcode cache should be cleared.
+     * Determine if the opcode cache should be cleared.
      *
      * @return bool
      */
-    protected function shouldClearOpcodeCache(): bool
+    protected function shouldClearOpcodeCache()
     {
         return config('octane.swoole.clear_opcache', true);
     }

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -51,9 +51,9 @@ class SwooleClient implements Client, ServesStaticFiles
     public function canServeRequestAsStaticFile(Request $request, RequestContext $context): bool
     {
         $octaneConfig = $context->octaneConfig ?? [];
-        
+
         // Check if static file serving is disabled
-        if (array_key_exists('serve_static_files', $octaneConfig) && !$octaneConfig['serve_static_files']) {
+        if (array_key_exists('serve_static_files', $octaneConfig) && ! $octaneConfig['serve_static_files']) {
             return false;
         }
 

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -50,6 +50,13 @@ class SwooleClient implements Client, ServesStaticFiles
      */
     public function canServeRequestAsStaticFile(Request $request, RequestContext $context): bool
     {
+        $octaneConfig = $context->octaneConfig ?? [];
+        
+        // Check if static file serving is disabled
+        if (array_key_exists('serve_static_files', $octaneConfig) && !$octaneConfig['serve_static_files']) {
+            return false;
+        }
+
         if (! ($context->publicPath ?? false) ||
             $request->path() === '/') {
             return false;

--- a/src/Swoole/SwooleClient.php
+++ b/src/Swoole/SwooleClient.php
@@ -52,8 +52,8 @@ class SwooleClient implements Client, ServesStaticFiles
     {
         $octaneConfig = $context->octaneConfig ?? [];
 
-        // Check if static file serving is disabled
-        if (array_key_exists('serve_static_files', $octaneConfig) && ! $octaneConfig['serve_static_files']) {
+        if (array_key_exists('serve_static_files', $octaneConfig) && 
+            ! $octaneConfig['serve_static_files']) {
             return false;
         }
 

--- a/tests/OnWorkerStartTest.php
+++ b/tests/OnWorkerStartTest.php
@@ -11,10 +11,10 @@ class OnWorkerStartTest extends TestCase
     public function test_should_clear_opcache_returns_true_by_default(): void
     {
         $this->createApplication();
-        
+
         // Mock the OnWorkerStart handler to test just the shouldClearOpcodeCache method
         $handler = Mockery::mock(OnWorkerStart::class)->makePartial();
-        
+
         $reflection = new \ReflectionClass($handler);
         $method = $reflection->getMethod('shouldClearOpcodeCache');
         $method->setAccessible(true);
@@ -26,10 +26,10 @@ class OnWorkerStartTest extends TestCase
     {
         $app = $this->createApplication();
         $app['config']['octane.swoole.clear_opcache'] = false;
-        
+
         // Mock the OnWorkerStart handler to test just the shouldClearOpcodeCache method
         $handler = Mockery::mock(OnWorkerStart::class)->makePartial();
-        
+
         $reflection = new \ReflectionClass($handler);
         $method = $reflection->getMethod('shouldClearOpcodeCache');
         $method->setAccessible(true);

--- a/tests/OnWorkerStartTest.php
+++ b/tests/OnWorkerStartTest.php
@@ -36,4 +36,3 @@ class OnWorkerStartTest extends TestCase
         $this->assertFalse($method->invoke($handler));
     }
 }
-

--- a/tests/OnWorkerStartTest.php
+++ b/tests/OnWorkerStartTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Laravel\Octane\Swoole\Handlers\OnWorkerStart;
+use Laravel\Octane\Swoole\SwooleExtension;
+use Mockery;
+
+class OnWorkerStartTest extends TestCase
+{
+    public function test_should_clear_opcache_returns_true_by_default(): void
+    {
+        $this->createApplication();
+        
+        // Mock the OnWorkerStart handler to test just the shouldClearOpcodeCache method
+        $handler = Mockery::mock(OnWorkerStart::class)->makePartial();
+        
+        $reflection = new \ReflectionClass($handler);
+        $method = $reflection->getMethod('shouldClearOpcodeCache');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($handler));
+    }
+
+    public function test_should_clear_opcache_returns_configured_value(): void
+    {
+        $app = $this->createApplication();
+        $app['config']['octane.swoole.clear_opcache'] = false;
+        
+        // Mock the OnWorkerStart handler to test just the shouldClearOpcodeCache method
+        $handler = Mockery::mock(OnWorkerStart::class)->makePartial();
+        
+        $reflection = new \ReflectionClass($handler);
+        $method = $reflection->getMethod('shouldClearOpcodeCache');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($handler));
+    }
+}

--- a/tests/OnWorkerStartTest.php
+++ b/tests/OnWorkerStartTest.php
@@ -3,7 +3,6 @@
 namespace Laravel\Octane\Tests;
 
 use Laravel\Octane\Swoole\Handlers\OnWorkerStart;
-use Laravel\Octane\Swoole\SwooleExtension;
 use Mockery;
 
 class OnWorkerStartTest extends TestCase
@@ -37,3 +36,4 @@ class OnWorkerStartTest extends TestCase
         $this->assertFalse($method->invoke($handler));
     }
 }
+

--- a/tests/SwooleClientTest.php
+++ b/tests/SwooleClientTest.php
@@ -73,6 +73,38 @@ class SwooleClientTest extends TestCase
         $this->assertTrue($client->canServeRequestAsStaticFile($request, $context));
     }
 
+    public function test_can_serve_static_files_when_explicitly_enabled(): void
+    {
+        $client = new SwooleClient;
+
+        $request = Request::create('/foo.txt', 'GET');
+
+        $context = new RequestContext([
+            'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [
+                'serve_static_files' => true,
+            ],
+        ]);
+
+        $this->assertTrue($client->canServeRequestAsStaticFile($request, $context));
+    }
+
+    public function test_cant_serve_static_files_when_disabled(): void
+    {
+        $client = new SwooleClient;
+
+        $request = Request::create('/foo.txt', 'GET');
+
+        $context = new RequestContext([
+            'publicPath' => __DIR__.'/public',
+            'octaneConfig' => [
+                'serve_static_files' => false,
+            ],
+        ]);
+
+        $this->assertFalse($client->canServeRequestAsStaticFile($request, $context));
+    }
+
     public function test_cant_serve_static_files_if_file_is_outside_public_directory(): void
     {
         $client = new SwooleClient;


### PR DESCRIPTION
## Summary

This PR adds two new configuration options to provide better control over Octane's behavior in different deployment scenarios:

1. **`octane.swoole.clear_opcache`** - Controls whether to clear opcache on Swoole worker startup (defaults to `true`)
2. **`octane.serve_static_files`** - Controls whether to serve static files through Octane (defaults to `true`)

## Motivation

These configuration options address common deployment scenarios where the default behavior may not be optimal:

### 1. Docker/Containerized Environments
In containerized environments, code changes typically trigger a complete image rebuild and redeployment rather than hot-reloading. In such scenarios, clearing opcache on every worker start provides minimal benefit while adding unnecessary overhead.

### 2. API-Only Applications
Many applications serve as pure API backends without any static file requirements. For these use cases, disabling static file handling can improve performance by eliminating unnecessary file system checks and routing logic.

### 3. Performance Optimization
Both features allow fine-tuning of Octane's behavior based on specific deployment requirements, enabling better performance optimization for different use cases.

## Changes

### Configuration Options
- Added `octane.swoole.clear_opcache` configuration (Swoole-specific)
- Added `octane.serve_static_files` configuration (Octane-wide)  
- Both options default to `true` to maintain backward compatibility

### Implementation
- Modified `OnWorkerStart::shouldClearOpcodeCache()` to check configuration
- Modified `SwooleClient::canServeRequestAsStaticFile()` to respect configuration
- All changes are backward compatible with existing installations

### Tests
- Added comprehensive unit tests for both features
- Tests verify default behavior and custom configuration scenarios
- Existing test suite continues to pass

## Usage

Users can control these features through configuration:

```php
// config/octane.php
return [
    // Control static file serving (default: true)
    'serve_static_files' => env('OCTANE_SERVE_STATIC_FILES', true),
    
    'swoole' => [
        // Control opcache clearing on worker start (default: true)
        'clear_opcache' => env('OCTANE_SWOOLE_CLEAR_OPCACHE', true),
    ],
    
    // ... other existing configuration options
];
```

Or via environment variables:

```bash
# Disable static file serving
OCTANE_SERVE_STATIC_FILES=false

# Disable opcache clearing on worker start
OCTANE_SWOOLE_CLEAR_OPCACHE=false
```

## Backward Compatibility

All changes maintain full backward compatibility. Existing installations will continue to work with the current behavior (both features enabled by default).

## Test Coverage

- Added `OnWorkerStartTest` for opcache clearing configuration
- Extended `SwooleClientTest` with static file serving configuration tests
- All existing tests continue to pass