### PR TITLE
fix: prevent configuration access before Octane boot

### DIFF
--- a/src/Swoole/Handlers/OnWorkerStart.php
+++ b/src/Swoole/Handlers/OnWorkerStart.php
@@ -30,14 +30,14 @@ class OnWorkerStart
      */
     public function __invoke($server, int $workerId)
     {
-        if ($this->shouldClearOpcodeCache()) {
-            $this->clearOpcodeCache();
-        }
-
         $this->workerState->server = $server;
         $this->workerState->workerId = $workerId;
         $this->workerState->workerPid = posix_getpid();
         $this->workerState->worker = $this->bootWorker($server);
+
+        if ($this->shouldClearOpcodeCache()) {
+            $this->clearOpcodeCache();
+        }
 
         $this->dispatchServerTickTaskEverySecond($server);
         $this->streamRequestsToConsole($server);


### PR DESCRIPTION

This PR addresses an issue where accessing configuration values within Octane's Octane::booting() callback could lead to unexpected behavior or errors when using the Swoole server. As reported in [issue #1038](https://github.com/laravel/octane/issues/1038), this happens because the Laravel application's configuration is not fully booted at the time the Octane::booting() callbacks are executed.

While this doesn't occur with the RoadRunner driver, it does affect Swoole, since its lifecycle differs in how the application is initialized and reused between requests.

This fix ensures that the Laravel application is fully booted (including the configuration) before any Octane::booting() callbacks are triggered. This allows developers to safely access configuration values or perform other application-dependent operations inside those callbacks without introducing instability.