### PR TITLE
Make Swoole package_max_length configurable via config and env

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -232,7 +232,4 @@ return [
             'package_max_length' => env('OCTANE_PACKAGE_MAX_LENGTH', 50 * 1024 * 1024), // 50MB default
         ],
     ],
-
-
-
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -221,4 +221,18 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+   |--------------------------------------------------------------------------
+   | Swoole Options (your custom part)
+   |--------------------------------------------------------------------------
+   */
+    'swoole' => [
+        'options' => [
+            // Maximum package (upload) size for Swoole. You can set it from .env via OCTANE_PACKAGE_MAX_LENGTH.
+            'package_max_length' => env('OCTANE_PACKAGE_MAX_LENGTH', 50 * 1024 * 1024), // 50MB default
+        ],
+    ],
+
+
+
 ];


### PR DESCRIPTION
This pull request adds the ability to configure the package_max_length option for Swoole directly from the config/octane.php configuration file, or by using the OCTANE_PACKAGE_MAX_LENGTH environment variable.

Motivation
Previously, the maximum allowed size for incoming requests in Swoole was not easily configurable. This change provides users with more flexibility to control upload limits based on their application needs, especially for handling large file uploads.

How it works
By default, the value is set to 50 MB. To customize, simply set the environment variable in your .env file

