### PR TITLE
FrankenPHP: show worker startup errors if `APP_DEBUG=true`

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,10 +56,10 @@ try {
                 report($e);
             }
 
-            $hasDebugModeEnabled = app()->has('config') && app()->hasDebugModeEnabled();
+            $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
-                $hasDebugModeEnabled ? (string)$e : 'Internal Server Error',
+                $debugMode === 'true' ? (string)$e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -59,7 +59,7 @@ try {
             $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
-                $debugMode === 'true' ? (string)$e : 'Internal Server Error',
+                $debugMode === 'true' ? (string) $e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,8 +56,10 @@ try {
                 report($e);
             }
 
+            $hasDebugModeEnabled = app()->has('config') && app()->hasDebugModeEnabled();
+
             $response = new Response(
-                'Internal Server Error',
+                $hasDebugModeEnabled ? (string)$e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',


### PR DESCRIPTION
Currently if an error happens during worker startup it will return a response showing 'Internal Server Error'.

This PR changes it so the error gets printed to the screen if `APP_DEBUG=true` in environment variables.

Laravel has potentially not started yet, so the error is printed literally as plain text. The immediate feedback still greatly helps when debugging certain bugs that can happen during startup.