### PR TITLE
Replace Octane::writeError with die statements

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -20,7 +20,7 @@ $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
 $basePath = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? $serverState['octaneConfig']['base_path'] ?? null;
 
 if (! is_string($basePath)) {
-    Octane::writeError('Cannot find application base path.');
+    die('Cannot find application base path.');
 
     exit(11);
 }
@@ -40,7 +40,7 @@ if (! is_string($basePath)) {
 $vendorDir = $_ENV['COMPOSER_VENDOR_DIR'] ?? "{$basePath}/vendor";
 
 if (! is_file($autoload_file = "{$vendorDir}/autoload.php")) {
-    Octane::writeError("Composer autoload file was not found. Did you install the project's dependencies?");
+    die("Composer autoload file was not found. Did you install the project's dependencies?");
 
     exit(10);
 }


### PR DESCRIPTION
the autoloader still not exist so it can not find the class

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
