### PR TITLE
Refactor error handling and environment variable access

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -1,7 +1,4 @@
 <?php
-
-use Laravel\Octane\Octane;
-
 ini_set('display_errors', 'stderr');
 
 $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
@@ -17,12 +14,10 @@ $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
 |
 */
 
-$basePath = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? $serverState['octaneConfig']['base_path'] ?? null;
+$basePath = $_SERVER['APP_BASE_PATH'] ?? getenv('APP_BASE_PATH') ?? $serverState['octaneConfig']['base_path'] ?? null;
 
 if (! is_string($basePath)) {
-    Octane::writeError('Cannot find application base path.');
-
-    exit(11);
+    exit('Cannot find application base path.');
 }
 
 /*
@@ -37,12 +32,10 @@ if (! is_string($basePath)) {
 |
 */
 
-$vendorDir = $_ENV['COMPOSER_VENDOR_DIR'] ?? "{$basePath}/vendor";
+$vendorDir = getenv('COMPOSER_VENDOR_DIR') ?? "{$basePath}/vendor";
 
 if (! is_file($autoload_file = "{$vendorDir}/autoload.php")) {
-    Octane::writeError("Composer autoload file was not found. Did you install the project's dependencies?");
-
-    exit(10);
+    exit("Composer autoload file was not found. Did you install the project's dependencies?");
 }
 
 require_once $autoload_file;


### PR DESCRIPTION
Access ENV vars using $_ENV require more additional settings in  php.ini to add "E" to variables_order so we can using getenv instead
