### PR TITLE
Advance worker initialization in frankenphp-worker

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -18,7 +18,7 @@ $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
 $basePath = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? $serverState['octaneConfig']['base_path'] ?? null;
 
 if (! is_string($basePath)) {
-    exit('Cannot find application base path.');
+    echo 'Cannot find application base path.';
 
     exit(11);
 }
@@ -38,7 +38,7 @@ if (! is_string($basePath)) {
 $vendorDir = $_ENV['COMPOSER_VENDOR_DIR'] ?? "{$basePath}/vendor";
 
 if (! is_file($autoload_file = "{$vendorDir}/autoload.php")) {
-    exit("Composer autoload file was not found. Did you install the project's dependencies?");
+    echo "Composer autoload file was not found. Did you install the project's dependencies?";
 
     exit(10);
 }

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -38,6 +38,7 @@ $worker = tap(
 
 $requestCount = 0;
 $maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
+$debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
 
 if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {
@@ -45,7 +46,7 @@ if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {
 }
 
 try {
-    $handleRequest = static function () use ($worker, $frankenPhpClient) {
+    $handleRequest = static function () use ($worker, $frankenPhpClient, $debugMode) {
         try {
             [$request, $context] = $frankenPhpClient->marshalRequest(new RequestContext());
 
@@ -54,8 +55,6 @@ try {
             if ($worker) {
                 report($e);
             }
-
-            $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
                 $debugMode === 'true' ? (string) $e : 'Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -30,15 +30,13 @@ $basePath = require __DIR__.'/bootstrap.php';
 
 $frankenPhpClient = new FrankenPhpClient();
 
-$worker = tap(
-    new Worker(
-        new ApplicationFactory($basePath), $frankenPhpClient
-    )
-)->boot();
+$worker = tap(new Worker(
+    new ApplicationFactory($basePath), $frankenPhpClient
+))->boot();
 
 $requestCount = 0;
-$maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
 $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
+$maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
 
 if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -30,7 +30,12 @@ $basePath = require __DIR__.'/bootstrap.php';
 
 $frankenPhpClient = new FrankenPhpClient();
 
-$worker = null;
+$worker = tap(
+    new Worker(
+        new ApplicationFactory($basePath), $frankenPhpClient
+    )
+)->boot();
+
 $requestCount = 0;
 $maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
@@ -40,14 +45,8 @@ if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {
 }
 
 try {
-    $handleRequest = static function () use (&$worker, $basePath, $frankenPhpClient) {
+    $handleRequest = static function () use ($worker, $frankenPhpClient) {
         try {
-            $worker ??= tap(
-                new Worker(
-                    new ApplicationFactory($basePath), $frankenPhpClient
-                )
-            )->boot();
-
             [$request, $context] = $frankenPhpClient->marshalRequest(new RequestContext());
 
             $worker->handle($request, $context);


### PR DESCRIPTION
- Output error messages and retain status codes
- Advance the initialization of the worker; this should fix #1056.