### PR TITLE
Add configurable vendor path and improve environment variable handling

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -15,7 +15,7 @@ $_ENV['APP_RUNNING_IN_CONSOLE'] = false;
 |
 */
 
-$basePath = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? $serverState['octaneConfig']['base_path'] ?? null;
+$basePath = $_SERVER['APP_BASE_PATH'] ?? getenv('APP_BASE_PATH') ?? $serverState['octaneConfig']['base_path'] ?? null;
 
 if (! is_string($basePath)) {
     echo 'Cannot find application base path.';
@@ -35,7 +35,7 @@ if (! is_string($basePath)) {
 |
 */
 
-$vendorDir = $_ENV['COMPOSER_VENDOR_DIR'] ?? "{$basePath}/vendor";
+$vendorDir = getenv('COMPOSER_VENDOR_DIR') ?? "{$basePath}/vendor";
 
 if (! is_file($autoload_file = "{$vendorDir}/autoload.php")) {
     echo "Composer autoload file was not found. Did you install the project's dependencies?";

--- a/config/octane.php
+++ b/config/octane.php
@@ -221,4 +221,17 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Vendor Path
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the path to the "vendor" directory that Octane will
+    | use when bootstrapping the application. By default, it will use the
+    | vendor folder inside the base path of the application.
+    |
+    */
+
+    'vendor_path' => env('OCTANE_VENDOR_PATH', base_path('vendor')),
+
 ];

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -106,6 +106,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'CADDY_SERVER_WORKER_DIRECTIVE' => $this->workerCount() ? "num {$this->workerCount()}" : '',
             'CADDY_SERVER_EXTRA_DIRECTIVES' => $this->buildMercureConfig(),
             'CADDY_SERVER_WATCH_DIRECTIVES' => $this->buildWatchConfig(),
+            'COMPOSER_VENDOR_DIR' => config('octane.vendor_path'),
         ]));
 
         $server = $process->start();

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -99,6 +99,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             'APP_ENV' => app()->environment(),
             'APP_BASE_PATH' => base_path(),
             'LARAVEL_OCTANE' => 1,
+            'COMPOSER_VENDOR_DIR' => config('octane.vendor_path'),
         ]))->start();
 
         $serverStateFile->writeProcessId($server->getPid());

--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -87,6 +87,7 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'APP_ENV' => app()->environment(),
             'APP_BASE_PATH' => base_path(),
             'LARAVEL_OCTANE' => 1,
+            'COMPOSER_VENDOR_DIR' => config('octane.vendor_path'),
         ]))->start();
 
         return $this->runServer($server, $inspector, 'swoole');


### PR DESCRIPTION
This PR enhances the Octane bootstrap process and server start commands with better environment handling and support for custom vendor paths.

### Changes
- Added `vendor_path` option in `config/octane.php`:
  - Defaults to `base_path('vendor')`.
  - Can be overridden via the `OCTANE_VENDOR_PATH` environment variable.
- Updated bootstrap to use `getenv()` instead of `$_ENV`, ensuring environment variables are always available without requiring changes to `php.ini` (`variables_order`).
- Updated Swoole, RoadRunner, and FrankenPHP server processes to pass `COMPOSER_VENDOR_DIR` from `config('octane.vendor_path')` to the environment.

### Why
- `$_ENV` may return `null` if PHP is not configured with `E` in `variables_order`. Using `getenv()` avoids this issue.
- Allowing a configurable vendor path makes Octane more flexible in setups where the `vendor` directory is not in the default location.
- Ensures all supported servers consistently receive the correct `COMPOSER_VENDOR_DIR`.

### Impact
- Backwards-compatible: defaults to the existing vendor path.
- No breaking changes for current Octane users.
- Provides greater flexibility and reliability across environments.
