### PR TITLE
FrankenPHP: Add env option to disable Caddy access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/laravel/octane/compare/v2.12.3...2.x)
 
+### Added
+
+* FrankenPHP: Add env option `OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS` to disable Caddy access logs
+
 ## [v2.12.3](https://github.com/laravel/octane/compare/v2.12.2...v2.12.3) - 2025-09-23
 
 * Replace Octane::writeError with die statements by [@7amoood](https://github.com/7amoood) in https://github.com/laravel/octane/pull/1057

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ Please review [our security policy](https://github.com/laravel/octane/security/p
 ## License
 
 Laravel Octane is open-sourced software licensed under the [MIT license](LICENSE.md).
+
+### Disable Caddy Access Logs
+
+By default, Caddy logs every request when using FrankenPHP. To disable these access logs, set the following environment variable in your `.env` or server configuration:
+
+```bash
+OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS=true
+```
+
+When not set, access logs remain enabled by default.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,3 @@ Please review [our security policy](https://github.com/laravel/octane/security/p
 ## License
 
 Laravel Octane is open-sourced software licensed under the [MIT license](LICENSE.md).
-
-### Disable Caddy Access Logs
-
-By default, Caddy logs every request when using FrankenPHP. To disable these access logs, set the following environment variable in your `.env` or server configuration:
-
-```bash
-OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS=true
-```
-
-When not set, access logs remain enabled by default.

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -84,6 +84,25 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         $serverName = $https
             ? "https://$host:$port"
             : "http://:$port";
+        // Allow disabling Caddy access logs via environment variable (default: enabled)
+        $disableAccessLogs = env('OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS', false);
+        $logBlock = $disableAccessLogs
+            ? '# Access logs disabled via env'
+            : <<<'LOG'
+log {
+	level {$CADDY_SERVER_LOG_LEVEL}
+
+	# Redact the authorization query parameter that can be set by Mercure...
+	format filter {
+		wrap {$CADDY_SERVER_LOGGER}
+		fields {
+			uri query {
+				replace authorization REDACTED
+			}
+		}
+	}
+}
+LOG;
 
         $process = tap(new Process([
             $frankenphpBinary,
@@ -101,6 +120,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'CADDY_SERVER_ADMIN_HOST' => $this->option('admin-host'),
             'CADDY_SERVER_LOG_LEVEL' => $this->option('log-level') ?: (app()->environment('local') ? 'INFO' : 'WARN'),
             'CADDY_SERVER_LOGGER' => 'json',
+            'CADDY_SERVER_LOG_BLOCK' => $logBlock,
             'CADDY_SERVER_SERVER_NAME' => $serverName,
             'CADDY_SERVER_WORKER_COUNT' => $this->workerCount() ?: '',
             'CADDY_SERVER_WORKER_DIRECTIVE' => $this->workerCount() ? "num {$this->workerCount()}" : '',

--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -15,19 +15,7 @@
 {$CADDY_EXTRA_CONFIG}
 
 {$CADDY_SERVER_SERVER_NAME} {
-	log {
-		level {$CADDY_SERVER_LOG_LEVEL}
-
-		# Redact the authorization query parameter that can be set by Mercure...
-		format filter {
-			wrap {$CADDY_SERVER_LOGGER}
-			fields {
-				uri query {
-					replace authorization REDACTED
-				}
-			}
-		}
-	}
+	{$CADDY_SERVER_LOG_BLOCK}
 
 	route {
 		root * "{$APP_PUBLIC_PATH}"


### PR DESCRIPTION

This PR adds support for disabling Caddy access logs when running Laravel Octane with FrankenPHP.

Problem:
Caddy logs every request by default, creating unnecessary noise in production logs where centralized logging (Grafana, NewRelic, etc.) is already used.

Solution:
Added an environment variable OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS that, when set to true, disables the access logs by commenting out the log {} block in the generated Caddyfile.

Behavior:

Default: logs enabled (backward-compatible).

When OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS=true, access logs are disabled.

Testing:
Verified locally with Octane + FrankenPHP; access logs were correctly suppressed when the env was set.

Changelog:
Added OCTANE_FRANKENPHP_DISABLE_ACCESS_LOGS environment variable to disable Caddy access logs.

