### PR TITLE
Added exception when empty tasks array passed to ProvidesConcurrencyS…

### DIFF
--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Concerns;
 
+use InvalidArgumentException;
 use Laravel\Octane\Contracts\DispatchesTasks;
 use Laravel\Octane\SequentialTaskDispatcher;
 use Laravel\Octane\Swoole\ServerStateFile;
@@ -23,6 +24,10 @@ trait ProvidesConcurrencySupport
      */
     public function concurrently(array $tasks, int $waitMilliseconds = 3000)
     {
+        if (empty($tasks)) {
+            throw new InvalidArgumentException('Tasks cannot be an empty array');
+        }
+
         return $this->tasks()->resolve($tasks, $waitMilliseconds);
     }
 

--- a/tests/ProvidesConcurrencyTest.php
+++ b/tests/ProvidesConcurrencyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use InvalidArgumentException;
+use Laravel\Octane\Concerns\ProvidesConcurrencySupport;
+
+class ProvidesConcurrencyTest extends TestCase
+{
+    private function fakeClass(): object
+    {
+        return new class
+        {
+            use ProvidesConcurrencySupport;
+        };
+    }
+
+    public function test_concurrently_fails_with_empty_tasks()
+    {
+        $fakeClass = $this->fakeClass();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tasks cannot be an empty array');
+
+        $fakeClass->concurrently([]);
+    }
+
+    public function test_concurrently_does_not_fail_with_not_empty_tasks()
+    {
+        $fakeClass = $this->fakeClass();
+
+
+        $results = $fakeClass->concurrently([
+            fn() => 1 + 1,
+            fn() => 2 + 2,
+        ]);
+
+        $this->assertEquals([2, 4], $results);
+    }
+}

--- a/tests/ProvidesConcurrencyTest.php
+++ b/tests/ProvidesConcurrencyTest.php
@@ -29,10 +29,9 @@ class ProvidesConcurrencyTest extends TestCase
     {
         $fakeClass = $this->fakeClass();
 
-
         $results = $fakeClass->concurrently([
-            fn() => 1 + 1,
-            fn() => 2 + 2,
+            fn () => 1 + 1,
+            fn () => 2 + 2,
         ]);
 
         $this->assertEquals([2, 4], $results);


### PR DESCRIPTION
Hi, I stumbled upon this in my app. When I accidentally passed an empty tasks array into Octane:concurrently() (using swoole) I got the TaskTimeoutException.

So I decided to fix this by checking if the tasks array is not empty in the ProvidesConcurrencySupport trait.

