### PR TITLE
[2.x] Don't ignore *write error* messages anymore

### DIFF
--- a/src/Commands/Concerns/InteractsWithIO.php
+++ b/src/Commands/Concerns/InteractsWithIO.php
@@ -37,7 +37,6 @@ trait InteractsWithIO
         '[INFO] sdnotify: not notified',
         'exiting; byeee!!',
         'storage cleaning happened too recently',
-        'write error',
         'unable to determine directory for user configuration; falling back to current directory',
         '$HOME environment variable is empty',
         'unable to get instance ID',


### PR DESCRIPTION
According to #778, that removal was intended as a temporary measure until @dunglas fixed the log level issue — which appears to have been addressed [here](https://github.com/php/frankenphp/blob/45823c51b26ed315220025b753efb38d60b020c3/frankenphp.go#L366).

However, since #778 doesn’t explicitly document why the log statements were removed, I’m not confident about the original rationale: @nunomaduro  — as the author of that PR, do you recall whether restoring this is safe now, or if there was a particular reason the logging was cut?