### PR TITLE
fix(concurrency): skip Octane::concurrently when no tasks to prevent …

### DIFF
--- a/src/Concerns/ProvidesConcurrencySupport.php
+++ b/src/Concerns/ProvidesConcurrencySupport.php
@@ -23,6 +23,10 @@ trait ProvidesConcurrencySupport
      */
     public function concurrently(array $tasks, int $waitMilliseconds = 3000)
     {
+        if (empty($tasks)) {
+            return [];
+        }
+
         return $this->tasks()->resolve($tasks, $waitMilliseconds);
     }
 


### PR DESCRIPTION
This patch prevents unnecessary calls to Octane::concurrently() when the $tasks array is empty.

Without this guard, Octane sometimes triggers a misleading
TaskTimeoutException: Task timed out after 30000 milliseconds — even when there are no actual tasks to run.
This happens because Octane initializes the task pool regardless of input size, and an empty collection causes its internal wait cycle to expire.

By returning an empty array early, we:

avoid wasting resources initializing a no-op concurrent pool;

prevent false timeouts and misleading error logs;

improve the reliability of concurrency handling for cases where dynamic task lists may be empty.