### PR TITLE
Update the signature for octane:start

### DIFF
--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -22,9 +22,9 @@ class StartCommand extends Command implements SignalableCommandInterface
                     {--admin-port= : The port the admin server should be available on [FrankenPHP only]}
                     {--rpc-host= : The RPC IP address the server should bind to}
                     {--rpc-port= : The RPC port the server should be available on}
-                    {--workers=auto : The number of workers that should be available to handle requests}
-                    {--task-workers=auto : The number of task workers that should be available to handle tasks}
-                    {--max-requests=500 : The number of requests to process before reloading the server}
+                    {--workers= : The number of workers that should be available to handle requests}
+                    {--task-workers= : The number of task workers that should be available to handle tasks}
+                    {--max-requests= : The number of requests to process before reloading the server}
                     {--rr-config= : The path to the RoadRunner .rr.yaml file}
                     {--caddyfile= : The path to the FrankenPHP Caddyfile file}
                     {--https : Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]}


### PR DESCRIPTION
Remove the default value configuration in the signature. If the command is not specified, use the configuration for reading. If no configuration is set, use the default value.

Close #1072
Close #1064