### PR TITLE
Remove setAccessible calls from reflection properties and methods

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -59,8 +59,6 @@ class ApplicationFactory
             $kernel = $app->make(HttpKernelContract::class)
         ))->getMethod('bootstrappers');
 
-        $method->setAccessible(true);
-
         return $this->injectBootstrapperBefore(
             RegisterProviders::class,
             SetRequestForConsole::class,

--- a/tests/FilesystemManagerStateTest.php
+++ b/tests/FilesystemManagerStateTest.php
@@ -16,7 +16,6 @@ class FilesystemManagerStateTest extends TestCase
         ]);
 
         $filesystemManagerApplication = new ReflectionProperty($app['filesystem'], 'app');
-        $filesystemManagerApplication->setAccessible(true);
 
         $app['router']->get('/first', function (Application $app) use ($filesystemManagerApplication) {
             return spl_object_hash($filesystemManagerApplication->getValue($app['filesystem']));

--- a/tests/Listeners/FlushStrCacheTest.php
+++ b/tests/Listeners/FlushStrCacheTest.php
@@ -28,7 +28,6 @@ class FlushStrCacheTest extends TestCase
 
         $reflection = new ReflectionClass(Str::class);
         $property = $reflection->getProperty('snakeCache');
-        $property->setAccessible(true);
 
         $this->assertEmpty($property->getValue());
 

--- a/tests/OnWorkerStartTest.php
+++ b/tests/OnWorkerStartTest.php
@@ -16,7 +16,6 @@ class OnWorkerStartTest extends TestCase
 
         $reflection = new \ReflectionClass($handler);
         $method = $reflection->getMethod('shouldClearOpcodeCache');
-        $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($handler));
     }
@@ -41,7 +40,6 @@ class OnWorkerStartTest extends TestCase
 
         $reflection = new \ReflectionClass($handler);
         $method = $reflection->getMethod('shouldClearOpcodeCache');
-        $method->setAccessible(true);
 
         $this->assertFalse($method->invoke($handler));
     }


### PR DESCRIPTION
Fix #1082

As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.