### PR TITLE
[2.x] Add GiveNewApplicationInstanceToEventDispatcher listener

### DIFF
--- a/src/Concerns/ProvidesDefaultConfigurationOptions.php
+++ b/src/Concerns/ProvidesDefaultConfigurationOptions.php
@@ -42,6 +42,7 @@ trait ProvidesDefaultConfigurationOptions
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToCacheManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToSessionManager::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToQueueManager::class,
+            \Laravel\Octane\Listeners\GiveNewApplicationInstanceToEventDispatcher::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToRouter::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToValidationFactory::class,
             \Laravel\Octane\Listeners\GiveNewApplicationInstanceToViewFactory::class,

--- a/src/Listeners/GiveNewApplicationInstanceToEventDispatcher.php
+++ b/src/Listeners/GiveNewApplicationInstanceToEventDispatcher.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class GiveNewApplicationInstanceToEventDispatcher
+{
+    /**
+     * Handle the event.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        if (! $event->sandbox->resolved('events')) {
+            return;
+        }
+
+        with($event->sandbox->make('events'), function ($dispatcher) use ($event) {
+            $dispatcher->setQueueResolver(fn () => $event->sandbox->make('queue'));
+        });
+    }
+}

--- a/tests/EventDispatcherStateTest.php
+++ b/tests/EventDispatcherStateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+class EventDispatcherStateTest extends TestCase
+{
+    public function test_event_dispatcher_resolves_queue_using_sandbox()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+        ]);
+
+        $app['events'];
+        $app['queue'];
+
+        $app['router']->get('/first', function (Application $app) {
+            $queueResolver = (fn () => $this->queueResolver)->call($app['events']);
+
+            return spl_object_hash($queueResolver()->getApplication());
+        });
+
+        $worker->run();
+
+        $this->assertNotEquals($client->responses[0]->original, $client->responses[1]->original);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a `GiveNewApplicationInstanceToEventDispatcher` listener that updates the EventDispatcher's queue resolver to use the sandbox application instance.

## Problem

The EventDispatcher's `queueResolver` closure is set during boot in Laravel's `EventServiceProvider` and captures the original application instance. When Octane creates a sandbox for each request and queue configuration is modified during that request, queued event listeners still dispatch to the original app's queue manager, ignoring the sandbox's configuration changes.

## Solution

Following the established pattern of `GiveNewApplicationInstanceToQueueManager` and other similar listeners, this PR adds a listener that updates the EventDispatcher's queue resolver to use the sandbox's queue manager for each request.

## Benefit to End Users

Applications that modify queue configuration during a request (e.g., dynamically switching queue connections based on tenant or request context) will now have their queued event listeners respect those configuration changes when running under Octane.

## Why This Doesn't Break Existing Features

- The listener follows the exact same pattern as existing listeners (`GiveNewApplicationInstanceToQueueManager`, `GiveNewApplicationInstanceToMailManager`, etc.)
- It only executes if the `events` service has been resolved
- It simply updates the queue resolver callable, which is the same operation Laravel performs during boot
- The listener is registered after `GiveNewApplicationInstanceToQueueManager` to ensure the queue manager is ready

## Files Changed

- `src/Listeners/GiveNewApplicationInstanceToEventDispatcher.php` - New listener
- `src/Concerns/ProvidesDefaultConfigurationOptions.php` - Register the listener
- `tests/EventDispatcherStateTest.php` - Test verifying the queue resolver uses the sandbox