### PR TITLE
Allow to use more environment variables to FrankenPHP/Caddyfile #895

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -221,17 +221,4 @@ return [
 
     'max_execution_time' => 30,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Extra Environment Vairables
-    |--------------------------------------------------------------------------
-    |
-    | Extra environment variables passed to Caddyfile.
-    |
-    */
-
-    'extra_envs' => [
-        // 'SOME_CONFIG_VALUE' => env('SOME_CONFIG_VALUE'),
-    ],
-
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -221,4 +221,17 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Extra Environment Vairables
+    |--------------------------------------------------------------------------
+    |
+    | Extra environment variables passed to Caddyfile.
+    |
+    */
+
+    'extra_envs' => [
+        // 'SOME_CONFIG_VALUE' => env('SOME_CONFIG_VALUE'),
+    ],
+
 ];

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -106,6 +106,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'CADDY_SERVER_WORKER_DIRECTIVE' => $this->workerCount() ? "num {$this->workerCount()}" : '',
             'CADDY_SERVER_EXTRA_DIRECTIVES' => $this->buildMercureConfig(),
             'CADDY_SERVER_WATCH_DIRECTIVES' => $this->buildWatchConfig(),
+            ...config('octane.extra_envs', []),
         ]));
 
         $server = $process->start();

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -106,7 +106,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             'CADDY_SERVER_WORKER_DIRECTIVE' => $this->workerCount() ? "num {$this->workerCount()}" : '',
             'CADDY_SERVER_EXTRA_DIRECTIVES' => $this->buildMercureConfig(),
             'CADDY_SERVER_WATCH_DIRECTIVES' => $this->buildWatchConfig(),
-            ...config('octane.extra_envs', []),
+            ...config('octane.caddy.env', []),
         ]));
 
         $server = $process->start();


### PR DESCRIPTION
This PR resolves the issue #895
As @dunglas and @driesvints asked for PR, here is mine.

This allows to define extra environment variables that can be used in Caddyfile.