### PR TITLE
Format Caddyfile stub

### DIFF
--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -5,14 +5,14 @@
 
 	frankenphp {
 		worker {
-			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php"
-			{$CADDY_SERVER_WORKER_DIRECTIVE}
+			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php" 
+			{$CADDY_SERVER_WORKER_DIRECTIVE} 
 			{$CADDY_SERVER_WATCH_DIRECTIVES}
 		}
 	}
 }
 
-{$CADDY_EXTRA_CONFIG}
+{$CADDY_EXTRA_CONFIG} 
 
 {$CADDY_SERVER_SERVER_NAME} {
 	log {


### PR DESCRIPTION
The Caddyfile stub doesn't match `caddy fmt` output, causing Caddy to emit a warning on every Octane startup:

```
WARN	Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies
```

This formats the stub with `frankenphp fmt` to silence the warning.