### PR TITLE
fix: FrankenPHP fallback to chokidar on poll

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,10 +56,10 @@ try {
                 report($e);
             }
 
-            $hasDebugModeEnabled = app()->has('config') && app()->hasDebugModeEnabled();
+            $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
-                $hasDebugModeEnabled ? (string)$e : 'Internal Server Error',
+                $debugMode === 'true' ? (string)$e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -59,7 +59,7 @@ try {
             $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
-                $debugMode === 'true' ? (string)$e : 'Internal Server Error',
+                $debugMode === 'true' ? (string) $e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,8 +56,10 @@ try {
                 report($e);
             }
 
+            $hasDebugModeEnabled = app()->has('config') && app()->hasDebugModeEnabled();
+
             $response = new Response(
-                'Internal Server Error',
+                $hasDebugModeEnabled ? (string)$e : 'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,7 +56,6 @@ try {
                 report($e);
             }
 
-
             $response = new Response(
                 'Internal Server Error',
                 500,

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -56,10 +56,9 @@ try {
                 report($e);
             }
 
-            $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 
             $response = new Response(
-                $debugMode === 'true' ? (string) $e : 'Internal Server Error',
+                'Internal Server Error',
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -17,6 +17,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
         Concerns\InteractsWithEnvironmentVariables,
         Concerns\InteractsWithServers {
             Concerns\InteractsWithServers::writeServerRunningMessage as baseWriteServerRunningMessage;
+            Concerns\InteractsWithServers::startServerWatcher as baseStartServerWatcher;
         }
 
     /**
@@ -192,12 +193,17 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
     }
 
     /**
-     * Always return a no-op object, because FrankenPHP has native watcher support.
+     * Use the regular watcher when --poll is passed (e.g. for network file systems).
+     * Otherwise use FrankenPHP's built-in watcher.
      *
-     * @return object
+     * @return \Symfony\Component\Process\Process|object
      */
     protected function startServerWatcher()
     {
+        if ($this->option('poll') && $this->option('watch')) {
+            return $this->baseStartServerWatcher();
+        }
+
         return new class
         {
             public function __call($method, $parameters)
@@ -209,12 +215,13 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
 
     /**
      * Generate the file watcher configuration snippet to include in the Caddyfile.
+     * When --poll is passed, the regular watcher is used instead, so no Caddy config.
      *
      * @return string
      */
     protected function buildWatchConfig()
     {
-        if (! $this->option('watch')) {
+        if (! $this->option('watch') || $this->option('poll')) {
             return '';
         }
 


### PR DESCRIPTION
Fixes #1034

FrankenPHP's built in watcher does not support polling. If --poll is passed, the watcher should fallback to chokidar. This fixes setups where the repo might be in a mount like the windows mount on wsl.

@IranMine123 can you try if this branch makes `--watch --poll` work for you on WSL?
