### PR TITLE
Fix Swoole auto worker count in containers

### DIFF
--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -41,6 +41,12 @@ class SwooleExtension
      */
     public function cpuCount(): int
     {
+        $cgroupCpuCount = $this->containerCpuCount();
+
+        if ($cgroupCpuCount !== null) {
+            return $cgroupCpuCount;
+        }
+
         if (function_exists('swoole_cpu_num')) {
             return swoole_cpu_num();
         }
@@ -50,5 +56,44 @@ class SwooleExtension
         }
 
         return 1;
+    }
+
+    /**
+     * Get the CPU count from the container's cgroup CPU quota, if available.
+     */
+    protected function containerCpuCount(): ?int
+    {
+        // cgroups v2
+        if (is_readable('/sys/fs/cgroup/cpu.max')) {
+            $cpuMax = @file_get_contents('/sys/fs/cgroup/cpu.max');
+
+            if ($cpuMax !== false) {
+                [$quota, $period] = explode(' ', trim($cpuMax));
+
+                if ($quota !== 'max') {
+                    return (int) max(1, ceil((int) $quota / (int) $period));
+                }
+            }
+        }
+
+        // cgroups v1
+        $quotaFile = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us';
+        $periodFile = '/sys/fs/cgroup/cpu/cpu.cfs_period_us';
+
+        if (is_readable($quotaFile) && is_readable($periodFile)) {
+            $quota = @file_get_contents($quotaFile);
+            $period = @file_get_contents($periodFile);
+
+            if ($quota !== false && $period !== false) {
+                $quota = (int) trim($quota);
+                $period = (int) trim($period);
+
+                if ($quota > 0 && $period > 0) {
+                    return (int) max(1, ceil($quota / $period));
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -63,7 +63,7 @@ class SwooleExtension
      */
     protected function containerCpuCount(): ?int
     {
-        // cgroups v2
+        // cgroups v2...
         if (is_readable('/sys/fs/cgroup/cpu.max')) {
             $cpuMax = @file_get_contents('/sys/fs/cgroup/cpu.max');
 
@@ -76,7 +76,7 @@ class SwooleExtension
             }
         }
 
-        // cgroups v1
+        // cgroups v1...
         $quotaFile = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us';
         $periodFile = '/sys/fs/cgroup/cpu/cpu.cfs_period_us';
 

--- a/src/Swoole/SwooleExtension.php
+++ b/src/Swoole/SwooleExtension.php
@@ -2,10 +2,22 @@
 
 namespace Laravel\Octane\Swoole;
 
+use Closure;
 use Swoole\Process;
 
 class SwooleExtension
 {
+    /**
+     * Create a new Swoole extension helper.
+     */
+    public function __construct(
+        protected ?Closure $isReadable = null,
+        protected ?Closure $fileGetContents = null,
+    ) {
+        $this->isReadable ??= static fn (string $path): bool => is_readable($path);
+        $this->fileGetContents ??= static fn (string $path): string|false => @file_get_contents($path);
+    }
+
     /**
      * Determine if the Swoole extension is installed.
      */
@@ -64,14 +76,16 @@ class SwooleExtension
     protected function containerCpuCount(): ?int
     {
         // cgroups v2...
-        if (is_readable('/sys/fs/cgroup/cpu.max')) {
-            $cpuMax = @file_get_contents('/sys/fs/cgroup/cpu.max');
+        if (($this->isReadable)('/sys/fs/cgroup/cpu.max')) {
+            $cpuMax = ($this->fileGetContents)('/sys/fs/cgroup/cpu.max');
 
             if ($cpuMax !== false) {
-                [$quota, $period] = explode(' ', trim($cpuMax));
+                $parts = preg_split('/\s+/', trim($cpuMax));
+                $quota = $parts[0] ?? null;
+                $period = isset($parts[1]) ? (int) $parts[1] : 0;
 
-                if ($quota !== 'max') {
-                    return (int) max(1, ceil((int) $quota / (int) $period));
+                if ($quota !== 'max' && $period > 0) {
+                    return (int) max(1, ceil((int) $quota / $period));
                 }
             }
         }
@@ -80,9 +94,9 @@ class SwooleExtension
         $quotaFile = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us';
         $periodFile = '/sys/fs/cgroup/cpu/cpu.cfs_period_us';
 
-        if (is_readable($quotaFile) && is_readable($periodFile)) {
-            $quota = @file_get_contents($quotaFile);
-            $period = @file_get_contents($periodFile);
+        if (($this->isReadable)($quotaFile) && ($this->isReadable)($periodFile)) {
+            $quota = ($this->fileGetContents)($quotaFile);
+            $period = ($this->fileGetContents)($periodFile);
 
             if ($quota !== false && $period !== false) {
                 $quota = (int) trim($quota);

--- a/tests/SwooleExtensionTest.php
+++ b/tests/SwooleExtensionTest.php
@@ -14,4 +14,38 @@ class SwooleExtensionTest extends TestCase
 
         $this->assertTrue($cpuCount > 0);
     }
+
+    public function test_container_cpu_count_returns_null_when_not_in_container()
+    {
+        $extension = new SwooleExtension();
+
+        $method = new \ReflectionMethod($extension, 'containerCpuCount');
+
+        // On non-container environments, either returns null or a valid count
+        $result = $method->invoke($extension);
+
+        $this->assertTrue($result === null || $result >= 1);
+    }
+
+    public function test_cpu_count_respects_cgroup_v2_limit()
+    {
+        $extension = $this->getMockBuilder(SwooleExtension::class)
+            ->onlyMethods(['containerCpuCount'])
+            ->getMock();
+
+        $extension->method('containerCpuCount')->willReturn(2);
+
+        $this->assertSame(2, $extension->cpuCount());
+    }
+
+    public function test_cpu_count_falls_back_when_no_cgroup_limit()
+    {
+        $extension = $this->getMockBuilder(SwooleExtension::class)
+            ->onlyMethods(['containerCpuCount'])
+            ->getMock();
+
+        $extension->method('containerCpuCount')->willReturn(null);
+
+        $this->assertTrue($extension->cpuCount() >= 1);
+    }
 }

--- a/tests/SwooleExtensionTest.php
+++ b/tests/SwooleExtensionTest.php
@@ -15,16 +15,41 @@ class SwooleExtensionTest extends TestCase
         $this->assertTrue($cpuCount > 0);
     }
 
-    public function test_container_cpu_count_returns_null_when_not_in_container()
+    public function test_container_cpu_count_reads_cgroup_v2_quota()
     {
-        $extension = new SwooleExtension();
+        $extension = $this->fakeExtensionWithFiles([
+            '/sys/fs/cgroup/cpu.max' => '200000 100000',
+        ]);
 
-        $method = new \ReflectionMethod($extension, 'containerCpuCount');
+        $this->assertSame(2, $extension->readContainerCpuCount());
+    }
 
-        // On non-container environments, either returns null or a valid count
-        $result = $method->invoke($extension);
+    public function test_container_cpu_count_reads_cgroup_v1_quota()
+    {
+        $extension = $this->fakeExtensionWithFiles([
+            '/sys/fs/cgroup/cpu/cpu.cfs_quota_us' => '250000',
+            '/sys/fs/cgroup/cpu/cpu.cfs_period_us' => '100000',
+        ]);
 
-        $this->assertTrue($result === null || $result >= 1);
+        $this->assertSame(3, $extension->readContainerCpuCount());
+    }
+
+    public function test_container_cpu_count_returns_null_when_unlimited_or_missing()
+    {
+        $extension = $this->fakeExtensionWithFiles([
+            '/sys/fs/cgroup/cpu.max' => 'max 100000',
+        ]);
+
+        $this->assertNull($extension->readContainerCpuCount());
+    }
+
+    public function test_container_cpu_count_ignores_invalid_v2_data()
+    {
+        $extension = $this->fakeExtensionWithFiles([
+            '/sys/fs/cgroup/cpu.max' => '200000',
+        ]);
+
+        $this->assertNull($extension->readContainerCpuCount());
     }
 
     public function test_cpu_count_respects_cgroup_v2_limit()
@@ -47,5 +72,24 @@ class SwooleExtensionTest extends TestCase
         $extension->method('containerCpuCount')->willReturn(null);
 
         $this->assertTrue($extension->cpuCount() >= 1);
+    }
+
+    protected function fakeExtensionWithFiles(array $files): object
+    {
+        return new class($files) extends SwooleExtension
+        {
+            public function __construct(private array $files)
+            {
+                parent::__construct(
+                    isReadable: fn (string $path): bool => array_key_exists($path, $this->files),
+                    fileGetContents: fn (string $path): string|false => $this->files[$path] ?? false,
+                );
+            }
+
+            public function readContainerCpuCount(): ?int
+            {
+                return $this->containerCpuCount();
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- When running in containers (Kubernetes, Docker), `swoole_cpu_num()` reports the host node's CPU count instead of the container's cgroup CPU limit
- This causes `--workers=auto` and `--task-workers=auto` to spawn far more processes than the container can handle, leading to OOMKills
- The fix reads the container's cgroup CPU quota (v2 and v1) before falling back to `swoole_cpu_num()`

## Example
A pod with 1 CPU limit on a 96-core node:
- **Before:** 96 workers + 96 task workers (OOMKilled)
- **After:** 1 worker + 1 task worker

## Test plan
- [x] Existing `SwooleExtensionTest::test_cpu_count` still passes
- [x] Added tests for container CPU detection and fallback behavior
- [x] Verified cgroup v2 values on a real Kubernetes pod (`cpu.max: 100000 100000` → 1 CPU)
- [x] Full test suite passes (174 tests)