### PR TITLE
[2.x] Remove conflict requirement for phpunit/phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "bin/swoole-server"
     ],
     "conflict": {
-        "phpunit/phpunit": ">12.0.0",
         "spiral/roadrunner": "<2023.1.0",
         "spiral/roadrunner-cli": "<2.6.0",
         "spiral/roadrunner-http": "<3.3.0"


### PR DESCRIPTION
Address the comments in #1093 and removes the PHPUnit conflict rule, which directly conflicts with the Laravel Skeleton, meaning Octane doesn't truly support L13 without first requiring a downgrade in PHPUnit version (which seems iffy)

I don't **_actually_** know why this was added, there's no mention of it in the original PR.