### PR TITLE
Guard POSIX signal constants for Windows compatibility (fixes laravel/octane#1100)

### DIFF
--- a/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
+++ b/src/Commands/Concerns/InstallsRoadRunnerDependencies.php
@@ -69,7 +69,7 @@ trait InstallsRoadRunnerDependencies
                 $this->output->write($line);
             });
         } catch (ProcessSignaledException $e) {
-            if (extension_loaded('pcntl') && $e->getSignal() !== SIGINT) {
+            if (extension_loaded('pcntl') && $e->getSignal() !== (defined('SIGINT') ? SIGINT : 2)) {
                 throw $e;
             }
         }

--- a/src/Commands/Concerns/InteractsWithServers.php
+++ b/src/Commands/Concerns/InteractsWithServers.php
@@ -171,7 +171,11 @@ trait InteractsWithServers
      */
     public function getSubscribedSignals(): array
     {
-        return [SIGINT, SIGTERM, SIGHUP];
+        return array_filter([
+            defined('SIGINT') ? SIGINT : null,
+            defined('SIGTERM') ? SIGTERM : null,
+            defined('SIGHUP') ? SIGHUP : null,
+        ]);
     }
 
     /**

--- a/src/RoadRunner/ServerProcessInspector.php
+++ b/src/RoadRunner/ServerProcessInspector.php
@@ -68,6 +68,6 @@ class ServerProcessInspector implements ServerProcessInspectorContract
             'masterProcessId' => $masterProcessId,
         ] = $this->serverStateFile->read();
 
-        return (bool) $this->posix->kill($masterProcessId, SIGTERM);
+        return (bool) $this->posix->kill($masterProcessId, defined('SIGTERM') ? SIGTERM : 15);
     }
 }

--- a/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
+++ b/src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php
@@ -42,7 +42,7 @@ class EnsureRequestsDontExceedMaxExecutionTime
                 continue;
             }
 
-            $this->extension->dispatchProcessSignal($row['worker_pid'], SIGKILL);
+            $this->extension->dispatchProcessSignal($row['worker_pid'], defined('SIGKILL') ? SIGKILL : 9);
 
             if ($this->server instanceof Server) {
                 $response = Response::create($this->server, $row['fd']);

--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -38,7 +38,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
             'masterProcessId' => $masterProcessId,
         ] = $this->serverStateFile->read();
 
-        $this->dispatcher->signal((int) $masterProcessId, SIGUSR1);
+        $this->dispatcher->signal((int) $masterProcessId, defined('SIGUSR1') ? SIGUSR1 : 10);
     }
 
     /**
@@ -54,7 +54,7 @@ class ServerProcessInspector implements ServerProcessInspectorContract
         $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
 
         foreach ([$masterProcessId, $managerProcessId, ...$workerProcessIds] as $processId) {
-            $this->dispatcher->signal((int) $processId, SIGKILL);
+            $this->dispatcher->signal((int) $processId, defined('SIGKILL') ? SIGKILL : 9);
         }
 
         return true;

--- a/src/Swoole/SignalDispatcher.php
+++ b/src/Swoole/SignalDispatcher.php
@@ -21,7 +21,9 @@ class SignalDispatcher
      */
     public function terminate(int $processId, int $wait = 0): bool
     {
-        $this->extension->dispatchProcessSignal($processId, SIGTERM);
+        $sigterm = defined('SIGTERM') ? SIGTERM : 15;
+
+        $this->extension->dispatchProcessSignal($processId, $sigterm);
 
         if ($wait) {
             $start = time();
@@ -31,7 +33,7 @@ class SignalDispatcher
                     return true;
                 }
 
-                $this->extension->dispatchProcessSignal($processId, SIGTERM);
+                $this->extension->dispatchProcessSignal($processId, $sigterm);
 
                 sleep(1);
             } while (time() < $start + $wait);

--- a/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
+++ b/tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php
@@ -25,7 +25,7 @@ class EnsureRequestsDontExceedMaxExecutionTimeTest extends TestCase
             30,
         );
 
-        $extension->shouldReceive('dispatchProcessSignal')->once()->with(111, SIGKILL);
+        $extension->shouldReceive('dispatchProcessSignal')->once()->with(111, defined('SIGKILL') ? SIGKILL : 9);
 
         $action();
     }

--- a/tests/SwooleServerProcessInspectorTest.php
+++ b/tests/SwooleServerProcessInspectorTest.php
@@ -92,7 +92,7 @@ class SwooleServerProcessInspectorTest extends TestCase
         collect([2, 3, 4, 5])->each(
             fn ($processId) => $dispatcher
                 ->shouldReceive('signal')
-                ->with($processId, SIGKILL)
+                ->with($processId, defined('SIGKILL') ? SIGKILL : 9)
                 ->once(),
         );
 


### PR DESCRIPTION
## Summary

Fixes laravel/octane#1100 — Cannot start Laravel Octane (FrankenPHP) on Windows due to `Undefined constant "SIGINT"`. POSIX signal constants are not defined on Windows PHP.

## Steps to Reproduce

1. Install Laravel Octane with FrankenPHP on Windows (FrankenPHP v1.12.0+ supports Windows natively)
2. Run `php artisan octane:start`
3. Fatal error:
   ```
   Undefined constant "Laravel\Octane\Commands\Concerns\SIGINT"
   at vendor/laravel/octane/src/Commands/Concerns/InteractsWithServers.php:174
   ```

## Before (Bug)

POSIX signal constants (`SIGINT`, `SIGTERM`, `SIGHUP`, `SIGKILL`, `SIGUSR1`) are not defined on Windows PHP. Any file referencing these constants causes a fatal error, making Octane completely unusable on Windows despite FrankenPHP adding native Windows support.

## After (Fix)

All signal constant references are guarded with `defined()` checks and standard POSIX numeric fallbacks. On Windows, `getSubscribedSignals()` returns an empty array (safe no-op). On Linux/macOS, the original constants are used — zero behavior change.

## Root Cause

POSIX signals are a Unix concept. Windows PHP does not define `SIGINT`, `SIGTERM`, `SIGHUP`, `SIGKILL`, or `SIGUSR1`. Octane references these constants unconditionally across 7 files.

## The Fix

Added `defined()` checks with standard POSIX numeric fallbacks across 7 files:

| File | Signal(s) | Fix |
|------|-----------|-----|
| `src/Commands/Concerns/InteractsWithServers.php` | SIGINT, SIGTERM, SIGHUP | Returns `[]` on Windows |
| `src/Commands/Concerns/InstallsRoadRunnerDependencies.php` | SIGINT | `defined('SIGINT') ? SIGINT : 2` |
| `src/RoadRunner/ServerProcessInspector.php` | SIGTERM | `defined('SIGTERM') ? SIGTERM : 15` |
| `src/Swoole/ServerProcessInspector.php` | SIGUSR1, SIGKILL | Fallbacks to 10 and 9 |
| `src/Swoole/SignalDispatcher.php` | SIGTERM | Fallback to 15 |
| `src/Swoole/Actions/EnsureRequestsDontExceedMaxExecutionTime.php` | SIGKILL | Fallback to 9 |
| `tests/EnsureRequestsDontExceedMaxExecutionTimeTest.php` | SIGKILL | Matching test update |

## Breaking Changes

None. On Linux/macOS, constants are defined so original values are used — zero behavior change.

## Files Changed

- 7 files updated with `defined()` guards and numeric fallbacks

## Test Results

| Platform | Result |
|----------|--------|
| Windows (PHP 8.4) | All constant references resolve without error, `getSubscribedSignals()` returns `[]` safely |
| Linux/WSL (PHP 8.3) | 177 tests — identical results to upstream (no regressions) |
| Modified test file | Passes (1 test, 1 assertion) |