### PR TITLE
Propagate #[Singleton] attribute bindings back to root app (fixes laravel/octane#1077)

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -19,6 +19,7 @@ use Laravel\Octane\Listeners\EnsureUploadedFilesCanBeMoved;
 use Laravel\Octane\Listeners\FlushOnce;
 use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
 use Laravel\Octane\Listeners\FlushUploadedFiles;
+use Laravel\Octane\Listeners\PropagateAttributeSingletons;
 use Laravel\Octane\Listeners\ReportException;
 use Laravel\Octane\Listeners\StopWorkerIfNecessary;
 use Laravel\Octane\Octane;
@@ -103,6 +104,7 @@ return [
         ],
 
         OperationTerminated::class => [
+            PropagateAttributeSingletons::class,
             FlushOnce::class,
             FlushTemporaryContainerInstances::class,
             // DisconnectFromDatabases::class,

--- a/src/Listeners/PropagateAttributeSingletons.php
+++ b/src/Listeners/PropagateAttributeSingletons.php
@@ -26,6 +26,13 @@ class PropagateAttributeSingletons
         $sandbox = $event->sandbox;
         $app = $event->app;
 
+        // The checkedForSingletonOrScopedAttributes property was introduced in
+        // Laravel 11 alongside the #[Singleton] attribute. On older versions
+        // there is nothing to propagate, so bail out early.
+        if (! property_exists($sandbox, 'checkedForSingletonOrScopedAttributes')) {
+            return;
+        }
+
         // Access the protected attribute cache from the sandbox via reflection.
         $checkedAttributes = $this->getProtectedProperty($sandbox, 'checkedForSingletonOrScopedAttributes');
 

--- a/src/Listeners/PropagateAttributeSingletons.php
+++ b/src/Listeners/PropagateAttributeSingletons.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Laravel\Octane\Listeners;
+
+class PropagateAttributeSingletons
+{
+    /**
+     * Handle the event.
+     *
+     * When classes decorated with the #[Singleton] attribute are resolved for
+     * the first time inside the request sandbox, the container lazily registers
+     * them as shared bindings and stores their instances – but only on the
+     * sandbox clone. Because the root application never receives these bindings,
+     * every subsequent request clone starts fresh, effectively treating the
+     * singleton as a scoped binding.
+     *
+     * This listener runs after each operation (request/task/tick) and copies any
+     * attribute-detected singleton bindings AND their resolved instances from
+     * the sandbox back to the root application, so that future clones inherit
+     * them and behave identically to singletons registered via a service provider.
+     *
+     * @param  mixed  $event
+     */
+    public function handle($event): void
+    {
+        $sandbox = $event->sandbox;
+        $app = $event->app;
+
+        // Access the protected attribute cache from the sandbox via reflection.
+        $checkedAttributes = $this->getProtectedProperty($sandbox, 'checkedForSingletonOrScopedAttributes');
+
+        if (empty($checkedAttributes)) {
+            return;
+        }
+
+        // For each class that was detected as a singleton via the attribute,
+        // register the binding and instance on the root app if not already present.
+        foreach ($checkedAttributes as $className => $type) {
+            if ($type !== 'singleton') {
+                continue;
+            }
+
+            // Skip if the root app already has this as a shared binding or instance.
+            if (isset($app[$className]) && $app->isShared($className)) {
+                continue;
+            }
+
+            // Register as singleton on root app.
+            if (! $app->bound($className)) {
+                $app->singleton($className);
+            }
+
+            // If the sandbox resolved an instance, copy it to the root app
+            // so clones won't need to rebuild it.
+            if ($sandbox->resolved($className)) {
+                $instances = $this->getProtectedProperty($sandbox, 'instances');
+
+                if (array_key_exists($className, $instances)) {
+                    $app->instance($className, $instances[$className]);
+                }
+            }
+        }
+
+        // Also propagate the attribute cache itself so the root app skips
+        // reflection on future clones.
+        $rootChecked = $this->getProtectedProperty($app, 'checkedForSingletonOrScopedAttributes');
+        $merged = array_merge($rootChecked, $checkedAttributes);
+        $this->setProtectedProperty($app, 'checkedForSingletonOrScopedAttributes', $merged);
+    }
+
+    /**
+     * Get a protected property from an object via reflection.
+     *
+     * @param  object  $object
+     * @param  string  $property
+     * @return mixed
+     */
+    protected function getProtectedProperty(object $object, string $property): mixed
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+
+        return $reflection->getValue($object);
+    }
+
+    /**
+     * Set a protected property on an object via reflection.
+     *
+     * @param  object  $object
+     * @param  string  $property
+     * @param  mixed  $value
+     */
+    protected function setProtectedProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+
+        $reflection->setValue($object, $value);
+    }
+}

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -150,6 +150,7 @@ class OctaneServiceProvider extends ServiceProvider
         $this->app->singleton(Listeners\PrepareLivewireForNextOperation::class);
         $this->app->singleton(Listeners\PrepareScoutForNextOperation::class);
         $this->app->singleton(Listeners\PrepareSocialiteForNextOperation::class);
+        $this->app->singleton(Listeners\PropagateAttributeSingletons::class);
         $this->app->singleton(Listeners\ReportException::class);
         $this->app->singleton(Listeners\StopWorkerIfNecessary::class);
     }

--- a/tests/AttributeSingletonPropagationTest.php
+++ b/tests/AttributeSingletonPropagationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Container\Attributes\Singleton;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+class AttributeSingletonPropagationTest extends TestCase
+{
+    public function test_singleton_attribute_classes_persist_across_requests()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+        ]);
+
+        $app['router']->get('/first', function (Application $app) {
+            $instance = $app->make(AttributeSingletonService::class);
+
+            return spl_object_hash($instance);
+        });
+
+        $worker->run();
+
+        // All three requests should receive the same singleton instance
+        // because the PropagateAttributeSingletons listener copies the
+        // binding and instance back to the root application.
+        $this->assertEquals(
+            $client->responses[0]->original,
+            $client->responses[1]->original,
+        );
+
+        $this->assertEquals(
+            $client->responses[1]->original,
+            $client->responses[2]->original,
+        );
+    }
+
+    public function test_singleton_attribute_constructor_only_called_once()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+        ]);
+
+        // Reset static counter.
+        AttributeSingletonWithCounter::$constructCount = 0;
+
+        $app['router']->get('/first', function (Application $app) {
+            $app->make(AttributeSingletonWithCounter::class);
+
+            return AttributeSingletonWithCounter::$constructCount;
+        });
+
+        $worker->run();
+
+        // First request: constructor called once.
+        $this->assertEquals(1, $client->responses[0]->original);
+        // Second request: still only called once (same instance reused).
+        $this->assertEquals(1, $client->responses[1]->original);
+    }
+
+    public function test_multiple_resolves_in_same_request_return_same_instance()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+        ]);
+
+        $app['router']->get('/first', function (Application $app) {
+            $a = $app->make(AttributeSingletonService::class);
+            $b = $app->make(AttributeSingletonService::class);
+            $c = $app->make(AttributeSingletonService::class);
+
+            return [
+                spl_object_hash($a),
+                spl_object_hash($b),
+                spl_object_hash($c),
+            ];
+        });
+
+        $worker->run();
+
+        $hashes = $client->responses[0]->original;
+        $this->assertEquals($hashes[0], $hashes[1]);
+        $this->assertEquals($hashes[1], $hashes[2]);
+    }
+}
+
+#[Singleton]
+class AttributeSingletonService
+{
+    //
+}
+
+#[Singleton]
+class AttributeSingletonWithCounter
+{
+    public static int $constructCount = 0;
+
+    public function __construct()
+    {
+        static::$constructCount++;
+    }
+}

--- a/tests/AttributeSingletonPropagationTest.php
+++ b/tests/AttributeSingletonPropagationTest.php
@@ -8,6 +8,16 @@ use Illuminate\Http\Request;
 
 class AttributeSingletonPropagationTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The #[Singleton] attribute was introduced in Laravel 11.
+        if (! class_exists(\Illuminate\Container\Attributes\Singleton::class)) {
+            $this->markTestSkipped('Requires Laravel 11+ for #[Singleton] attribute support.');
+        }
+    }
+
     public function test_singleton_attribute_classes_persist_across_requests()
     {
         [$app, $worker, $client] = $this->createOctaneContext([

--- a/tests/AttributeSingletonPropagationTest.php
+++ b/tests/AttributeSingletonPropagationTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Tests;
 
+use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
@@ -96,6 +97,42 @@ class AttributeSingletonPropagationTest extends TestCase
         $this->assertEquals($hashes[0], $hashes[1]);
         $this->assertEquals($hashes[1], $hashes[2]);
     }
+
+    public function test_scoped_attribute_classes_are_not_propagated_to_root_app()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+            Request::create('/first', 'GET'),
+        ]);
+
+        $app['router']->get('/first', function (Application $app) {
+            $instance = $app->make(AttributeScopedService::class);
+
+            return spl_object_hash($instance);
+        });
+
+        $worker->run();
+
+        // Each request should get a fresh scoped instance because the
+        // PropagateAttributeSingletons listener intentionally skips
+        // classes with the #[Scoped] attribute.
+        $this->assertNotEquals(
+            $client->responses[0]->original,
+            $client->responses[1]->original,
+        );
+
+        $this->assertNotEquals(
+            $client->responses[1]->original,
+            $client->responses[2]->original,
+        );
+    }
+}
+
+#[Scoped]
+class AttributeScopedService
+{
+    //
 }
 
 #[Singleton]


### PR DESCRIPTION
## Summary

Fixes laravel/octane#1077 -- Classes decorated with PHP's `#[Singleton]` attribute are re-instantiated on every request in Octane, defeating the purpose of the singleton pattern. The attribute works correctly in standard Laravel but fails in Octane's sandbox architecture.

## Root Cause

**The bug exists because** Octane clones the application container for each request (the "sandbox"). When a `#[Singleton]` class is first resolved during a request, the container lazily detects the attribute and registers a shared binding -- but only on the sandbox clone. When the request ends, the sandbox is discarded. The root application never receives the singleton binding or instance, so the next request's fresh sandbox clone starts over, resolving and constructing the class again. Effectively, `#[Singleton]` behaves as a scoped binding in Octane.

## Why This Fix Works

**This fix works because** it introduces a `PropagateAttributeSingletons` listener that runs after each request (on the `OperationTerminated` event). The listener inspects the sandbox's internal `checkedForSingletonOrScopedAttributes` cache to find any classes that were detected as singletons during the request. For each one, it copies three things back to the root application: (1) the singleton binding registration, (2) the resolved instance, and (3) the attribute cache entry. Future sandbox clones inherit these from the root app, so the singleton is resolved once and reused across all subsequent requests -- matching the behavior of singletons registered in service providers.

## Alternatives Considered

**We chose this approach over** pre-scanning all classes at boot time because: (1) the attribute detection is intentionally lazy in Laravel -- forcing eager scanning would slow boot time; (2) modifying the container's clone behavior would risk breaking scoped bindings (`#[Scoped]`) that intentionally should NOT persist across requests; (3) the listener approach is non-invasive, only affects classes actually resolved during requests, and correctly distinguishes between `singleton` and `scoped` attribute types via the cache metadata.

## Files Changed

- `src/Listeners/PropagateAttributeSingletons.php` -- New listener that copies attribute singleton bindings and instances from sandbox to root app
- `config/octane.php` -- Registers the listener on `OperationTerminated`
- `src/OctaneServiceProvider.php` -- Registers the listener as a singleton
- `tests/AttributeSingletonPropagationTest.php` -- 2 tests verifying instance persistence and single construction across requests