### PR TITLE
Fix null worker crash in Swoole during code reload

### DIFF
--- a/bin/swoole-server
+++ b/bin/swoole-server
@@ -109,6 +109,13 @@ $server->on('workerstart', fn (Server $server, $workerId) =>
 */
 
 $server->on('request', function ($request, $response) use ($server, $workerState, $serverState) {
+    if (! $workerState->worker || ! $workerState->client) {
+        $response->status(503);
+        $response->end('Service Unavailable');
+
+        return;
+    }
+
     $workerState->lastRequestTime = microtime(true);
 
     if ($workerState->timerTable) {


### PR DESCRIPTION
## Summary

Fixes a crash in Swoole's request handler where `$workerState->worker` or `$workerState->client` is null during file watcher reloads, causing a fatal "Call to a member function handle() on null" error.

Fixes laravel/octane#1053

## Problem

When Swoole's file watcher triggers a reload, there is a brief window where the worker state is being re-initialized. Requests arriving during this window hit a null `$workerState->worker`, causing:

```
Fatal error: Call to a member function handle() on null
  vendor/laravel/octane/src/Swoole/SwooleRequestHandler.php
```

This crashes the entire worker process rather than gracefully handling the transient state.

## Solution

Add a null guard for `$workerState->worker` and `$workerState->client` in the Swoole request handler. If either is null (worker still initializing after reload), return a 503 Service Unavailable response instead of crashing.

## Before/After

**Before:** Requests during reload window cause a fatal error, killing the worker process.

**After:** Requests during reload window receive a 503 response. Normal requests work immediately after the reload completes.

## Test Plan

- Start Octane with Swoole and file watcher enabled
- Make a code change to trigger a reload
- Send requests during the reload window -- should get 503 instead of fatal error
- Verify normal requests resume after reload completes