### PR TITLE
[2.x] Restore Glob Support For Chokidar v5

### DIFF
--- a/bin/file-watcher.cjs
+++ b/bin/file-watcher.cjs
@@ -1,52 +1,54 @@
 const chokidar = require('chokidar');
 
-const paths = JSON.parse(process.argv[2]);
-const poll = process.argv[3] ? true : false;
-
-// Chokidar removed support for glob in version 4...
-const chokidarPackagePath = require.resolve('chokidar').replace('index.js', 'package.json');
-const chokidarVersion4 = require(chokidarPackagePath).version.startsWith('4.');
-
-const extractWildcardExtension = (path) => {
-    // Match patterns like *.php, **/*.blade.php
-    const match = path.match(/\/\*\.((\w|\.)+)$/);
-
-    return match ? match[1] : null;
-};
-
-const getPathBeforeWildcard = (path) => {
-    const match = path.match(/^(.*?)(\*|$)/);
-
-    return match ? match[1] : path;
-};
-
-const extractedPaths = paths.map(path => {
-    return { path: getPathBeforeWildcard(path), extension: extractWildcardExtension(path) };
-});
-
-const watcherPaths = chokidarVersion4 ? extractedPaths.map(ep => ep.path) : paths;
-
-const watcherIgnored = chokidarVersion4 ? (path, stats) => {
-    if (! stats?.isFile()) {
-        return false;
-    }
-
-    const matchedPattern = extractedPaths.find(ep => path.startsWith(ep.path));
-
-    if (! matchedPattern) {
-        return true;
-    }
-
-    return matchedPattern.extension ? ! path.endsWith(`.${matchedPattern.extension}`) : false;
-} : undefined;
-
-const watcher = chokidar.watch(watcherPaths, {
+const options = {
     ignoreInitial: true,
-    usePolling: poll,
-    ignored: watcherIgnored,
-});
+    paths: JSON.parse(process.argv[2]),
+    usePolling: process.argv[3] ? true : false,
+};
 
-watcher
+/**
+ * Chokidar +4 removed built-in glob support. For users on these versions,
+ * we manually parse the paths to extract base directories and extensions,
+ * ensuring Octane's wildcard configurations continue to function via
+ * the manual "ignored" filter below.
+ */
+const chokidarMajorVersion = () => {
+    const path = require
+        .resolve('chokidar')
+        .replace('index.js', 'package.json');
+
+    return parseInt(require(path)
+        .version
+        .split('.')[0]
+    );
+};
+
+if (chokidarMajorVersion() > 3) {
+    const extractedPaths = options.paths.map(path => ({
+        path: path.match(/^(?<path>.*?)(?=\*|$)/)?.groups?.path ?? path,
+        extension: path.match(/^.+?(?<=\.)(?<extension>.+)/)?.groups?.extension ?? null,
+    }));
+
+    options.ignored = (path, stats) => {
+        if (! stats?.isFile()) {
+            return false;
+        }
+
+        const matchedPattern = extractedPaths.find(ep => path.startsWith(ep.path));
+
+        if (! matchedPattern) {
+            return true;
+        }
+
+        return matchedPattern.extension ? !path.endsWith(`.${matchedPattern.extension}`) : false;
+    };
+
+    options.paths = extractedPaths.map(ep => ep.path);
+}
+
+const { paths: watcherPaths, ...watcherOptions } = options;
+
+chokidar.watch(watcherPaths, watcherOptions)
     .on('add', () => console.log('File added...'))
     .on('change', () => console.log('File changed...'))
     .on('unlink', () => console.log('File deleted...'))


### PR DESCRIPTION
### Description

This pull request restores and future-proofs the file-watching mechanism for users on modern versions of Chokidar (v4 and the recently released v5). 

While Chokidar removed native glob support starting in version 4, the previous implementation of the watcher script had a version-specific check that hardcoded a search for version `4.x`. When Chokidar v5 was released, this check failed. This caused the watcher to attempt to pass glob patterns directly to a library that no longer understands them, resulting in a `TypeError`.

This commit improves the version detection to apply a manual glob polyfill for all versions greater than 3.

### Benefits to End Users

* **Compatibility:** Restores file-watching functionality for developers on the latest Node environments.
* **Future-proofing:** Using a generic greater-than-3 version check prevents this exact regression from happening on future Chokidar major releases.
* **Efficiency:** The custom path parsing logic is completely bypassed if the user is running Chokidar v3, avoiding any unnecessary regex execution.

### Why This Does Not Break Existing Features

The manual glob polyfill is strictly conditional. Users on Chokidar v3 will continue to use the native glob engine without any changes to their execution path. The script also introduces zero new dependencies to the repository.

### Tests

As this is a standalone Node script, I manually verified the fix across multiple environments within a Docker container to ensure no regressions:

* **Verified on Chokidar v5.0.0:** Confirmed it resolves the `TypeError` and correctly filters files via the new polyfill.
* **Verified on Chokidar v4.0.0:** Confirmed the polyfill correctly handles the missing glob support.
* **Verified on Chokidar v3.6.0:** Confirmed the script skips the polyfill entirely and uses the native glob engine as expected.

**Verified Scenarios:**
I successfully tested all path definitions that ship by default in the `config/octane.php` file, including:
1. Standard files (e.g., `composer.lock`)
2. Simple directories (e.g., `app`)
3. Wildcard patterns (e.g., `config/**/*.php`)
