### PR TITLE
Update Caddyfile

### DIFF
--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -36,11 +36,23 @@
 		# Mercure configuration is injected here...
 		{$CADDY_SERVER_EXTRA_DIRECTIVES}
 
+		# Serve static assets directly via Caddy; never fall through to PHP.
+		@static {
+			path *.css *.js *.mjs *.map *.ico *.png *.jpg *.jpeg *.gif *.svg *.webp *.avif *.woff *.woff2 *.ttf *.otf *.eot *.mp4 *.webm *.ogg *.mp3 *.wav *.pdf *.zip *.txt *.xml *.json *.wasm *.webmanifest *.manifest
+		}
+		file_server @static
+
 		php_server {
 			index frankenphp-worker.php
 			try_files {path} frankenphp-worker.php
 			# Required for the public/storage/ directory...
 			resolve_root_symlink
+		}
+
+		# Friendly fallback page for static-asset 404s (and any other unhandled error).
+		handle_errors {
+			header Content-Type "text/html; charset=utf-8"
+			respond "<!doctype html><html><head><meta charset=utf-8><title>{err.status_code} {err.status_text}</title><style>body{font-family:system-ui,sans-serif;text-align:center;padding:3em;color:#333}h1{font-size:2em;margin:.2em 0}hr{margin:1.5em auto;width:6em;border:none;border-top:1px solid #ccc}small{color:#888}</style></head><body><h1>{err.status_code} {err.status_text}</h1></body></html>" {err.status_code}
 		}
 	}
 }


### PR DESCRIPTION
Fixes issue https://github.com/laravel/octane/issues/1114
The current Caddy configuration template for **FrankenPHP** utilizes a broad `try_files` directive:
`try_files {path} frankenphp-worker.php`

This logic causes all requests for non-existent static files (e.g., versioned assets like `app-v123.js` after a deployment) to be forwarded to the **PHP worker**. In high-traffic environments, a surge of requests for missing assets triggers unnecessary PHP process execution, leading to worker saturation, increased CPU/Memory overhead, and potential system failure.

**Technical Impact**
* **Performance:** High overhead for 404 responses that should be handled at the web-server level.
* **Stability:** Potential **DoS** condition when static asset paths are brute-forced or when client-side caches request deprecated versioned files.
* **Resource Allocation:** PHP workers are occupied by I/O-bound requests for missing files instead of processing dynamic application logic.

**Proposed Solution**
Refactor the Caddyfile logic to isolate static file handling. A dedicated **matcher** for common file extensions should be implemented to ensure that if a static file is not found on disk, Caddy returns a **404 Not Found** immediately, bypassing the `php_server` or `php_dispatch` logic.

This PR fixes the problem.

No tests possible as this config for the Caddy webserver and it wasn't tested before too.