### PR TITLE
Refresh Router Containers for Compiled Routes

### DIFF
--- a/src/Listeners/GiveNewApplicationInstanceToRouter.php
+++ b/src/Listeners/GiveNewApplicationInstanceToRouter.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Octane\Listeners;
 
+use Illuminate\Routing\CompiledRouteCollection;
 use Illuminate\Routing\RouteCollection;
 
 class GiveNewApplicationInstanceToRouter
@@ -19,10 +20,28 @@ class GiveNewApplicationInstanceToRouter
 
         $event->sandbox->make('router')->setContainer($event->sandbox);
 
-        if ($event->sandbox->resolved('routes') && $event->sandbox->make('routes') instanceof RouteCollection) {
-            foreach ($event->sandbox->make('routes') as $route) {
+        if (! $event->sandbox->resolved('routes')) {
+            return;
+        }
+
+        $routes = $event->sandbox->make('routes');
+
+        if (! $routes instanceof RouteCollection && ! $routes instanceof CompiledRouteCollection) {
+            return;
+        }
+
+        if ($routes instanceof CompiledRouteCollection) {
+            $routes->setContainer($event->sandbox);
+
+            foreach ((function () {
+                return $this->nameCache ?? [];
+            })->call($routes) as $route) {
                 $route->setContainer($event->sandbox);
             }
+        }
+
+        foreach ($routes as $route) {
+            $route->setContainer($event->sandbox);
         }
     }
 }

--- a/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
+++ b/tests/Listeners/GiveNewApplicationInstanceToRouterTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Octane\Listeners;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\CompiledRouteCollection;
 use Illuminate\Routing\Route;
 use Laravel\Octane\Tests\TestCase;
 
@@ -37,6 +38,83 @@ class GiveNewApplicationInstanceToRouterTest extends TestCase
 
         $worker->run();
 
+        $this->assertEquals($client->responses[0]->getData()[0], $client->responses[0]->getData()[1]);
+        $this->assertEquals($client->responses[1]->getData()[0], $client->responses[1]->getData()[1]);
+    }
+
+    public function test_router_has_new_instance_when_routes_are_compiled()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/second', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/first', function () {
+            $route = collect(app('router')->getRoutes()->getRoutes())->firstWhere(fn (Route $route) => $route->uri() === 'second');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container),
+                app('router')->getRoutes()::class,
+            ];
+        })->name('first');
+
+        $app['router']->middleware('web')->get('/second', function () {
+            $route = collect(app('router')->getRoutes()->getRoutes())->firstWhere(fn (Route $route) => $route->uri() === 'first');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container),
+                app('router')->getRoutes()::class,
+            ];
+        })->name('second');
+
+        $app['router']->setCompiledRoutes($app['router']->getRoutes()->compile());
+
+        $worker->run();
+
+        $this->assertSame(CompiledRouteCollection::class, $client->responses[0]->getData()[2]);
+        $this->assertSame(CompiledRouteCollection::class, $client->responses[1]->getData()[2]);
+        $this->assertEquals($client->responses[0]->getData()[0], $client->responses[0]->getData()[1]);
+        $this->assertEquals($client->responses[1]->getData()[0], $client->responses[1]->getData()[1]);
+    }
+
+    public function test_router_has_new_instance_when_compiled_route_name_cache_is_warmed()
+    {
+        [$app, $worker, $client] = $this->createOctaneContext([
+            Request::create('/first', 'GET'),
+            Request::create('/second', 'GET'),
+        ]);
+
+        $app['router']->middleware('web')->get('/first', function () {
+            $route = app('router')->getRoutes()->getByName('second');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container),
+                app('router')->getRoutes()::class,
+            ];
+        })->name('first');
+
+        $app['router']->middleware('web')->get('/second', function () {
+            $route = app('router')->getRoutes()->getByName('first');
+
+            return [
+                spl_object_id(app()),
+                spl_object_id(invade($route)->container),
+                app('router')->getRoutes()::class,
+            ];
+        })->name('second');
+
+        $app['router']->setCompiledRoutes($app['router']->getRoutes()->compile());
+
+        $app['router']->getRoutes()->getByName('first');
+        $app['router']->getRoutes()->getByName('second');
+
+        $worker->run();
+
+        $this->assertSame(CompiledRouteCollection::class, $client->responses[0]->getData()[2]);
+        $this->assertSame(CompiledRouteCollection::class, $client->responses[1]->getData()[2]);
         $this->assertEquals($client->responses[0]->getData()[0], $client->responses[0]->getData()[1]);
         $this->assertEquals($client->responses[1]->getData()[0], $client->responses[1]->getData()[1]);
     }


### PR DESCRIPTION
Currently we're only rebinding the containers for non compiled routes.

This PR properly updates all containers for, compiled route, their routes, and more importantly, their warmed routes.

I got hit by this issue when upgrading from Laravel 11 to 12, so i guess this new warm behavior is the most important one, as it still breaks if i don't refresh on the warmed ones too...

PS: this weird syntax for warmed routes is needed because the param is protected and no method to clean that up or access it, also, the check is needed as old laravel version doesn't have it, so it's backward compatible.