### PR TITLE
Skip full compiled route iteration in router listener

### DIFF
--- a/src/Listeners/GiveNewApplicationInstanceToRouter.php
+++ b/src/Listeners/GiveNewApplicationInstanceToRouter.php
@@ -26,10 +26,6 @@ class GiveNewApplicationInstanceToRouter
 
         $routes = $event->sandbox->make('routes');
 
-        if (! $routes instanceof RouteCollection && ! $routes instanceof CompiledRouteCollection) {
-            return;
-        }
-
         if ($routes instanceof CompiledRouteCollection) {
             $routes->setContainer($event->sandbox);
 
@@ -38,10 +34,14 @@ class GiveNewApplicationInstanceToRouter
             })->call($routes) as $route) {
                 $route->setContainer($event->sandbox);
             }
+
+            return;
         }
 
-        foreach ($routes as $route) {
-            $route->setContainer($event->sandbox);
+        if ($routes instanceof RouteCollection) {
+            foreach ($routes as $route) {
+                $route->setContainer($event->sandbox);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1125.

#1121 fixed a real warmed-routes container leak, but the trailing `foreach ($routes as $route)` loop forces full hydration of every compiled route on every request, which defeats the lazy design and causes a regression in route-heavy apps (+20 ms p50 / +143 ms p95 for ~1200 routes in production).

This PR keeps the warmed-routes fix (the `nameCache` iteration) but skips the full collection iteration. Dev-mode `RouteCollection` behavior is preserved as before #1121.

All existing tests pass.