### PR TITLE
fix: prevent frankenphp-worker from spitting html into stdout

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -1,10 +1,13 @@
 <?php
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\FrankenPhp\FrankenPhpClient;
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Worker;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpFoundation\Response;
 
 if ((! ($_SERVER['FRANKENPHP_WORKER'] ?? false)) || ! function_exists('frankenphp_handle_request')) {
@@ -30,9 +33,31 @@ $basePath = require __DIR__.'/bootstrap.php';
 
 $frankenPhpClient = new FrankenPhpClient();
 
-$worker = tap(new Worker(
-    new ApplicationFactory($basePath), $frankenPhpClient
-))->boot();
+try {
+    $worker = tap(new Worker(
+        new ApplicationFactory($basePath), $frankenPhpClient
+    ))->boot();
+} catch (Throwable $e) {
+    try {
+        $container = Container::getInstance();
+        if ($container && $container->bound(ExceptionHandler::class)) {
+            $container->make(ExceptionHandler::class)
+                ->renderForConsole(new ConsoleOutput, $e);
+        } else {
+            fwrite(STDERR, sprintf(
+                "[octane bootstrap] %s: %s\n  in %s:%d\n%s\n",
+                $e::class, $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()
+            ));
+        }
+    } catch (Throwable) {
+        fwrite(STDERR, sprintf(
+            "[octane bootstrap] %s: %s\n  in %s:%d\n%s\n",
+            $e::class, $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()
+        ));
+    }
+
+    exit(1);
+}
 
 $requestCount = 0;
 $debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';

--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -40,6 +40,7 @@ try {
 } catch (Throwable $e) {
     try {
         $container = Container::getInstance();
+
         if ($container && $container->bound(ExceptionHandler::class)) {
             $container->make(ExceptionHandler::class)
                 ->renderForConsole(new ConsoleOutput, $e);


### PR DESCRIPTION
## Summary

When the Laravel application fails to bootstrap inside
`vendor/laravel/octane/bin/frankenphp-worker.php` (like a missing PHP
extension, unreachable Redis, an exception in a service provider) the
default Laravel exception handler renders the exception as an HTML
response and writes it to the worker process's stdout, illegible both
in the console and in structured logs.

This PR wraps the worker's boot phase in a `try/catch` and forces the
exception to be rendered for the console (with a structured `STDERR`
fallback). No behavior change on the happy path or for per-request
exceptions.

## Why this happens

`Application::runningInConsole()` evaluates to `false` under FrankenPHP's
SAPI, so `HandleExceptions::handleException()` takes the `renderHttpResponse()`
branch and emits HTML, even though no HTTP client exists yet: FrankenPHP
has not dispatched any request to the worker at that point.

## The invariant

Between the first line of `bin/frankenphp-worker.php` and the
`frankenphp_handle_request($handleRequest)` loop, the worker is by
construction outside any HTTP request. The script is doing process-level
setup and the only consumer of its output is stdout/stderr. Forcing
console-style rendering in that window is unambiguously correct.

## What the fix does

In the `catch`:

1. If the Laravel container has already bound `ExceptionHandler`, call
   `renderForConsole(new ConsoleOutput, $e)`, the same path
   `HandleExceptions::handleException()` already takes when
   `runningInConsole()` is `true` (Collision-style output when
   installed).
2. Otherwise, or if `renderForConsole` itself throws, fall back to a
   structured `sprintf` block on `STDERR` carrying class, message, file,
   line and trace of the **original** exception.
3. `exit(1)` either way.

The nested `try/catch` ensures a secondary rendering failure can't mask
the root cause.

## Why this is worth fixing even with `octane:start`

In the canonical Supervisor + `php artisan octane:start` setup, many
bootstrap errors fire in the parent Artisan process and are already
formatted correctly by Laravel's CLI path: for those cases this fix is
a no-op.

Some deployments, however, invoke `frankenphp run` directly rather than
`php artisan octane:start`, for example to use `--resume`, to integrate
with Caddy admin API workflows, or to serve multiple Laravel apps under
a single FrankenPHP instance. These are legitimate setups even if
they're not the canonical Octane recommendation. In those cases there's
no parent Artisan process to render the bootstrap exception, and the
worker currently emits raw HTML to stdout.

PS: pr message drafted with LLM assistance (a lot).
