### PR TITLE
Return responses for FrankenPHP worker boot exceptions

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -1,13 +1,12 @@
 <?php
 
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\FrankenPhp\FrankenPhpClient;
+use Laravel\Octane\FrankenPhp\WorkerBootExceptionRenderer;
+use Laravel\Octane\Octane;
 use Laravel\Octane\RequestContext;
 use Laravel\Octane\Stream;
 use Laravel\Octane\Worker;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpFoundation\Response;
 
 if ((! ($_SERVER['FRANKENPHP_WORKER'] ?? false)) || ! function_exists('frankenphp_handle_request')) {
@@ -32,36 +31,21 @@ $basePath = require __DIR__.'/bootstrap.php';
 */
 
 $frankenPhpClient = new FrankenPhpClient();
+$debugMode = filter_var($_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? false, FILTER_VALIDATE_BOOL);
+$worker = null;
+$workerBootExceptionRenderer = null;
 
 try {
     $worker = tap(new Worker(
         new ApplicationFactory($basePath), $frankenPhpClient
     ))->boot();
 } catch (Throwable $e) {
-    try {
-        $container = Container::getInstance();
+    $workerBootExceptionRenderer = new WorkerBootExceptionRenderer($e, $debugMode);
 
-        if ($container && $container->bound(ExceptionHandler::class)) {
-            $container->make(ExceptionHandler::class)
-                ->renderForConsole(new ConsoleOutput, $e);
-        } else {
-            fwrite(STDERR, sprintf(
-                "[octane bootstrap] %s: %s\n  in %s:%d\n%s\n",
-                $e::class, $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()
-            ));
-        }
-    } catch (Throwable) {
-        fwrite(STDERR, sprintf(
-            "[octane bootstrap] %s: %s\n  in %s:%d\n%s\n",
-            $e::class, $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()
-        ));
-    }
-
-    exit(1);
+    $workerBootExceptionRenderer->renderForConsole();
 }
 
 $requestCount = 0;
-$debugMode = $_ENV['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] ?? 'false';
 $maxRequests = $_ENV['MAX_REQUESTS'] ?? $_SERVER['MAX_REQUESTS'] ?? 1000;
 $requestMaxExecutionTime = $_ENV['REQUEST_MAX_EXECUTION_TIME'] ?? $_SERVER['REQUEST_MAX_EXECUTION_TIME'] ?? null;
 
@@ -70,7 +54,13 @@ if (PHP_OS_FAMILY === 'Linux' && ! is_null($requestMaxExecutionTime)) {
 }
 
 try {
-    $handleRequest = static function () use ($worker, $frankenPhpClient, $debugMode) {
+    $handleRequest = static function () use ($worker, $workerBootExceptionRenderer, $frankenPhpClient, $debugMode) {
+        if ($workerBootExceptionRenderer) {
+            $workerBootExceptionRenderer->renderForRequest()->send();
+
+            return;
+        }
+
         try {
             [$request, $context] = $frankenPhpClient->marshalRequest(new RequestContext());
 
@@ -81,7 +71,7 @@ try {
             }
 
             $response = new Response(
-                $debugMode === 'true' ? (string) $e : 'Internal Server Error',
+                Octane::formatExceptionForClient($e, $debugMode),
                 500,
                 [
                     'Status' => '500 Internal Server Error',

--- a/src/Commands/StartFrankenPhpCommand.php
+++ b/src/Commands/StartFrankenPhpCommand.php
@@ -91,6 +91,7 @@ class StartFrankenPhpCommand extends Command implements SignalableCommandInterfa
             '-c', $this->configPath(),
         ], base_path(), [
             'APP_ENV' => app()->environment(),
+            'APP_DEBUG' => config('app.debug') ? 'true' : 'false',
             'APP_BASE_PATH' => base_path(),
             'APP_PUBLIC_PATH' => public_path(),
             'LARAVEL_OCTANE' => 1,

--- a/src/FrankenPhp/WorkerBootExceptionRenderer.php
+++ b/src/FrankenPhp/WorkerBootExceptionRenderer.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Laravel\Octane\FrankenPhp;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Request;
+use Laravel\Octane\Octane;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class WorkerBootExceptionRenderer
+{
+    /**
+     * Create a new worker boot exception renderer instance.
+     */
+    public function __construct(
+        protected Throwable $exception,
+        protected bool $debug,
+    ) {
+    }
+
+    /**
+     * Render the worker boot exception for the console.
+     */
+    public function renderForConsole(): void
+    {
+        try {
+            $container = Container::getInstance();
+
+            if ($container->bound(ExceptionHandler::class)) {
+                $container->make(ExceptionHandler::class)
+                    ->renderForConsole(new ConsoleOutput, $this->exception);
+
+                return;
+            }
+
+            $this->writeExceptionToErrorLog($this->exception);
+        } catch (Throwable) {
+            $this->writeExceptionToErrorLog($this->exception);
+        }
+    }
+
+    /**
+     * Render the worker boot exception as an HTTP response.
+     */
+    public function renderForRequest(): Response
+    {
+        return $this->renderUsingLaravel() ?? $this->renderFallbackResponse();
+    }
+
+    /**
+     * Render the exception using Laravel's exception handler when it is available.
+     */
+    protected function renderUsingLaravel(): ?Response
+    {
+        try {
+            $container = Container::getInstance();
+
+            if (! $container->bound(ExceptionHandler::class)) {
+                return null;
+            }
+
+            $request = Request::capture();
+
+            $container->instance('request', $request);
+
+            return $container->make(ExceptionHandler::class)->render($request, $this->exception);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Render a fallback response when Laravel's exception handler is unavailable.
+     */
+    protected function renderFallbackResponse(): Response
+    {
+        return new Response(
+            Octane::formatExceptionForClient($this->exception, $this->debug),
+            500,
+            [
+                'Status' => '500 Internal Server Error',
+                'Content-Type' => 'text/plain',
+            ],
+        );
+    }
+
+    /**
+     * Write the exception details to the error log.
+     */
+    protected function writeExceptionToErrorLog(Throwable $exception): void
+    {
+        fwrite(STDERR, sprintf(
+            "[octane bootstrap] %s: %s\n  in %s:%d\n%s\n",
+            $exception::class,
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine(),
+            $exception->getTraceAsString(),
+        ));
+    }
+}

--- a/tests/FrankenPhpWorkerBootExceptionRendererTest.php
+++ b/tests/FrankenPhpWorkerBootExceptionRendererTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Request;
+use Laravel\Octane\FrankenPhp\WorkerBootExceptionRenderer;
+use Mockery;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+class FrankenPhpWorkerBootExceptionRendererTest extends TestCase
+{
+    protected ?Container $previousContainer = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousContainer = Container::getInstance();
+    }
+
+    public function test_worker_boot_exceptions_are_rendered_with_laravels_exception_handler()
+    {
+        $container = $this->useContainer();
+        $exception = new RuntimeException('Worker failed to boot.');
+        $response = new Response('Rendered by Laravel.', 500);
+
+        $handler = Mockery::mock(ExceptionHandler::class);
+        $handler->shouldReceive('render')
+            ->once()
+            ->with(Mockery::type(Request::class), $exception)
+            ->andReturn($response);
+
+        $container->instance(ExceptionHandler::class, $handler);
+
+        $this->assertSame($response, (new WorkerBootExceptionRenderer($exception, false))->renderForRequest());
+        $this->assertInstanceOf(Request::class, $container->make('request'));
+    }
+
+    public function test_worker_boot_exceptions_fall_back_to_a_plain_response()
+    {
+        $this->useContainer();
+
+        $response = (new WorkerBootExceptionRenderer(new RuntimeException('Worker failed to boot.'), false))->renderForRequest();
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame('Internal server error.', $response->getContent());
+        $this->assertSame('text/plain', $response->headers->get('Content-Type'));
+    }
+
+    public function test_fallback_responses_include_exception_details_when_debugging()
+    {
+        $this->useContainer();
+
+        $response = (new WorkerBootExceptionRenderer(new RuntimeException('Worker failed to boot.'), true))->renderForRequest();
+
+        $this->assertStringContainsString('RuntimeException', $response->getContent());
+        $this->assertStringContainsString('Worker failed to boot.', $response->getContent());
+    }
+
+    public function test_worker_boot_exceptions_fall_back_when_laravels_exception_handler_fails()
+    {
+        $container = $this->useContainer();
+        $exception = new RuntimeException('Worker failed to boot.');
+
+        $handler = Mockery::mock(ExceptionHandler::class);
+        $handler->shouldReceive('render')
+            ->once()
+            ->andThrow(new RuntimeException('Handler failed.'));
+
+        $container->instance(ExceptionHandler::class, $handler);
+
+        $response = (new WorkerBootExceptionRenderer($exception, true))->renderForRequest();
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertStringContainsString('Worker failed to boot.', $response->getContent());
+        $this->assertStringNotContainsString('Handler failed.', $response->getContent());
+    }
+
+    protected function useContainer(): Container
+    {
+        return tap(new Container(), fn ($container) => Container::setInstance($container));
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance($this->previousContainer);
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
### Summary

This PR extends the FrankenPHP worker boot exception handling added in #1127.

Currently, if `Worker::boot()` throws, the FrankenPHP worker renders the exception for the console and exits. That fixed the previous behavior where Laravel could render HTML to stdout during worker startup.

This PR preserves that console behavior, but keeps the worker script available to handle incoming requests with an HTTP `500` response while the worker is in a failed boot state.

### Behavior

When the Laravel application boots successfully, behavior is unchanged.

When `Worker::boot()` throws:

- The exception is still rendered for the console, preserving the behavior from #1127.
- The worker stores a boot exception renderer.
- The worker still enters the FrankenPHP request loop.
- Incoming requests receive an HTTP `500` response.
- If Laravel exception handler is available, the response is rendered through Laravel.
- If Laravel exception handler is unavailable or fails, Octane falls back to `Octane::formatExceptionForClient()`.
- In debug mode, the fallback includes exception details.
- In non-debug mode, the fallback returns a plain internal server error response.

### Why this is needed

Octane boots the Laravel application before handling requests. If a provider, configuration file, or package route registration throws during boot, the exception happens before `Worker::handle()` and before Laravel normal per-request exception path.

That means request-time exceptions already return useful responses, but boot-time exceptions can leave FrankenPHP without a request callback that can send a response. This is especially noticeable during development with `--watch`, where a reload can encounter a provider or bootstrap error after the server is already running.

### Related

- Builds on #1127.
- Related to #1055.
- Related to #1056 and #1059.
- Adjacent to #1133, although that issue was closed as a framework duplicate.

### Tests

Added coverage for `WorkerBootExceptionRenderer`:

- Renders boot exceptions through Laravel exception handler when available.
- Falls back to a plain `500` response when Laravel exception handler is unavailable.
- Includes exception details in fallback responses when debug mode is enabled.
- Falls back safely if Laravel exception handler itself throws.

Local verification:

```bash
vendor/bin/phpunit
vendor/bin/phpunit tests/FrankenPhpWorkerBootExceptionRendererTest.php
vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M src/FrankenPhp/WorkerBootExceptionRenderer.php src/Commands/StartFrankenPhpCommand.php
php -l bin/frankenphp-worker.php
php -l src/FrankenPhp/WorkerBootExceptionRenderer.php
php -l src/Commands/StartFrankenPhpCommand.php
php -l tests/FrankenPhpWorkerBootExceptionRendererTest.php
```

Full PHPStan in this local environment is blocked by the missing `Swoole\Coroutine\WaitGroup` class, unrelated to this patch.