### PR TITLE
Fix FrankenPHP streamed generator responses

### DIFF
--- a/src/FrankenPhp/FrankenPhpClient.php
+++ b/src/FrankenPhp/FrankenPhpClient.php
@@ -2,13 +2,16 @@
 
 namespace Laravel\Octane\FrankenPhp;
 
+use Generator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use ReflectionFunction;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
 class FrankenPhpClient implements Client
@@ -29,7 +32,52 @@ class FrankenPhpClient implements Client
      */
     public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
     {
+        if (($octaneResponse->response instanceof StreamedResponse) &&
+            ! is_null($responseCallback = static::resolveStreamResponseCallback($octaneResponse->response))) {
+            $octaneResponse->response->sendHeaders();
+
+            $response = $responseCallback();
+
+            if (is_iterable($response)) {
+                foreach ($response as $chunk) {
+                    echo $chunk;
+                    flush();
+                }
+
+                return;
+            }
+
+            if (is_string($response)) {
+                echo $response;
+                flush();
+            }
+
+            return;
+        }
+
         $octaneResponse->response->send();
+    }
+
+    /**
+     * Resolve the stream response callback from the given response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\StreamedResponse  $response
+     * @return \Closure|null
+     */
+    public static function resolveStreamResponseCallback(StreamedResponse $response)
+    {
+        if (is_null($responseCallback = $response->getCallback())) {
+            return null;
+        }
+
+        $reflection = new ReflectionFunction($responseCallback);
+
+        if ($reflection->isGenerator() || ($reflection->hasReturnType() === true &&
+            in_array($reflection->getReturnType()?->getName(), [Generator::class, 'string']))) {
+            return $responseCallback;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/FrankenPhpClientTest.php
+++ b/tests/FrankenPhpClientTest.php
@@ -3,10 +3,14 @@
 namespace Laravel\Octane\Tests;
 
 use Illuminate\Http\Request;
+use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\FrankenPhp\FrankenPhpClient;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use Laravel\Octane\Testing\Fakes\FakeWorker;
+use Mockery;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class FrankenPhpClientTest extends TestCase
 {
@@ -26,5 +30,76 @@ class FrankenPhpClientTest extends TestCase
         (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
 
         $this->assertTrue(true);
+    }
+
+    public function test_response_with_streamed_generator()
+    {
+        $response = new StreamedResponse(function (): iterable {
+            yield 'Hello ';
+            yield 'World';
+        }, 200);
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
+
+        $this->assertSame('Hello World', ob_get_clean());
+    }
+
+    public function test_worker_streams_generator_responses_created_by_response_factory()
+    {
+        $previousOctaneServerFlag = $_SERVER['LARAVEL_OCTANE'] ?? null;
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        try {
+            $app = $this->createApplication();
+
+            $app['router']->get('/stream', fn () => response()->stream(function (): iterable {
+                yield "data: hello\n\n";
+                yield "data: [DONE]\n\n";
+            }, headers: ['Content-Type' => 'text/event-stream']));
+
+            $appFactory = Mockery::mock(ApplicationFactory::class);
+            $appFactory->shouldReceive('createApplication')->andReturn($app);
+
+            $worker = new FakeWorker($appFactory, new class([Request::create('/stream')]) extends FrankenPhpClient
+            {
+                public function __construct(public array $requests)
+                {
+                }
+
+                public function marshalRequest(RequestContext $context): array
+                {
+                    return [$context->request, $context];
+                }
+            });
+
+            $worker->boot();
+
+            ob_start();
+
+            $worker->run();
+
+            $this->assertSame("data: hello\n\ndata: [DONE]\n\n", ob_get_clean());
+        } finally {
+            if ($previousOctaneServerFlag === null) {
+                unset($_SERVER['LARAVEL_OCTANE']);
+            } else {
+                $_SERVER['LARAVEL_OCTANE'] = $previousOctaneServerFlag;
+            }
+        }
+    }
+
+    public function test_response_with_streamed_string_callback()
+    {
+        $response = new StreamedResponse(function (): string {
+            return 'Hello World';
+        }, 200);
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
+
+        $this->assertSame('Hello World', ob_get_clean());
     }
 }


### PR DESCRIPTION
Fixes laravel/octane#1142.

### What changed

This updates the FrankenPHP client to handle `StreamedResponse` callbacks that return a generator or string directly. Laravel Framework's `response()->stream()` intentionally installs generator callbacks directly while `LARAVEL_OCTANE` is set. Under FrankenPHP, delegating those responses to Symfony's `send()` sends headers but does not write the returned generator chunks, producing a `200 OK` response with an empty body.

The new path is limited to `StreamedResponse` callbacks that can be safely detected as returning `Generator` or `string`. Normal responses and traditional echo-based `StreamedResponse` callbacks continue through the existing `$response->send()` behavior.

### End-user benefit

This fixes streamed responses such as SSE/event streams under Octane with FrankenPHP. In practice, generator-based streams can currently appear to succeed while returning an empty body, which breaks features like chat/event streaming responses.

### Compatibility

This mirrors the existing RoadRunner behavior, which already detects generator/string streamed callbacks and sends them through RoadRunner's streaming response path. Echo-based streaming remains untouched because callbacks without a supported return type still fall back to Symfony's normal `send()` handling.

### Tests

Added coverage for:

- Direct FrankenPHP streamed generator callbacks.
- Direct FrankenPHP streamed string callbacks.
- Worker-level streamed responses created by Laravel's response factory while `LARAVEL_OCTANE` is set.