### PR TITLE
Add state_file config option with env() override

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -42,22 +42,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Octane Server State File
-    |--------------------------------------------------------------------------
-    |
-    | This value determines where Octane stores the state file used to track
-    | the running server's master process ID and admin endpoint, which is
-    | read by the octane:status, octane:stop, and octane:reload commands.
-    | You may change this value if your deployment needs the file stored
-    | outside of the default location, such as when running multiple
-    | servers against shared storage.
-    |
-    */
-
-    'state_file' => env('OCTANE_STATE_FILE', storage_path('logs/octane-server-state.json')),
-
-    /*
-    |--------------------------------------------------------------------------
     | Force HTTPS
     |--------------------------------------------------------------------------
     |
@@ -236,5 +220,18 @@ return [
     */
 
     'max_execution_time' => 30,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Server State File
+    |--------------------------------------------------------------------------
+    |
+    | This value determines where Octane stores the state file used to track
+    | the running server's master process ID and admin endpoint, which is
+    | read by various Octane commands. You may tweak this if necessary.
+    |
+    */
+
+    'state_file' => env('OCTANE_STATE_FILE', storage_path('logs/octane-server-state.json')),
 
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -42,6 +42,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Octane Server State File
+    |--------------------------------------------------------------------------
+    |
+    | This value determines where Octane stores the state file used to track
+    | the running server's master process ID and admin endpoint, which is
+    | read by the octane:status, octane:stop, and octane:reload commands.
+    | You may change this value if your deployment needs the file stored
+    | outside of the default location, such as when running multiple
+    | servers against shared storage.
+    |
+    */
+
+    'state_file' => env('OCTANE_STATE_FILE', storage_path('logs/octane-server-state.json')),
+
+    /*
+    |--------------------------------------------------------------------------
     | Force HTTPS
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary

Adds `state_file` to the published `config/octane.php`, with an `env()` override:

```php
'state_file' => env('OCTANE_STATE_FILE', storage_path('logs/octane-server-state.json')),
```

`OctaneServiceProvider` already reads `config('octane.state_file', storage_path(...))` when binding the RoadRunner, Swoole, and FrankenPHP server state file implementations — so this is a real, functional option today, it's just invisible: it's in none of the published stub config, and not documented on the Octane docs page. This surfaces it and, more importantly, makes it overridable per-environment via `.env` instead of requiring an edit to the checked-in config file.

## Motivation

The state file tracks the running server's master process ID and admin endpoint. `octane:status`, `octane:stop`, and `octane:reload` all read it to find and act on the running process.

In a multi-server deployment where `storage/logs` is shared between hosts (e.g. NFS, or any shared volume), every host's state file resolves to the same path by default. That means these control commands can read another host's PID/admin-endpoint entry and target the wrong process. Setting `OCTANE_STATE_FILE` per host to a host-local path (or otherwise outside the shared mount) avoids the collision without needing a custom service provider override just to move one path.

## Prior art

#185 proposed adding this same key back in 2021, but hardcoded the value with no `env()` override — which meant changing it still required publishing and editing the config file, so it didn't really solve the "override per deployment" use case. It stalled after a maintainer asked for the reasoning and didn't get a follow-up, and was eventually closed unmerged. This PR adds the override and includes the deployment scenario as justification.

## Test plan

- [x] Confirmed `OctaneServiceProvider` reads `octane.state_file` with the same default (`storage_path('logs/octane-server-state.json')`) for all three server bindings, so this is purely additive — no behavior changes for anyone not setting `OCTANE_STATE_FILE`.
- [ ] n/a — config-only change, no new logic to unit test.
