### PR TITLE
Update the existing OCTANE_SERVER value on install

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -82,8 +82,11 @@ class InstallCommand extends Command
                     PHP_EOL.'OCTANE_SERVER='.$server.PHP_EOL,
                 );
             } else {
-                $this->newLine();
-                $this->components->warn('Please adjust the `OCTANE_SERVER` environment variable.');
+                File::put($env, preg_replace(
+                    '/^OCTANE_SERVER=.*/m',
+                    'OCTANE_SERVER='.$server,
+                    $contents,
+                ));
             }
         }
     }

--- a/tests/InstallCommandTest.php
+++ b/tests/InstallCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Laravel\Octane\Commands\InstallCommand;
+
+class InstallCommandTest extends TestCase
+{
+    protected $environmentFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->environmentFile = sys_get_temp_dir().'/octane_install_test.env';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->environmentFile);
+
+        parent::tearDown();
+    }
+
+    public function test_octane_server_variable_is_updated_when_already_present()
+    {
+        $this->createApplication()->loadEnvironmentFrom($this->environmentFile);
+
+        file_put_contents($this->environmentFile, "APP_NAME=Laravel\nOCTANE_SERVER=swoole\nAPP_ENV=local\n");
+
+        (new InstallCommand)->updateEnvironmentFile('roadrunner');
+
+        $contents = file_get_contents($this->environmentFile);
+
+        $this->assertStringContainsString('OCTANE_SERVER=roadrunner', $contents);
+        $this->assertStringNotContainsString('OCTANE_SERVER=swoole', $contents);
+        $this->assertStringContainsString('APP_NAME=Laravel', $contents);
+        $this->assertStringContainsString('APP_ENV=local', $contents);
+    }
+
+    public function test_octane_server_variable_is_appended_when_missing()
+    {
+        $this->createApplication()->loadEnvironmentFrom($this->environmentFile);
+
+        file_put_contents($this->environmentFile, "APP_NAME=Laravel\n");
+
+        (new InstallCommand)->updateEnvironmentFile('roadrunner');
+
+        $this->assertStringContainsString('OCTANE_SERVER=roadrunner', file_get_contents($this->environmentFile));
+    }
+}


### PR DESCRIPTION
When `octane:install` runs and `.env` already contains an `OCTANE_SERVER` entry (for example from a previous install that selected a different server), the command only printed a warning and left the old value in place, so `octane:start` would then boot the wrong server. This updates the existing value to the selected server instead of just warning.

Fixes #1097
