### PR TITLE
fix: prevent malformed multipart request from crashing the frankenphp worker

### DIFF
--- a/bin/frankenphp-worker.php
+++ b/bin/frankenphp-worker.php
@@ -95,7 +95,7 @@ try {
         }
     };
 
-    while ($requestCount < $maxRequests && frankenphp_handle_request($handleRequest)) {
+    while ($requestCount < $maxRequests && @frankenphp_handle_request($handleRequest)) {
         $requestCount++;
     }
 } finally {


### PR DESCRIPTION
Any `POST` that sends a `multipart/form-data` content type without a boundary takes the whole worker down. PHP raises a warning while parsing the body, Laravel's `HandleExceptions` turns that warning into an `ErrorException`, and since it fires on the worker loop rather than inside the request handler's `try`/`catch`, nothing catches it and the worker dies. One malformed request from a broken client or a bot is enough to do it.

I added `@` to the `frankenphp_handle_request()` call so the warning stops being promoted. The request comes through with an empty body, same as php-fpm, and the worker stays up. Octane already uses `@` this way around `fsockopen` and `file_get_contents`, so it fits what's there.

Fixes #1151