### PR TITLE
Fix formatting in Caddyfile stub

### DIFF
--- a/src/Commands/stubs/Caddyfile
+++ b/src/Commands/stubs/Caddyfile
@@ -5,14 +5,14 @@
 
 	frankenphp {
 		worker {
-			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php" 
-			{$CADDY_SERVER_WORKER_DIRECTIVE} 
+			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php"
+			{$CADDY_SERVER_WORKER_DIRECTIVE}
 			{$CADDY_SERVER_WATCH_DIRECTIVES}
 		}
 	}
 }
 
-{$CADDY_EXTRA_CONFIG} 
+{$CADDY_EXTRA_CONFIG}
 
 {$CADDY_SERVER_SERVER_NAME} {
 	log {


### PR DESCRIPTION
Basically does what https://github.com/laravel/octane/pull/1096 did, since it seems like it regressed.

Before:
<img width="790" height="236" alt="image" src="https://github.com/user-attachments/assets/18db9db9-96ae-48d3-b2d3-fd6662842556" />

After:
<img width="790" height="236" alt="image" src="https://github.com/user-attachments/assets/fe3cfc96-7ab7-475a-bd48-257c5762563d" />
