### PR TITLE
Fix FrankenPHP output buffering

### DIFF
--- a/src/FrankenPhp/FrankenPhpClient.php
+++ b/src/FrankenPhp/FrankenPhpClient.php
@@ -8,7 +8,9 @@ use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
 class FrankenPhpClient implements Client
@@ -29,6 +31,14 @@ class FrankenPhpClient implements Client
      */
     public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
     {
+        if ($octaneResponse->outputBuffer &&
+            ! $octaneResponse->response instanceof StreamedResponse &&
+            ! $octaneResponse->response instanceof BinaryFileResponse) {
+            $octaneResponse->response->setContent(
+                $octaneResponse->outputBuffer.$octaneResponse->response->getContent()
+            );
+        }
+
         $octaneResponse->response->send();
     }
 

--- a/tests/FrankenPhpClientTest.php
+++ b/tests/FrankenPhpClientTest.php
@@ -6,7 +6,9 @@ use Illuminate\Http\Request;
 use Laravel\Octane\FrankenPhp\FrankenPhpClient;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class FrankenPhpClientTest extends TestCase
 {
@@ -26,5 +28,49 @@ class FrankenPhpClientTest extends TestCase
         (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
 
         $this->assertTrue(true);
+    }
+
+    public function test_response_includes_the_output_buffer()
+    {
+        $response = new Response('Hello World');
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(
+            new RequestContext(),
+            new OctaneResponse($response, 'Output Buffer')
+        );
+
+        $this->assertSame('Output BufferHello World', ob_get_clean());
+    }
+
+    public function test_streamed_response_does_not_include_the_output_buffer()
+    {
+        $response = new StreamedResponse(static function () {
+            echo 'Hello World';
+        });
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(
+            new RequestContext(),
+            new OctaneResponse($response, 'Output Buffer')
+        );
+
+        $this->assertSame('Hello World', ob_get_clean());
+    }
+
+    public function test_binary_file_response_does_not_include_the_output_buffer()
+    {
+        $response = new BinaryFileResponse(__DIR__.'/public/foo.txt');
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(
+            new RequestContext(),
+            new OctaneResponse($response, 'Output Buffer')
+        );
+
+        $this->assertSame(file_get_contents(__DIR__.'/public/foo.txt'), ob_get_clean());
     }
 }


### PR DESCRIPTION
This PR makes it possible to view the output of `dump()` in the browser when using FrankenPHP.

Viewing `dump()` output in the browser is already supported by `SwooleClient` and `RoadRunnerClient`. `dump()` remains a developer-friendly and convenient way to quickly inspect values during development. For that reason, it would be great to have the same functionality available with FrankenPHP.

Thank you for your consideration.