### PR TITLE
Override "server" `artisan dev` command

### DIFF
--- a/src/Octane.php
+++ b/src/Octane.php
@@ -54,4 +54,14 @@ class Octane
 
         error_log($message, 4);
     }
+
+    /**
+     * Register the Octane dev commands.
+     */
+    public static function registerDevCommands(): void
+    {
+        if (class_exists(\Illuminate\Foundation\DevCommands::class)) {
+            \Illuminate\Foundation\DevCommands::artisan('octane:start --watch', 'server');
+        }
+    }
 }

--- a/src/OctaneServiceProvider.php
+++ b/src/OctaneServiceProvider.php
@@ -91,6 +91,8 @@ class OctaneServiceProvider extends ServiceProvider
                         ? new SwooleCoroutineDispatcher($app->bound('Swoole\Http\Server'))
                         : $app->make(SequentialCoroutineDispatcher::class);
         });
+
+        Octane::registerDevCommands();
     }
 
     /**


### PR DESCRIPTION
If `\Illuminate\Foundation\DevCommands` is available, the package now automatically overrides the `server` command so that you use Octane in watch mode locally.