### PR TITLE
Fix Swoole send yield default when coroutines are disabled

### DIFF
--- a/src/Commands/StartSwooleCommand.php
+++ b/src/Commands/StartSwooleCommand.php
@@ -130,7 +130,6 @@ class StartSwooleCommand extends Command implements SignalableCommandInterface
             'max_request' => $this->option('max-requests'),
             'package_max_length' => 10 * 1024 * 1024,
             'reactor_num' => $this->workerCount($extension),
-            'send_yield' => true,
             'socket_buffer_size' => 10 * 1024 * 1024,
             'task_max_request' => $this->option('max-requests'),
             'task_worker_num' => $this->taskWorkerCount($extension),

--- a/tests/StartSwooleCommandTest.php
+++ b/tests/StartSwooleCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Laravel\Octane\Commands\StartSwooleCommand;
+use Laravel\Octane\Swoole\SwooleExtension;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class StartSwooleCommandTest extends TestCase
+{
+    public function test_default_options_leave_send_yield_to_swoole(): void
+    {
+        if (! defined('SWOOLE_LOG_INFO')) {
+            define('SWOOLE_LOG_INFO', 0);
+        }
+
+        if (! defined('SWOOLE_LOG_ERROR')) {
+            define('SWOOLE_LOG_ERROR', 3);
+        }
+
+        $this->createApplication();
+
+        $command = new class extends StartSwooleCommand
+        {
+            public function defaultOptions(SwooleExtension $extension): array
+            {
+                return $this->defaultServerOptions($extension);
+            }
+        };
+
+        $command->setInput(new ArrayInput([
+            '--workers' => 1,
+            '--task-workers' => 0,
+            '--max-requests' => 500,
+        ], $command->getDefinition()));
+
+        $options = $command->defaultOptions(new SwooleExtension);
+
+        $this->assertFalse($options['enable_coroutine']);
+        $this->assertArrayNotHasKey('send_yield', $options);
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the explicit Swoole send_yield default from Octane.
- Lets Swoole derive the setting from the final enable_coroutine value.
- Adds a regression test for the default server options.

## Why

Octane defaults to disabled coroutines, while the explicit send_yield setting can require a coroutine when a response reaches backpressure. Leaving the setting to Swoole keeps the safe default and preserves native yielding when an application enables coroutines.

## Testing

- vendor/bin/phpunit tests/StartSwooleCommandTest.php tests/SwooleClientTest.php
- vendor/bin/phpunit
- php -l on changed files
- git diff --check

I also exercised the related response paths in a local PHP 8.5 / Swoole 6.2.0 container. The Swoole 6.2.2 source path was reviewed; an exact local 6.2.2 build was unavailable because the disposable image lacks an optional Brotli development package.