### PR TITLE
Make RoadRunner worker command configurable and absolute-path safe

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -234,4 +234,21 @@ return [
 
     'state_file' => env('OCTANE_STATE_FILE', storage_path('logs/octane-server-state.json')),
 
+    /*
+    |--------------------------------------------------------------------------
+    | RoadRunner Options
+    |--------------------------------------------------------------------------
+    |
+    | The following options are only used when the RoadRunner server is the
+    | server powering your application. You may customize the path to the
+    | worker binary here, which is useful for zero-downtime deployments
+    | where the application is served from a symlinked "current" path.
+    |
+    */
+
+    'roadrunner' => [
+        'command' => env('OCTANE_ROADRUNNER_COMMAND', 'vendor/bin/roadrunner-worker'),
+        'http_middleware' => env('OCTANE_ROADRUNNER_HTTP_MIDDLEWARE', 'static'),
+    ],
+
 ];

--- a/src/Commands/StartRoadRunnerCommand.php
+++ b/src/Commands/StartRoadRunnerCommand.php
@@ -83,7 +83,7 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
             '-c', $this->configPath(),
             '-o', 'version=3',
             '-o', 'http.address='.$this->getHost().':'.$this->getPort(),
-            '-o', 'server.command='.(new PhpExecutableFinder)->find().','.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
+            '-o', 'server.command='.(new PhpExecutableFinder)->find().','.$this->workerCommand(),
             '-o', 'http.pool.num_workers='.$this->workerCount(),
             '-o', 'http.pool.max_jobs='.$this->option('max-requests'),
             '-o', 'rpc.listen=tcp://'.$this->rpcHost().':'.$this->rpcPort(),
@@ -135,6 +135,29 @@ class StartRoadRunnerCommand extends Command implements SignalableCommandInterfa
         return $this->option('workers') == 'auto'
                             ? 0
                             : $this->option('workers');
+    }
+
+    /**
+     * Get the path to the RoadRunner worker command.
+     *
+     * @return string
+     */
+    protected function workerCommand()
+    {
+        $command = config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker');
+
+        return $this->isAbsolutePath($command) ? $command : base_path($command);
+    }
+
+    /**
+     * Determine if the given path is absolute.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function isAbsolutePath($path)
+    {
+        return str_starts_with($path, '/') || preg_match('/^[a-zA-Z]:[\\\\\/]/', $path) === 1;
     }
 
     /**

--- a/tests/StartRoadRunnerCommandTest.php
+++ b/tests/StartRoadRunnerCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Octane\Tests;
+
+use Laravel\Octane\Commands\StartRoadRunnerCommand;
+
+class StartRoadRunnerCommandTest extends TestCase
+{
+    public function test_default_worker_command_is_resolved_relative_to_the_base_path()
+    {
+        $app = $this->createApplication();
+
+        $command = $this->command();
+
+        $this->assertEquals(
+            $app->basePath('vendor/bin/roadrunner-worker'),
+            $command->workerCommand()
+        );
+    }
+
+    public function test_configured_relative_worker_command_is_resolved_relative_to_the_base_path()
+    {
+        $app = $this->createApplication();
+
+        $app['config']->set('octane.roadrunner.command', 'vendor/bin/custom-worker');
+
+        $command = $this->command();
+
+        $this->assertEquals(
+            $app->basePath('vendor/bin/custom-worker'),
+            $command->workerCommand()
+        );
+    }
+
+    public function test_configured_absolute_worker_command_is_not_prefixed_with_the_base_path()
+    {
+        $app = $this->createApplication();
+
+        $app['config']->set('octane.roadrunner.command', '/var/www/current/vendor/bin/roadrunner-worker');
+
+        $command = $this->command();
+
+        $this->assertEquals(
+            '/var/www/current/vendor/bin/roadrunner-worker',
+            $command->workerCommand()
+        );
+    }
+
+    protected function command()
+    {
+        return new class extends StartRoadRunnerCommand
+        {
+            public function __construct()
+            {
+                //
+            }
+
+            public function workerCommand()
+            {
+                return parent::workerCommand();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #996.

`StartRoadRunnerCommand` builds the worker command like this:

```php
'-o', 'server.command='.(new PhpExecutableFinder)->find().','.base_path(config('octane.roadrunner.command', 'vendor/bin/roadrunner-worker')),
```

Two problems: `config/octane.php` never actually defines an `octane.roadrunner.command` key (same goes for `octane.roadrunner.http_middleware`, used a few lines below), so there was no way to override it, and even if you set it via config or a service provider, `base_path()` unconditionally prefixed it, so an absolute path override got mangled anyway.

That combination is what breaks `octane:reload` under a zero-downtime deploy setup like Deployer's `current` symlink, as described in the issue: `base_path()` resolves against whatever release directory was current when the RoadRunner server first booted, so a reload after the symlink moves to a new release still runs the old release's worker.

This adds the `roadrunner` config array with `command` and `http_middleware` (env-backed, same pattern as the other keys in that file), and only wraps the configured command in `base_path()` when it isn't already an absolute path.

Added `tests/StartRoadRunnerCommandTest.php` covering the default relative path, an overridden relative path, and an absolute override.

I didn't have a local Laravel/RoadRunner setup handy, so I ran the suite in a plain `php:8.3-cli` container with the sockets/zip/sodium extensions and a Composer install. New tests pass (3/3), and the full suite is green except two pre-existing failures unrelated to this change (`EnsureRequestsDontExceedMaxExecutionTimeTest` and `SwooleServerProcessInspectorTest` both fail on `Undefined constant SIGKILL` because that container doesn't have `pcntl`).

Kept this scoped to the config/base_path issue — didn't touch the broader zero-downtime deployment discussion in #1004.
