### PR TITLE
Fix FrankenPHP generator stream responses

### DIFF
--- a/src/FrankenPhp/FrankenPhpClient.php
+++ b/src/FrankenPhp/FrankenPhpClient.php
@@ -2,13 +2,16 @@
 
 namespace Laravel\Octane\FrankenPhp;
 
+use Generator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Laravel\Octane\Contracts\Client;
 use Laravel\Octane\Octane;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use ReflectionFunction;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
 class FrankenPhpClient implements Client
@@ -29,7 +32,33 @@ class FrankenPhpClient implements Client
      */
     public function respond(RequestContext $context, OctaneResponse $octaneResponse): void
     {
+        if (($octaneResponse->response instanceof StreamedResponse) &&
+            ! is_null($responseCallback = static::resolveStreamResponseCallback($octaneResponse->response))) {
+            $octaneResponse->response->sendHeaders();
+
+            foreach ($responseCallback() as $chunk) {
+                echo $chunk;
+                flush();
+            }
+
+            return;
+        }
+
         $octaneResponse->response->send();
+    }
+
+    /**
+     * Resolve the stream response callback from the given response if it returns a generator.
+     *
+     * @return \Closure|null
+     */
+    public static function resolveStreamResponseCallback(StreamedResponse $response)
+    {
+        if (is_null($responseCallback = $response->getCallback())) {
+            return null;
+        }
+
+        return (new ReflectionFunction($responseCallback))->isGenerator() ? $responseCallback : null;
     }
 
     /**

--- a/tests/FrankenPhpClientTest.php
+++ b/tests/FrankenPhpClientTest.php
@@ -3,10 +3,14 @@
 namespace Laravel\Octane\Tests;
 
 use Illuminate\Http\Request;
+use Laravel\Octane\ApplicationFactory;
 use Laravel\Octane\FrankenPhp\FrankenPhpClient;
 use Laravel\Octane\OctaneResponse;
 use Laravel\Octane\RequestContext;
+use Laravel\Octane\Testing\Fakes\FakeWorker;
+use Mockery;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class FrankenPhpClientTest extends TestCase
 {
@@ -20,11 +24,80 @@ class FrankenPhpClientTest extends TestCase
 
     public function test_response()
     {
-        $response = \Mockery::mock(Response::class);
+        $response = Mockery::mock(Response::class);
         $response->shouldReceive('send');
 
         (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
 
         $this->assertTrue(true);
+    }
+
+    public function test_response_with_a_streamed_generator_callback_echoes_each_yielded_chunk()
+    {
+        $response = new StreamedResponse(function () {
+            yield 'Hello ';
+            yield 'World';
+        });
+
+        ob_start();
+
+        (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
+
+        $this->assertSame('Hello World', ob_get_clean());
+    }
+
+    public function test_response_with_a_regular_streamed_callback_is_left_to_symfony()
+    {
+        $response = Mockery::mock(StreamedResponse::class)->makePartial();
+        $response->setCallback(function () {
+            echo 'Hello World';
+        });
+        $response->shouldReceive('send')->once();
+
+        (new FrankenPhpClient())->respond(new RequestContext(), new OctaneResponse($response));
+    }
+
+    public function test_worker_streams_a_generator_based_response_created_by_the_stream_response_helper()
+    {
+        $previousOctaneServerFlag = $_SERVER['LARAVEL_OCTANE'] ?? null;
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        try {
+            $app = $this->createApplication();
+
+            $app['router']->get('/stream', fn () => response()->stream(function () {
+                yield "data: hello\n\n";
+                yield "data: [DONE]\n\n";
+            }, headers: ['Content-Type' => 'text/event-stream']));
+
+            $appFactory = Mockery::mock(ApplicationFactory::class);
+            $appFactory->shouldReceive('createApplication')->andReturn($app);
+
+            $worker = new FakeWorker($appFactory, new class([Request::create('/stream')]) extends FrankenPhpClient
+            {
+                public function __construct(public array $requests)
+                {
+                }
+
+                public function marshalRequest(RequestContext $context): array
+                {
+                    return [$context->request, $context];
+                }
+            });
+
+            $worker->boot();
+
+            ob_start();
+
+            $worker->run();
+
+            $this->assertSame("data: hello\n\ndata: [DONE]\n\n", ob_get_clean());
+        } finally {
+            if ($previousOctaneServerFlag === null) {
+                unset($_SERVER['LARAVEL_OCTANE']);
+            } else {
+                $_SERVER['LARAVEL_OCTANE'] = $previousOctaneServerFlag;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1142.

response()->stream() with a generator callback is silently broken under FrankenPHP. The Octane FrankenPHP client's respond() just delegates to Symfony's StreamedResponse::send(), which calls sendContent() — and sendContent() just invokes the callback, it never iterates a return value. It's written for callbacks that echo their own output. So when Laravel's ResponseFactory::stream() installs a generator directly as the callback (which it does whenever LARAVEL_OCTANE is set, see Illuminate\Routing\ResponseFactory::stream), FrankenPHP runs the generator, throws away everything it yielded, and sends a 200 with an empty body.

RoadRunnerClient already has to deal with this same mismatch and solves it by reflecting on the callback to see if it's a generator, and if so calling it directly and echoing each yielded chunk instead of handing it to Symfony. I did the same thing here for FrankenPhpClient: sendHeaders() up front (since we're bypassing send() entirely for this path), then iterate the generator with echo + flush per chunk.

There's an earlier attempt at this in #1141 with the same core idea. I kept the fix itself close to that, since it matches the existing RoadRunner convention, but simplified resolveStreamResponseCallback down to just the isGenerator() check — that's exactly what Laravel's own ResponseFactory uses to decide whether to hand FrankenPHP a raw generator in the first place, so checking for anything else (like an explicit `: string` return type) isn't actually reachable from that code path and just adds surface area.

For tests, I added a unit test that reproduces the bug directly against FrankenPhpClient::respond() with a generator-returning StreamedResponse, a test confirming plain echo-based streamed callbacks still fall through to Symfony's send() untouched, and an end-to-end test that boots a real worker with a route registered through response()->stream() (with LARAVEL_OCTANE set, same as production) and asserts the SSE-style output actually comes out the other end. I ran the new tests against the old respond() first to confirm they fail with an empty string (reproducing the reported bug exactly), then confirmed they pass with the fix, then ran the full suite to make sure nothing else broke.
